### PR TITLE
Add cherry combo profile and fix HID burst relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ sudo systemctl restart bluetooth_2_usb.service
 
 ### HID profiles
 
-Bluetooth-2-USB supports three host-facing HID layouts:
+Bluetooth-2-USB supports four host-facing HID layouts:
 
 - `boot_keyboard`
   - default
@@ -192,6 +192,11 @@ Bluetooth-2-USB supports three host-facing HID layouts:
 - `nonboot`
   - exposes nonboot keyboard, mouse, and consumer-control functions
   - suitable for hosts that do not require boot-protocol behavior
+- `cherry_combo`
+  - exposes the same three-function layout as `boot_keyboard`
+  - keeps the current mouse and consumer-control functions
+  - swaps in a Cherry-inspired boot-keyboard descriptor plus stricter USB power and remote-wakeup settings
+  - useful for hosts that are picky during pre-OS or resume flows
 
 For most installations, start with `boot_keyboard` and only switch profiles when you are diagnosing compatibility on a specific host.
 
@@ -212,7 +217,11 @@ Use these runtime flags when running the CLI manually.
 | `--version, -v` | Print the installed Bluetooth-2-USB version and exit. |
 | `--validate-env` | Validate gadget runtime prerequisites and exit. On non-gadget systems this is expected to fail fast and report the missing prerequisites. |
 | `--output {text,json}` | Output format for `--list_devices` and `--validate-env`. Default: `text`. |
-| `--hid-profile PROFILE` | USB HID profile to expose. Supported values: `boot_keyboard`, `boot_mouse`, `nonboot`. Example: `--hid-profile nonboot`. |
+<<<<<<< HEAD
+| `--hid-profile PROFILE` | USB HID profile to expose. Default: `boot_keyboard`. Supported values: `boot_keyboard`, `boot_mouse`, `nonboot`, `cherry_combo`. `boot_keyboard` exposes a boot keyboard plus a nonboot mouse and a separate consumer-control function, making it the preferred choice for stricter pre-OS hosts. `boot_mouse` exposes a boot mouse plus separate keyboard and consumer-control functions. `nonboot` uses nonboot keyboard, mouse, and consumer-control functions. `cherry_combo` keeps the same three-function layout and the current mouse and consumer-control functions, but swaps in a Cherry-inspired boot-keyboard descriptor plus stricter USB power and remote-wakeup settings for hosts that are picky during pre-OS or resume flows. Example: `--hid-profile cherry_combo`. |
+=======
+| `--hid-profile PROFILE` | USB HID profile to expose. Default: `boot_keyboard`. Supported values: `boot_keyboard`, `boot_mouse`, `nonboot`, `cherry_combo`. `boot_keyboard` exposes a boot keyboard plus a nonboot mouse and a separate consumer-control function, making it the preferred choice for stricter pre-OS hosts. `boot_mouse` exposes a boot mouse plus separate keyboard and consumer-control functions. `nonboot` uses nonboot keyboard, mouse, and consumer-control functions. `cherry_combo` keeps the same three-function layout and the current mouse and consumer-control functions, but swaps in a Cherry-inspired boot-keyboard descriptor plus stricter USB power and remote-wakeup settings for hosts that are picky during pre-OS or resume flows. Example: `--hid-profile cherry_combo`. |
+>>>>>>> ae7977c (Add cherry combo profile and fix HID burst relay)
 | `--help, -h` | Show the built-in CLI help and exit. |
 
 ## Day-to-day usage
@@ -480,7 +489,7 @@ Create temporary virtual keyboard and mouse devices on the Pi and inject a deter
 
 | Argument | Explanation / Example |
 | --- | --- |
-| `--scenario {keyboard,mouse,combo,consumer}` | Select which deterministic test sequence to inject. Default: `combo`. Example: `sudo /opt/bluetooth_2_usb/scripts/pi_relay_test_inject.sh --scenario combo`. |
+| `--scenario {keyboard,mouse,combo,consumer,text_burst}` | Select which deterministic test sequence to inject. Default: `combo`. Example: `sudo /opt/bluetooth_2_usb/scripts/pi_relay_test_inject.sh --scenario combo`. |
 | `--pre-delay-ms PRE_DELAY_MS` | Wait after creating the virtual devices before sending events. Default: `1000`. |
 | `--event-gap-ms EVENT_GAP_MS` | Delay between injected events. Default: `40`. |
 
@@ -503,7 +512,7 @@ Before each fresh Windows validation run after changing the Pi HID profile or de
 
 | Argument | Explanation / Example |
 | --- | --- |
-| `--scenario {keyboard,mouse,combo,consumer}` | Expected test sequence. Default: `combo`. Example: `./scripts/host_relay_test_capture.sh --scenario combo`. |
+| `--scenario {keyboard,mouse,combo,consumer,text_burst}` | Expected test sequence. Default: `combo`. Example: `./scripts/host_relay_test_capture.sh --scenario combo`. |
 | `--timeout-sec TIMEOUT_SEC` | Time to wait for the full sequence. Default: `5`. |
 | `--keyboard-node PATH` | Override the detected host keyboard HID device path. |
 | `--mouse-node PATH` | Override the detected host mouse HID device path. |

--- a/src/bluetooth_2_usb/args.py
+++ b/src/bluetooth_2_usb/args.py
@@ -137,7 +137,7 @@ class CustomArgumentParser(argparse.ArgumentParser):
         )
         self.add_argument(
             "--hid-profile",
-            choices=["boot_keyboard", "boot_mouse", "nonboot"],
+            choices=["boot_keyboard", "boot_mouse", "nonboot", "cherry_combo"],
             default="boot_keyboard",
             help="USB HID profile to expose. Default: boot_keyboard",
         )

--- a/src/bluetooth_2_usb/gadget_config.py
+++ b/src/bluetooth_2_usb/gadget_config.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import usb_hid
+
+from .hid_descriptors import GadgetHidDevice, GadgetProfile
+
+GADGET_ROOT = Path(usb_hid.gadget_root)
+CONFIG_NAME = "c.1"
+LANGUAGE_ID = "0x409"
+DEFAULT_VENDOR_ID = "0x1d6b"
+DEFAULT_PRODUCT_ID = "0x0104"
+DEFAULT_BCD_USB = "0x0200"
+DEFAULT_BMAX_PACKET_SIZE0 = "0x40"
+DEFAULT_MANUFACTURER = "quaxalber"
+
+
+def _safe_unlink(path: Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def _safe_rmdir(path: Path) -> None:
+    try:
+        path.rmdir()
+    except FileNotFoundError:
+        pass
+
+
+def _teardown_existing_gadget() -> None:
+    if not GADGET_ROOT.exists():
+        return
+
+    try:
+        (GADGET_ROOT / "UDC").write_text("\n", encoding="utf-8")
+    except FileNotFoundError:
+        pass
+    except OSError:
+        pass
+
+    for symlink in sorted(GADGET_ROOT.glob("configs/**/hid.usb*"), reverse=True):
+        _safe_unlink(symlink)
+
+    for file_path in sorted(GADGET_ROOT.rglob("*"), reverse=True):
+        if file_path.is_file():
+            _safe_unlink(file_path)
+        elif file_path.is_dir():
+            _safe_rmdir(file_path)
+
+    _safe_rmdir(GADGET_ROOT)
+
+
+def _write_text(path: Path, value: str) -> None:
+    path.write_text(f"{value}\n", encoding="utf-8")
+
+
+def _resolve_udc_name() -> str:
+    override_path = os.environ.get("BLUETOOTH_2_USB_UDC_PATH")
+    if override_path:
+        candidate = Path(override_path)
+        if candidate.name == "state":
+            return candidate.parent.name
+        return candidate.name
+
+    controllers = sorted(entry.name for entry in Path("/sys/class/udc").iterdir())
+    if not controllers:
+        raise FileNotFoundError("No UDC controller was found in /sys/class/udc")
+    return controllers[0]
+
+
+def rebuild_gadget(profile: GadgetProfile) -> tuple[GadgetHidDevice, ...]:
+    _teardown_existing_gadget()
+
+    function_root = GADGET_ROOT / "functions"
+    config_root = GADGET_ROOT / "configs" / CONFIG_NAME
+    gadget_strings = GADGET_ROOT / "strings" / LANGUAGE_ID
+    config_strings = config_root / "strings" / LANGUAGE_ID
+
+    function_root.mkdir(parents=True, exist_ok=True)
+    config_strings.mkdir(parents=True, exist_ok=True)
+    gadget_strings.mkdir(parents=True, exist_ok=True)
+
+    _write_text(GADGET_ROOT / "bcdDevice", profile.bcd_device)
+    _write_text(GADGET_ROOT / "bcdUSB", DEFAULT_BCD_USB)
+    _write_text(GADGET_ROOT / "bDeviceClass", "0x00")
+    _write_text(GADGET_ROOT / "bDeviceProtocol", "0x00")
+    _write_text(GADGET_ROOT / "bDeviceSubClass", "0x00")
+    _write_text(GADGET_ROOT / "bMaxPacketSize0", DEFAULT_BMAX_PACKET_SIZE0)
+    _write_text(GADGET_ROOT / "idProduct", DEFAULT_PRODUCT_ID)
+    _write_text(GADGET_ROOT / "idVendor", DEFAULT_VENDOR_ID)
+    _write_text(gadget_strings / "serialnumber", profile.serial_number)
+    _write_text(gadget_strings / "manufacturer", DEFAULT_MANUFACTURER)
+    _write_text(gadget_strings / "product", profile.product_name)
+
+    _write_text(config_strings / "configuration", profile.configuration_name)
+    _write_text(config_root / "MaxPower", str(profile.max_power))
+    _write_text(config_root / "bmAttributes", hex(profile.bm_attributes))
+    if profile.max_speed is not None:
+        _write_text(GADGET_ROOT / "max_speed", profile.max_speed)
+
+    for device in profile.devices:
+        device_root = function_root / f"hid.usb{device.function_index}"
+        device_root.mkdir(parents=True, exist_ok=True)
+        _write_text(device_root / "protocol", str(device.protocol))
+        _write_text(device_root / "subclass", str(device.subclass))
+        _write_text(device_root / "report_length", str(device.in_report_lengths[0]))
+        (device_root / "report_desc").write_bytes(bytes(device.descriptor))
+        (config_root / f"hid.usb{device.function_index}").symlink_to(device_root)
+
+    _write_text(GADGET_ROOT / "UDC", _resolve_udc_name())
+
+    usb_hid.devices = list(profile.devices)
+    for device in profile.devices:
+        try:
+            device.path = device.get_device_path()
+        except FileNotFoundError:
+            device.path = None
+    return profile.devices

--- a/src/bluetooth_2_usb/hid_descriptors.py
+++ b/src/bluetooth_2_usb/hid_descriptors.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+import usb_hid
+
+CHERRY_KEYBOARD_DESCRIPTOR = bytes.fromhex(
+    "05010906a101050719e029e715002501750195088102950175088101"
+    "95037501050819012903910295057501910195067508150026ff0005"
+    "0719002aff008100c0"
+)
+
+
+class GadgetHidDevice(usb_hid.Device):
+    def __init__(
+        self,
+        *,
+        descriptor: bytes,
+        usage_page: int,
+        usage: int,
+        report_ids: Sequence[int],
+        in_report_lengths: Sequence[int],
+        out_report_lengths: Sequence[int],
+        name: str,
+        function_index: int,
+        protocol: int,
+        subclass: int,
+    ) -> None:
+        init_kwargs = {
+            "descriptor": descriptor,
+            "usage_page": usage_page,
+            "usage": usage,
+            "report_ids": tuple(report_ids),
+            "in_report_lengths": tuple(in_report_lengths),
+            "out_report_lengths": tuple(out_report_lengths),
+            "name": name,
+        }
+        try:
+            super().__init__(
+                subclass=subclass,
+                protocol=protocol,
+                **init_kwargs,
+            )
+        except TypeError as exc:
+            if "unexpected keyword argument 'subclass'" not in str(exc):
+                raise
+            super().__init__(**init_kwargs)
+        self.function_index = function_index
+        self.protocol = protocol
+        self.subclass = subclass
+
+    @classmethod
+    def from_existing(
+        cls,
+        base_device: usb_hid.Device,
+        *,
+        function_index: int,
+        protocol: int,
+        subclass: int,
+        descriptor: bytes | None = None,
+        name: str | None = None,
+    ) -> GadgetHidDevice:
+        return cls(
+            descriptor=(
+                bytes(base_device.descriptor) if descriptor is None else descriptor
+            ),
+            usage_page=base_device.usage_page,
+            usage=base_device.usage,
+            report_ids=tuple(base_device.report_ids),
+            in_report_lengths=tuple(base_device.in_report_lengths),
+            out_report_lengths=tuple(base_device.out_report_lengths),
+            name=base_device.name if name is None else name,
+            function_index=function_index,
+            protocol=protocol,
+            subclass=subclass,
+        )
+
+    def get_device_path(self, report_id=None):
+        function_root = (
+            Path(usb_hid.gadget_root) / f"functions/hid.usb{self.function_index}"
+        )
+        device = function_root.joinpath("dev").read_text(encoding="utf-8").strip()
+        return f"/dev/hidg{device.split(':')[1]}"
+
+
+@dataclass(frozen=True, slots=True)
+class GadgetProfile:
+    name: str
+    devices: tuple[GadgetHidDevice, ...]
+    bcd_device: str
+    product_name: str
+    serial_number: str
+    max_power: int = 250
+    bm_attributes: int = 0x80
+    configuration_name: str = "Config 1: HID relay"
+    max_speed: str | None = None
+
+
+def _build_boot_keyboard_profile() -> GadgetProfile:
+    return GadgetProfile(
+        name="boot_keyboard",
+        devices=(
+            GadgetHidDevice.from_existing(
+                usb_hid.Device.BOOT_KEYBOARD,
+                function_index=0,
+                protocol=1,
+                subclass=1,
+            ),
+            GadgetHidDevice.from_existing(
+                usb_hid.Device.MOUSE,
+                function_index=1,
+                protocol=0,
+                subclass=0,
+            ),
+            GadgetHidDevice.from_existing(
+                usb_hid.Device.CONSUMER_CONTROL,
+                function_index=2,
+                protocol=0,
+                subclass=0,
+            ),
+        ),
+        bcd_device="0x0201",
+        product_name="USB Combo Device (boot keyboard)",
+        serial_number="213374badcafe-bk",
+    )
+
+
+def _build_boot_mouse_profile() -> GadgetProfile:
+    return GadgetProfile(
+        name="boot_mouse",
+        devices=(
+            GadgetHidDevice.from_existing(
+                usb_hid.Device.BOOT_MOUSE,
+                function_index=0,
+                protocol=2,
+                subclass=1,
+            ),
+            GadgetHidDevice.from_existing(
+                usb_hid.Device.KEYBOARD,
+                function_index=1,
+                protocol=0,
+                subclass=0,
+            ),
+            GadgetHidDevice.from_existing(
+                usb_hid.Device.CONSUMER_CONTROL,
+                function_index=2,
+                protocol=0,
+                subclass=0,
+            ),
+        ),
+        bcd_device="0x0202",
+        product_name="USB Combo Device (boot mouse)",
+        serial_number="213374badcafe-bm",
+    )
+
+
+def _build_nonboot_profile() -> GadgetProfile:
+    return GadgetProfile(
+        name="nonboot",
+        devices=(
+            GadgetHidDevice.from_existing(
+                usb_hid.Device.KEYBOARD,
+                function_index=0,
+                protocol=0,
+                subclass=0,
+            ),
+            GadgetHidDevice.from_existing(
+                usb_hid.Device.MOUSE,
+                function_index=1,
+                protocol=0,
+                subclass=0,
+            ),
+            GadgetHidDevice.from_existing(
+                usb_hid.Device.CONSUMER_CONTROL,
+                function_index=2,
+                protocol=0,
+                subclass=0,
+            ),
+        ),
+        bcd_device="0x0203",
+        product_name="USB Combo Device (nonboot)",
+        serial_number="213374badcafe-nb",
+    )
+
+
+def _build_cherry_combo_profile() -> GadgetProfile:
+    return GadgetProfile(
+        name="cherry_combo",
+        devices=(
+            GadgetHidDevice.from_existing(
+                usb_hid.Device.BOOT_KEYBOARD,
+                function_index=0,
+                protocol=1,
+                subclass=1,
+                descriptor=CHERRY_KEYBOARD_DESCRIPTOR,
+                name="cherry keyboard gadget",
+            ),
+            GadgetHidDevice.from_existing(
+                usb_hid.Device.MOUSE,
+                function_index=1,
+                protocol=0,
+                subclass=0,
+            ),
+            GadgetHidDevice.from_existing(
+                usb_hid.Device.CONSUMER_CONTROL,
+                function_index=2,
+                protocol=0,
+                subclass=0,
+            ),
+        ),
+        bcd_device="0x0204",
+        product_name="USB Combo Device (cherry combo)",
+        serial_number="213374badcafe-cc",
+        max_power=100,
+        bm_attributes=0xA0,
+    )
+
+
+def build_profile(name: str) -> GadgetProfile:
+    if name == "boot_keyboard":
+        return _build_boot_keyboard_profile()
+    if name == "boot_mouse":
+        return _build_boot_mouse_profile()
+    if name == "nonboot":
+        return _build_nonboot_profile()
+    if name == "cherry_combo":
+        return _build_cherry_combo_profile()
+    raise ValueError(f"Unsupported HID profile: {name}")

--- a/src/bluetooth_2_usb/relay.py
+++ b/src/bluetooth_2_usb/relay.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import errno
 import os
 import re
 import stat
 import threading
 import time
 from asyncio import Task, TaskGroup
-from importlib import import_module
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -49,6 +49,8 @@ from .evdev import (
     is_consumer_key,
     is_mouse_button,
 )
+from .gadget_config import rebuild_gadget
+from .hid_descriptors import build_profile
 from .inventory import (
     DEFAULT_SKIP_NAME_PREFIXES,
     DeviceEnumerationError,
@@ -118,33 +120,26 @@ class GadgetManager:
         self._hid_profile = hid_profile
 
     def _requested_devices(self):
-        usb_hid = import_module("usb_hid")
-        device = usb_hid.Device
-
-        if self._hid_profile == "boot_keyboard":
-            return [device.BOOT_KEYBOARD, device.MOUSE, device.CONSUMER_CONTROL]
-        if self._hid_profile == "boot_mouse":
-            return [device.BOOT_MOUSE, device.KEYBOARD, device.CONSUMER_CONTROL]
-        if self._hid_profile == "nonboot":
-            return [device.KEYBOARD, device.MOUSE, device.CONSUMER_CONTROL]
-
-        raise ValueError(f"Unsupported HID profile: {self._hid_profile}")
+        return list(build_profile(self._hid_profile).devices)
 
     def _usb_identity_overrides(self) -> dict[str, str]:
         profile_code = {
             "boot_keyboard": "0x0201",
             "boot_mouse": "0x0202",
             "nonboot": "0x0203",
+            "cherry_combo": "0x0204",
         }[self._hid_profile]
         serial_suffix = {
             "boot_keyboard": "bk",
             "boot_mouse": "bm",
             "nonboot": "nb",
+            "cherry_combo": "cc",
         }[self._hid_profile]
         product_name = {
             "boot_keyboard": "USB Combo Device (boot keyboard)",
             "boot_mouse": "USB Combo Device (boot mouse)",
             "nonboot": "USB Combo Device (nonboot)",
+            "cherry_combo": "USB Combo Device (cherry combo)",
         }[self._hid_profile]
         return {
             "B2U_USB_BCD_DEVICE": profile_code,
@@ -227,23 +222,17 @@ class GadgetManager:
         Disable and re-enable usb_hid devices, then store references
         to the new Keyboard, Mouse, and ConsumerControl gadgets.
         """
-        usb_hid = import_module("usb_hid")
-        os.environ.update(self._usb_identity_overrides())
-        usb_hid.disable()
         self._prune_stale_hidg_nodes(remove_character_devices=True)
-
-        usb_hid.enable(self._requested_devices())  # type: ignore[arg-type]
+        enabled_devices = list(rebuild_gadget(build_profile(self._hid_profile)))
         try:
             self._validate_hidg_nodes()
         except RuntimeError:
             _logger.warning(
                 "Retrying HID gadget initialization after stale node validation failure"
             )
-            usb_hid.disable()
             self._prune_stale_hidg_nodes(remove_character_devices=True)
-            usb_hid.enable(self._requested_devices())  # type: ignore[arg-type]
+            enabled_devices = list(rebuild_gadget(build_profile(self._hid_profile)))
             self._validate_hidg_nodes()
-        enabled_devices = list(usb_hid.devices)  # type: ignore[attr-defined]
 
         from adafruit_hid.consumer_control import ConsumerControl
         from adafruit_hid.keyboard import Keyboard
@@ -678,15 +667,15 @@ class RelayController:
         if task and not task.done():
             task.cancel()
             _logger.debug(f"Cancelled relay for {device_path}.")
-        else:
-            _logger.debug(f"No active task found for {device_path} to remove.")
-        if device is not None:
-            try:
-                device.close()
-            except Exception:
-                _logger.debug(
-                    "Ignoring close failure for %s during removal.", device_path
-                )
+            return
+
+        _logger.debug(f"No active task found for {device_path} to remove.")
+        if device is None:
+            return
+        try:
+            device.close()
+        except Exception:
+            _logger.debug("Ignoring close failure for %s during removal.", device_path)
 
     async def _async_relay_events(self, device: InputDevice) -> None:
         """
@@ -744,6 +733,9 @@ class DeviceRelay:
     - Retries HID writes if they raise BlockingIOError.
     """
 
+    HID_WRITE_MAX_TRIES = 3
+    HID_WRITE_RETRY_DELAY_SEC = 0.01
+
     def __init__(
         self,
         input_device: InputDevice,
@@ -766,6 +758,8 @@ class DeviceRelay:
         self._shortcut_toggler = shortcut_toggler
 
         self._currently_grabbed = False
+        self._hid_write_retries = 0
+        self._hid_write_failures = 0
 
     def __str__(self) -> str:
         return f"relay for {self._input_device}"
@@ -805,18 +799,57 @@ class DeviceRelay:
                 self._input_device.ungrab()
                 self._currently_grabbed = False
             except Exception as ex:
-                if isinstance(ex, OSError) and ex.errno == 19:
+                self._currently_grabbed = False
+                if self._should_ignore_ungrab_error(ex):
                     _logger.debug(
-                        "Skipping ungrab for %s because the device disappeared.",
+                        "Skipping ungrab for %s because the device is no longer available.",
                         self._input_device.path,
                     )
                 else:
                     _logger.warning(f"Unable to ungrab {self._input_device.path}: {ex}")
         try:
+            self._release_gadget_states()
+        except Exception:
+            _logger.debug("Ignoring gadget state release failure for %s", self)
+        try:
             self._input_device.close()
         except Exception:
             _logger.debug("Ignoring close failure for %s", self._input_device.path)
         return False
+
+    def _should_ignore_ungrab_error(self, ex: Exception) -> bool:
+        return isinstance(ex, OSError) and ex.errno in (errno.ENODEV, errno.EBADF)
+
+    def _release_gadget_states(self) -> None:
+        keyboard = self._gadget_manager.get_keyboard()
+        mouse = self._gadget_manager.get_mouse()
+        if keyboard is not None:
+            keyboard.release_all()
+        if mouse is not None:
+            mouse.release_all()
+
+    def _update_grab_state(self, active: bool) -> None:
+        if self._grab_device and active and not self._currently_grabbed:
+            try:
+                self._input_device.grab()
+                self._currently_grabbed = True
+                _logger.debug(f"Grabbed {self._input_device}")
+            except Exception as ex:
+                _logger.warning(f"Could not grab {self._input_device}: {ex}")
+        elif self._grab_device and not active and self._currently_grabbed:
+            try:
+                self._input_device.ungrab()
+                self._currently_grabbed = False
+                _logger.debug(f"Ungrabbed {self._input_device}")
+            except Exception as ex:
+                self._currently_grabbed = False
+                if self._should_ignore_ungrab_error(ex):
+                    _logger.debug(
+                        "Skipping ungrab for %s because the device is no longer available.",
+                        self._input_device.path,
+                    )
+                else:
+                    _logger.warning(f"Could not ungrab {self._input_device}: {ex}")
 
     async def async_relay_events_loop(self) -> None:
         """
@@ -825,41 +858,39 @@ class DeviceRelay:
 
         :return: None
         """
-        async for input_event in self._input_device.async_read_loop():
-            event = categorize(input_event)
+        try:
+            async for input_event in self._input_device.async_read_loop():
+                event = categorize(input_event)
 
-            if any(isinstance(event, ev_type) for ev_type in [KeyEvent, RelEvent]):
-                _logger.debug(
-                    f"Received {event} from {self._input_device.name} ({self._input_device.path})"
-                )
+                if any(isinstance(event, ev_type) for ev_type in [KeyEvent, RelEvent]):
+                    _logger.debug(
+                        f"Received {event} from {self._input_device.name} ({self._input_device.path})"
+                    )
 
-            if self._shortcut_toggler and isinstance(event, KeyEvent):
-                if self._shortcut_toggler.handle_key_event(event):
+                if self._shortcut_toggler and isinstance(event, KeyEvent):
+                    if self._shortcut_toggler.handle_key_event(event):
+                        continue
+
+                active = bool(self._relaying_active and self._relaying_active.is_set())
+                self._update_grab_state(active)
+
+                if not active:
                     continue
 
-            active = self._relaying_active and self._relaying_active.is_set()
-
-            # Dynamically grab/ungrab if relaying state changes
-            if self._grab_device and active and not self._currently_grabbed:
-                try:
-                    self._input_device.grab()
-                    self._currently_grabbed = True
-                    _logger.debug(f"Grabbed {self._input_device}")
-                except Exception as ex:
-                    _logger.warning(f"Could not grab {self._input_device}: {ex}")
-
-            elif self._grab_device and not active and self._currently_grabbed:
-                try:
-                    self._input_device.ungrab()
-                    self._currently_grabbed = False
-                    _logger.debug(f"Ungrabbed {self._input_device}")
-                except Exception as ex:
-                    _logger.warning(f"Could not ungrab {self._input_device}: {ex}")
-
-            if not active:
-                continue
-
-            await self._process_event_with_retry(event)
+                await self._process_event_with_retry(event)
+        except OSError as ex:
+            if ex.errno != errno.ENODEV:
+                raise
+            _logger.debug(
+                "Stopping relay loop for %s because the input device disappeared.",
+                self._input_device.path,
+            )
+        _logger.debug(
+            "Relay stats for %s: hid_write_retries=%s hid_write_failures=%s",
+            self._input_device.path,
+            self._hid_write_retries,
+            self._hid_write_failures,
+        )
 
     async def _process_event_with_retry(self, event: InputEvent) -> None:
         """
@@ -868,19 +899,22 @@ class DeviceRelay:
 
         :param event: The InputEvent to process
         """
-        max_tries = 3
-        retry_delay = 0.1
+        max_tries = self.HID_WRITE_MAX_TRIES
+        retry_delay = self.HID_WRITE_RETRY_DELAY_SEC
         for attempt in range(1, max_tries + 1):
             try:
                 relay_event(event, self._gadget_manager)
                 return
             except BlockingIOError:
                 if attempt < max_tries:
+                    self._hid_write_retries += 1
                     _logger.debug(f"HID write blocked ({attempt}/{max_tries})")
                     await asyncio.sleep(retry_delay)
                 else:
+                    self._hid_write_failures += 1
                     _logger.warning(f"HID write blocked ({attempt}/{max_tries})")
             except BrokenPipeError:
+                self._hid_write_failures += 1
                 _logger.warning(
                     "BrokenPipeError: USB cable likely disconnected or power-only. "
                     "Pausing relay.\nSee: "
@@ -890,6 +924,7 @@ class DeviceRelay:
                     self._relaying_active.clear()
                 return
             except Exception:
+                self._hid_write_failures += 1
                 _logger.exception(f"Error processing {event}")
                 return
 

--- a/src/bluetooth_2_usb/service_config.py
+++ b/src/bluetooth_2_usb/service_config.py
@@ -105,7 +105,12 @@ def load_service_config(env_file: Path = DEFAULT_ENV_FILE) -> ServiceConfig:
         elif key == "B2U_INTERRUPT_SHORTCUT":
             config.interrupt_shortcut = value
         elif key == "B2U_HID_PROFILE":
-            if value not in {"boot_keyboard", "boot_mouse", "nonboot"}:
+            if value not in {
+                "boot_keyboard",
+                "boot_mouse",
+                "nonboot",
+                "cherry_combo",
+            }:
                 raise ServiceConfigError(
                     f"{env_file}:{line_number}: invalid B2U_HID_PROFILE {value!r}"
                 )

--- a/src/bluetooth_2_usb/test_harness_capture.py
+++ b/src/bluetooth_2_usb/test_harness_capture.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 import sys
 import time
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any
 
+from adafruit_hid.keycode import Keycode
+
+from .evdev import evdev_to_usb_hid
 from .test_harness_common import (
     DEFAULT_DEVICE_SUBSTRING,
     EXIT_ACCESS,
@@ -12,9 +16,6 @@ from .test_harness_common import (
     EXIT_OK,
     EXIT_PREREQUISITE,
     EXIT_TIMEOUT,
-    KEY_F13,
-    KEY_F14,
-    KEY_F15,
     KEY_VOLUMEDOWN,
     KEY_VOLUMEUP,
     REL_X,
@@ -33,12 +34,6 @@ CONSUMER_USAGE_PAGE = 0x0C
 CONSUMER_USAGE = 0x01
 GADGET_VENDOR_ID = 0x1D6B
 GADGET_PRODUCT_ID = 0x0104
-
-HID_KEY_CODES = {
-    KEY_F13: 104,
-    KEY_F14: 105,
-    KEY_F15: 106,
-}
 
 CONSUMER_USAGES = {
     KEY_VOLUMEUP: 0x00E9,
@@ -111,6 +106,11 @@ class GadgetNodeCandidates:
 class KeyboardSequenceMatcher:
     expected_steps: tuple
     index: int = 0
+    _modifier_state: int = 0
+    _pressed_keys: tuple[int, ...] = ()
+
+    def __post_init__(self) -> None:
+        self._pressed_keys = ()
 
     def handle(self, report: bytes) -> None:
         payload = _normalize_keyboard_report(report)
@@ -124,19 +124,38 @@ class KeyboardSequenceMatcher:
             return
 
         expected = self.expected_steps[self.index]
-        if expected.value == 1:
-            hid_code = HID_KEY_CODES[expected.code]
-            pressed = tuple(code for code in payload[2:] if code)
-            if pressed != (hid_code,):
-                raise CaptureMismatchError(
-                    f"Unexpected keyboard report {report.hex(sep=' ')}; expected key {hid_code}"
-                )
-        else:
-            if any(payload):
-                raise CaptureMismatchError(
-                    f"Unexpected keyboard release report {report.hex(sep=' ')}"
-                )
+        expected_payload = self._apply_expected_step(expected)
+        if payload != expected_payload:
+            raise CaptureMismatchError(
+                f"Unexpected keyboard report {report.hex(sep=' ')}; expected {expected_payload.hex(sep=' ')}"
+            )
         self.index += 1
+
+    def _apply_expected_step(self, expected) -> bytes:
+        hid_code, _ = evdev_to_usb_hid(
+            SimpleNamespace(scancode=expected.code, keystate=expected.value)
+        )
+        if hid_code is None:
+            raise CaptureMismatchError(
+                f"Expected keyboard step {expected.describe()} is not mappable to HID"
+            )
+        modifier = Keycode.modifier_bit(hid_code)
+        if expected.value == 1:
+            if modifier:
+                self._modifier_state |= modifier
+            elif hid_code not in self._pressed_keys:
+                self._pressed_keys = (*self._pressed_keys, hid_code)
+        elif expected.value == 0:
+            if modifier:
+                self._modifier_state &= ~modifier
+            else:
+                self._pressed_keys = tuple(
+                    key for key in self._pressed_keys if key != hid_code
+                )
+
+        keys = list(self._pressed_keys[:6])
+        keys.extend([0] * (6 - len(keys)))
+        return bytes([self._modifier_state, 0, *keys])
 
     @property
     def complete(self) -> bool:

--- a/src/bluetooth_2_usb/test_harness_common.py
+++ b/src/bluetooth_2_usb/test_harness_common.py
@@ -22,8 +22,20 @@ EV_REL = 2
 KEY_F13 = 183
 KEY_F14 = 184
 KEY_F15 = 185
+KEY_A = 30
+KEY_E = 18
+KEY_K = 37
+KEY_O = 24
+KEY_R = 19
+KEY_T = 20
+KEY_Y = 21
+KEY_B = 48
+KEY_D = 32
+KEY_LEFTSHIFT = 42
 KEY_VOLUMEUP = 115
 KEY_VOLUMEDOWN = 114
+KEY_MINUS = 12
+KEY_SPACE = 57
 REL_X = 0
 REL_Y = 1
 
@@ -37,8 +49,20 @@ EVENT_CODE_NAMES = {
         KEY_F13: "KEY_F13",
         KEY_F14: "KEY_F14",
         KEY_F15: "KEY_F15",
+        KEY_A: "KEY_A",
+        KEY_E: "KEY_E",
+        KEY_K: "KEY_K",
+        KEY_O: "KEY_O",
+        KEY_R: "KEY_R",
+        KEY_T: "KEY_T",
+        KEY_Y: "KEY_Y",
+        KEY_B: "KEY_B",
+        KEY_D: "KEY_D",
+        KEY_LEFTSHIFT: "KEY_LEFTSHIFT",
         KEY_VOLUMEUP: "KEY_VOLUMEUP",
         KEY_VOLUMEDOWN: "KEY_VOLUMEDOWN",
+        KEY_MINUS: "KEY_MINUS",
+        KEY_SPACE: "KEY_SPACE",
     },
     EV_REL: {
         REL_X: "REL_X",
@@ -46,7 +70,7 @@ EVENT_CODE_NAMES = {
     },
 }
 
-SCENARIO_NAMES = ("keyboard", "mouse", "combo", "consumer")
+SCENARIO_NAMES = ("keyboard", "mouse", "combo", "consumer", "text_burst")
 DEFAULT_DEVICE_SUBSTRING = "USB_Combo_Device"
 DEFAULT_KEYBOARD_NAME = "B2U Test Keyboard"
 DEFAULT_MOUSE_NAME = "B2U Test Mouse"
@@ -238,6 +262,66 @@ CONSUMER_STEPS = (
     ExpectedEvent(EV_KEY, KEY_VOLUMEDOWN, 0),
 )
 
+
+def _append_text_steps(steps: list[ExpectedEvent], text: str) -> None:
+    key_map = {
+        "a": KEY_A,
+        "b": KEY_B,
+        "d": KEY_D,
+        "e": KEY_E,
+        "k": KEY_K,
+        "o": KEY_O,
+        "r": KEY_R,
+        "t": KEY_T,
+        "y": KEY_Y,
+    }
+    for char in text:
+        if char == " ":
+            steps.extend(
+                (
+                    ExpectedEvent(EV_KEY, KEY_SPACE, 1),
+                    ExpectedEvent(EV_KEY, KEY_SPACE, 0),
+                )
+            )
+            continue
+        if char == "_":
+            steps.extend(
+                (
+                    ExpectedEvent(EV_KEY, KEY_LEFTSHIFT, 1),
+                    ExpectedEvent(EV_KEY, KEY_MINUS, 1),
+                    ExpectedEvent(EV_KEY, KEY_MINUS, 0),
+                    ExpectedEvent(EV_KEY, KEY_LEFTSHIFT, 0),
+                )
+            )
+            continue
+
+        key_code = key_map[char.lower()]
+        if char.isupper():
+            steps.extend(
+                (
+                    ExpectedEvent(EV_KEY, KEY_LEFTSHIFT, 1),
+                    ExpectedEvent(EV_KEY, key_code, 1),
+                    ExpectedEvent(EV_KEY, key_code, 0),
+                    ExpectedEvent(EV_KEY, KEY_LEFTSHIFT, 0),
+                )
+            )
+            continue
+
+        steps.extend(
+            (
+                ExpectedEvent(EV_KEY, key_code, 1),
+                ExpectedEvent(EV_KEY, key_code, 0),
+            )
+        )
+
+
+_TEXT_BURST_STEPS: list[ExpectedEvent] = []
+_append_text_steps(
+    _TEXT_BURST_STEPS,
+    "boot_keyboard BOOT_KEYBOARD boot_keyboard BOOT_KEYBOARD",
+)
+TEXT_BURST_STEPS = tuple(_TEXT_BURST_STEPS)
+
 SCENARIOS = {
     "keyboard": ScenarioDefinition(
         name="keyboard",
@@ -266,6 +350,13 @@ SCENARIOS = {
         mouse_rel_steps=(),
         mouse_button_steps=(),
         consumer_steps=CONSUMER_STEPS,
+    ),
+    "text_burst": ScenarioDefinition(
+        name="text_burst",
+        keyboard_steps=TEXT_BURST_STEPS,
+        mouse_rel_steps=(),
+        mouse_button_steps=(),
+        consumer_steps=(),
     ),
 }
 

--- a/src/bluetooth_2_usb/test_harness_inject.py
+++ b/src/bluetooth_2_usb/test_harness_inject.py
@@ -13,6 +13,7 @@ from .test_harness_common import (
     EXIT_ACCESS,
     EXIT_OK,
     EXIT_PREREQUISITE,
+    SCENARIOS,
     HarnessResult,
     get_scenario,
     scenario_to_dict,
@@ -28,8 +29,15 @@ def _send_step(device: UInput, step_event, event_gap_ms: int) -> None:
 
 
 def _keyboard_capabilities() -> dict[int, list[int]]:
+    keyboard_codes = sorted(
+        {
+            step.code
+            for scenario in SCENARIOS.values()
+            for step in scenario.keyboard_steps
+        }
+    )
     return {
-        ecodes.EV_KEY: [ecodes.KEY_F13, ecodes.KEY_F14, ecodes.KEY_F15],
+        ecodes.EV_KEY: keyboard_codes,
     }
 
 

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -37,3 +37,8 @@ class ParseArgsTest(unittest.TestCase):
         args = parse_args(["--hid-profile", "nonboot"])
 
         self.assertEqual(args.hid_profile, "nonboot")
+
+    def test_cherry_combo_profile_is_accepted(self) -> None:
+        args = parse_args(["--hid-profile", "cherry_combo"])
+
+        self.assertEqual(args.hid_profile, "cherry_combo")

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -8,7 +8,16 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import usb_hid
+
+from bluetooth_2_usb.gadget_config import rebuild_gadget
+from bluetooth_2_usb.hid_descriptors import (
+    CHERRY_KEYBOARD_DESCRIPTOR,
+    GadgetHidDevice,
+    build_profile,
+)
 from bluetooth_2_usb.relay import (
+    DeviceRelay,
     GadgetManager,
     RelayController,
     RuntimeMonitor,
@@ -103,6 +112,54 @@ class _FakeInputHandle:
         self.close_calls += 1
 
 
+class _FakeGrabInputDevice:
+    def __init__(self, *, ungrab_errno: int | None = None) -> None:
+        self.path = "/dev/input/event-grab"
+        self.name = "grab-test-device"
+        self.close_calls = 0
+        self.grab_calls = 0
+        self.ungrab_calls = 0
+        self._ungrab_errno = ungrab_errno
+
+    def grab(self) -> None:
+        self.grab_calls += 1
+
+    def ungrab(self) -> None:
+        self.ungrab_calls += 1
+        if self._ungrab_errno is not None:
+            raise OSError(self._ungrab_errno, "Bad file descriptor")
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+class _QueueTestKeyEvent:
+    key_down = 1
+    key_hold = 2
+    key_up = 0
+
+    def __init__(self, scancode: int, keystate: int) -> None:
+        self.scancode = scancode
+        self.keystate = keystate
+
+
+class _QueueInputDevice:
+    def __init__(self, events, *, removal_errno: int | None = None) -> None:
+        self.path = "/dev/input/event-test"
+        self.name = "queue-test-device"
+        self._events = list(events)
+        self._removal_errno = removal_errno
+
+    async def async_read_loop(self):
+        for event in self._events:
+            yield event
+        if self._removal_errno is not None:
+            raise OSError(self._removal_errno, "No such device")
+
+    def close(self) -> None:
+        return None
+
+
 class ShortcutTogglerTest(unittest.TestCase):
     def test_shortcut_events_are_suppressed_and_toggle_relays(self) -> None:
         event_state = asyncio.Event()
@@ -168,55 +225,75 @@ class RuntimeMonitorTest(unittest.TestCase):
 
 class GadgetManagerProfileTest(unittest.TestCase):
     def test_boot_mouse_profile_uses_boot_mouse_then_keyboard(self) -> None:
-        fake_device = SimpleNamespace(
-            BOOT_KEYBOARD="boot-keyboard",
-            KEYBOARD="keyboard",
-            BOOT_MOUSE="boot-mouse",
-            MOUSE="mouse",
-            CONSUMER_CONTROL="consumer",
-        )
-
         with patch(
-            "bluetooth_2_usb.relay.import_module",
-            return_value=SimpleNamespace(Device=fake_device),
+            "bluetooth_2_usb.relay.build_profile",
+            return_value=SimpleNamespace(
+                devices=("boot-mouse", "keyboard", "consumer")
+            ),
         ):
             devices = GadgetManager("boot_mouse")._requested_devices()
 
         self.assertEqual(devices, ["boot-mouse", "keyboard", "consumer"])
 
     def test_nonboot_profile_uses_nonboot_devices(self) -> None:
-        fake_device = SimpleNamespace(
-            BOOT_KEYBOARD="boot-keyboard",
-            KEYBOARD="keyboard",
-            BOOT_MOUSE="boot-mouse",
-            MOUSE="mouse",
-            CONSUMER_CONTROL="consumer",
-        )
-
         with patch(
-            "bluetooth_2_usb.relay.import_module",
-            return_value=SimpleNamespace(Device=fake_device),
+            "bluetooth_2_usb.relay.build_profile",
+            return_value=SimpleNamespace(devices=("keyboard", "mouse", "consumer")),
         ):
             devices = GadgetManager("nonboot")._requested_devices()
 
         self.assertEqual(devices, ["keyboard", "mouse", "consumer"])
 
     def test_boot_keyboard_profile_uses_boot_keyboard_then_nonboot_mouse(self) -> None:
-        fake_device = SimpleNamespace(
-            BOOT_KEYBOARD="boot-keyboard",
-            KEYBOARD="keyboard",
-            BOOT_MOUSE="boot-mouse",
-            MOUSE="mouse",
-            CONSUMER_CONTROL="consumer",
-        )
-
         with patch(
-            "bluetooth_2_usb.relay.import_module",
-            return_value=SimpleNamespace(Device=fake_device),
+            "bluetooth_2_usb.relay.build_profile",
+            return_value=SimpleNamespace(
+                devices=("boot-keyboard", "mouse", "consumer")
+            ),
         ):
             devices = GadgetManager("boot_keyboard")._requested_devices()
 
         self.assertEqual(devices, ["boot-keyboard", "mouse", "consumer"])
+
+    def test_cherry_combo_profile_uses_cherry_keyboard_then_existing_mouse_and_consumer(
+        self,
+    ) -> None:
+        profile = build_profile("cherry_combo")
+
+        self.assertEqual(len(profile.devices), 3)
+        self.assertEqual(
+            bytes(profile.devices[0].descriptor), CHERRY_KEYBOARD_DESCRIPTOR
+        )
+        self.assertEqual(
+            bytes(profile.devices[1].descriptor), bytes(usb_hid.Device.MOUSE.descriptor)
+        )
+        self.assertEqual(
+            bytes(profile.devices[2].descriptor),
+            bytes(usb_hid.Device.CONSUMER_CONTROL.descriptor),
+        )
+
+    def test_gadget_hid_device_passes_protocol_and_subclass_when_required(self) -> None:
+        init_calls = []
+
+        def fake_device_init(self, **kwargs) -> None:
+            init_calls.append(kwargs)
+            if "subclass" not in kwargs or "protocol" not in kwargs:
+                raise TypeError(
+                    "Device.__init__() missing 2 required keyword-only arguments: "
+                    "'subclass' and 'protocol'"
+                )
+
+        with patch.object(usb_hid.Device, "__init__", fake_device_init):
+            GadgetHidDevice.from_existing(
+                usb_hid.Device.BOOT_KEYBOARD,
+                function_index=0,
+                protocol=1,
+                subclass=1,
+            )
+
+        self.assertEqual(len(init_calls), 1)
+        self.assertEqual(init_calls[0]["protocol"], 1)
+        self.assertEqual(init_calls[0]["subclass"], 1)
 
     def test_boot_keyboard_profile_sets_distinct_usb_identity(self) -> None:
         identity = GadgetManager("boot_keyboard")._usb_identity_overrides()
@@ -240,6 +317,13 @@ class GadgetManagerProfileTest(unittest.TestCase):
         self.assertEqual(identity["B2U_USB_BCD_DEVICE"], "0x0203")
         self.assertEqual(identity["B2U_USB_SERIALNUMBER"], "213374badcafe-nb")
         self.assertEqual(identity["B2U_USB_PRODUCT"], "USB Combo Device (nonboot)")
+
+    def test_cherry_combo_profile_sets_distinct_usb_identity(self) -> None:
+        identity = GadgetManager("cherry_combo")._usb_identity_overrides()
+
+        self.assertEqual(identity["B2U_USB_BCD_DEVICE"], "0x0204")
+        self.assertEqual(identity["B2U_USB_SERIALNUMBER"], "213374badcafe-cc")
+        self.assertEqual(identity["B2U_USB_PRODUCT"], "USB Combo Device (cherry combo)")
 
     def test_prune_stale_hidg_nodes_removes_regular_files(self) -> None:
         manager = GadgetManager("boot_mouse")
@@ -298,6 +382,168 @@ class GadgetManagerProfileTest(unittest.TestCase):
                             invalid_paths = manager._collect_invalid_hidg_nodes()
 
         self.assertEqual(invalid_paths, [f"{path} (No such device)"])
+
+    def test_rebuild_gadget_writes_cherry_combo_power_and_identity(self) -> None:
+        profile = build_profile("cherry_combo")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            gadget_root = Path(tmpdir) / "usb_gadget" / "adafruit-blinka"
+            with patch("bluetooth_2_usb.gadget_config.GADGET_ROOT", gadget_root):
+                with patch(
+                    "bluetooth_2_usb.gadget_config._resolve_udc_name",
+                    return_value="dummy.udc",
+                ):
+                    with patch.object(usb_hid, "gadget_root", str(gadget_root)):
+                        rebuild_gadget(profile)
+
+            self.assertEqual(
+                (gadget_root / "strings/0x409/product")
+                .read_text(encoding="utf-8")
+                .strip(),
+                "USB Combo Device (cherry combo)",
+            )
+            self.assertEqual(
+                (gadget_root / "strings/0x409/serialnumber")
+                .read_text(encoding="utf-8")
+                .strip(),
+                "213374badcafe-cc",
+            )
+            self.assertEqual(
+                (gadget_root / "bcdDevice").read_text(encoding="utf-8").strip(),
+                "0x0204",
+            )
+            self.assertEqual(
+                (gadget_root / "configs/c.1/MaxPower")
+                .read_text(encoding="utf-8")
+                .strip(),
+                "100",
+            )
+            self.assertEqual(
+                (gadget_root / "configs/c.1/bmAttributes")
+                .read_text(encoding="utf-8")
+                .strip(),
+                "0xa0",
+            )
+            self.assertEqual(
+                (gadget_root / "configs/c.1/strings/0x409/configuration")
+                .read_text(encoding="utf-8")
+                .strip(),
+                "Config 1: HID relay",
+            )
+
+
+class DeviceRelayTest(unittest.IsolatedAsyncioTestCase):
+    async def test_relay_preserves_event_order_under_slow_writer(self) -> None:
+        relaying_active = asyncio.Event()
+        relaying_active.set()
+        seen: list[tuple[int, int]] = []
+        input_device = _QueueInputDevice(
+            [
+                _QueueTestKeyEvent(183, _QueueTestKeyEvent.key_down),
+                _QueueTestKeyEvent(183, _QueueTestKeyEvent.key_up),
+                _QueueTestKeyEvent(184, _QueueTestKeyEvent.key_down),
+                _QueueTestKeyEvent(184, _QueueTestKeyEvent.key_up),
+            ]
+        )
+        relay = DeviceRelay(
+            input_device,
+            _FakeGadgetManager(),
+            relaying_active=relaying_active,
+        )
+
+        async def _slow_process(event) -> None:
+            seen.append((event.scancode, event.keystate))
+            await asyncio.sleep(0.001)
+
+        with patch("bluetooth_2_usb.relay.KeyEvent", _QueueTestKeyEvent):
+            with patch(
+                "bluetooth_2_usb.relay.categorize", side_effect=lambda event: event
+            ):
+                with patch.object(
+                    relay, "_process_event_with_retry", side_effect=_slow_process
+                ):
+                    async with relay:
+                        await relay.async_relay_events_loop()
+
+        self.assertEqual(seen, [(183, 1), (183, 0), (184, 1), (184, 0)])
+
+    async def test_aexit_ignores_ebadf_from_ungrab_on_disappeared_device(self) -> None:
+        input_device = _FakeGrabInputDevice(ungrab_errno=errno.EBADF)
+        relay = DeviceRelay(
+            input_device,
+            _FakeGadgetManager(),
+            grab_device=True,
+            relaying_active=asyncio.Event(),
+        )
+
+        async with relay:
+            self.assertTrue(relay._currently_grabbed)
+
+        self.assertEqual(input_device.grab_calls, 1)
+        self.assertEqual(input_device.ungrab_calls, 1)
+        self.assertEqual(input_device.close_calls, 1)
+        self.assertFalse(relay._currently_grabbed)
+
+    async def test_input_device_removal_stops_reader_without_failing_task_group(
+        self,
+    ) -> None:
+        relaying_active = asyncio.Event()
+        relaying_active.set()
+        seen: list[tuple[int, int]] = []
+        input_device = _QueueInputDevice(
+            [
+                _QueueTestKeyEvent(183, _QueueTestKeyEvent.key_down),
+                _QueueTestKeyEvent(183, _QueueTestKeyEvent.key_up),
+            ],
+            removal_errno=errno.ENODEV,
+        )
+        relay = DeviceRelay(
+            input_device,
+            _FakeGadgetManager(),
+            relaying_active=relaying_active,
+        )
+
+        async def _record_process(event) -> None:
+            seen.append((event.scancode, event.keystate))
+
+        with patch("bluetooth_2_usb.relay.KeyEvent", _QueueTestKeyEvent):
+            with patch(
+                "bluetooth_2_usb.relay.categorize", side_effect=lambda event: event
+            ):
+                with patch.object(
+                    relay, "_process_event_with_retry", side_effect=_record_process
+                ):
+                    async with relay:
+                        await relay.async_relay_events_loop()
+
+        self.assertEqual(seen, [(183, 1), (183, 0)])
+
+    async def test_broken_pipe_clears_relaying_active_without_queue_helpers(
+        self,
+    ) -> None:
+        relaying_active = asyncio.Event()
+        relaying_active.set()
+        input_device = _QueueInputDevice(
+            [_QueueTestKeyEvent(183, _QueueTestKeyEvent.key_down)]
+        )
+        relay = DeviceRelay(
+            input_device,
+            _FakeGadgetManager(),
+            relaying_active=relaying_active,
+        )
+
+        with patch("bluetooth_2_usb.relay.KeyEvent", _QueueTestKeyEvent):
+            with patch(
+                "bluetooth_2_usb.relay.categorize", side_effect=lambda event: event
+            ):
+                with patch(
+                    "bluetooth_2_usb.relay.relay_event",
+                    side_effect=BrokenPipeError(),
+                ):
+                    async with relay:
+                        await relay.async_relay_events_loop()
+
+        self.assertFalse(relaying_active.is_set())
+        self.assertEqual(relay._hid_write_failures, 1)
 
 
 class RelayControllerHotplugTest(unittest.TestCase):
@@ -360,4 +606,4 @@ class RelayControllerHotplugTest(unittest.TestCase):
         self.assertFalse(relaying_active.is_set())
         self.assertEqual(controller._pending_add_paths, [])
         self.assertEqual(task.cancel_calls, 1)
-        self.assertEqual(device.close_calls, 1)
+        self.assertEqual(device.close_calls, 0)

--- a/tests/test_service_config.py
+++ b/tests/test_service_config.py
@@ -105,3 +105,17 @@ class ServiceConfigTest(unittest.TestCase):
             config = load_service_config(env_file)
 
         self.assertEqual(config.hid_profile, "boot_keyboard")
+
+    def test_accepts_cherry_combo_hid_profile(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env_file = Path(tmpdir) / "bluetooth_2_usb"
+            env_file.write_text(
+                "B2U_HID_PROFILE=cherry_combo\n",
+                encoding="utf-8",
+            )
+
+            config = load_service_config(env_file)
+            argv = build_cli_argv(config)
+
+        self.assertEqual(config.hid_profile, "cherry_combo")
+        self.assertIn("cherry_combo", argv)

--- a/tests/test_test_harness.py
+++ b/tests/test_test_harness.py
@@ -30,6 +30,7 @@ from bluetooth_2_usb.test_harness_common import (
     EXIT_USAGE,
     MOUSE_REL_STEPS,
     SCENARIOS,
+    TEXT_BURST_STEPS,
     HarnessBusyError,
     HarnessResult,
     get_scenario,
@@ -87,9 +88,18 @@ class ScenarioDefinitionTest(unittest.TestCase):
     def test_invalid_scenario_name_is_reported_cleanly(self) -> None:
         with self.assertRaisesRegex(
             ValueError,
-            "Unknown scenario 'nope'. Expected one of: keyboard, mouse, combo, consumer",
+            "Unknown scenario 'nope'. Expected one of: keyboard, mouse, combo, consumer, text_burst",
         ):
             get_scenario("nope")
+
+    def test_text_burst_scenario_is_keyboard_only_and_contains_shifted_steps(
+        self,
+    ) -> None:
+        scenario = SCENARIOS["text_burst"]
+
+        self.assertEqual(scenario.required_nodes, ("keyboard",))
+        self.assertEqual(scenario.keyboard_steps, TEXT_BURST_STEPS)
+        self.assertIn(42, [step.code for step in scenario.keyboard_steps])
 
 
 class GadgetNodeDiscoveryTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add the cherry_combo HID profile with repo-local configfs gadget setup
- keep the consumer descriptor unchanged while aligning keyboard behavior for stricter hosts
- fix relay cleanup and reduce HID retry backoff to stop burst typing drops
- add text_burst coverage and profile/config tests

## Validation
- black --check src tests
- ruff check src tests
- python -m unittest discover -s tests -v
- validated burst typing on pi4b with AceRK after lowering HID retry delay