### PR TITLE
Simplify HID layout and add managed update flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ Important:
 Files and directories that matter most:
 
 - `src/bluetooth_2_usb/`
-  Python package for CLI, runtime, HID profiles, relay logic, logging, and
+  Python package for CLI, runtime, HID layout, relay logic, logging, and
   version handling
 - `scripts/`
   Managed install, uninstall, smoke/debug, and persistent read-only helpers
@@ -110,8 +110,7 @@ Preserve these unless the task explicitly redesigns them:
   - clone to `/opt/bluetooth_2_usb`
   - run `sudo /opt/bluetooth_2_usb/scripts/install.sh`
 - Supported update flow:
-  - `sudo git -C /opt/bluetooth_2_usb pull --ff-only`
-  - `sudo /opt/bluetooth_2_usb/scripts/install.sh`
+  - `sudo /opt/bluetooth_2_usb/scripts/update.sh`
 - Shell scripts should fail loudly on ambiguous or unsafe input.
 - Boot changes should be conservative and leave timestamped backups, but scripts
   should not attempt automatic rollback restores.
@@ -202,9 +201,9 @@ For runtime-affecting changes, validate on real hardware when feasible:
 - host capture can temporarily claim the gadget HID interfaces while the test
   runs; do not assume normal local desktop handling remains active during the
   capture window
-- before each new Windows validation run for a changed HID profile or
-  descriptor layout:
-  1. set the Pi HID profile
+- before each new Windows validation run for a changed gadget descriptor
+  layout or USB identity:
+  1. set the Pi to the intended software revision
   2. reboot the Pi
   3. ask the user for a Windows PnP admin reset
   4. wait for explicit confirmation before starting host capture

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,8 +63,7 @@ sudo /opt/bluetooth_2_usb/scripts/install.sh
 The operational update flow is:
 
 ```bash
-sudo git -C /opt/bluetooth_2_usb pull --ff-only
-sudo /opt/bluetooth_2_usb/scripts/install.sh
+sudo /opt/bluetooth_2_usb/scripts/update.sh
 ```
 
 Keep code and docs aligned with that model.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ If possible, power the Pi from a separate stable power supply using the power-on
 - Bluetooth keyboard and mouse input relayed as standard USB HID
 - Auto-discovery and auto-reconnect for supported input devices
 - Optional input grabbing so the Pi does not also consume local keyboard and mouse events
-- HID compatibility profiles for stricter hosts and pre-OS environments
+- A fixed strict-host USB HID layout aimed at pre-OS environments and picky hosts
 - A small, well-supported diagnostics surface built around `--validate-env`, `smoke_test.sh`, and `debug.sh`
 - Optional persistent read-only operation with writable Bluetooth state on a separate ext4 filesystem
 - A single supported managed-install workflow in `/opt/bluetooth_2_usb`
@@ -149,7 +149,6 @@ Default content:
 B2U_AUTO_DISCOVER=1
 B2U_GRAB_DEVICES=1
 B2U_INTERRUPT_SHORTCUT=CTRL+SHIFT+F12
-B2U_HID_PROFILE=boot_keyboard
 B2U_LOG_TO_FILE=0
 B2U_LOG_PATH=/var/log/bluetooth_2_usb/bluetooth_2_usb.log
 B2U_DEBUG=0
@@ -162,12 +161,18 @@ Meaning:
 - `B2U_AUTO_DISCOVER=1` relays all suitable readable input devices except known excluded platform devices.
 - `B2U_GRAB_DEVICES=1` grabs the selected input devices so the Pi stops consuming their local events.
 - `B2U_INTERRUPT_SHORTCUT=CTRL+SHIFT+F12` defines a plus-separated key chord that toggles relaying on and off at runtime.
-- `B2U_HID_PROFILE=boot_keyboard` selects the USB HID profile exposed to the host.
 - `B2U_LOG_TO_FILE=0` disables file logging by default.
 - `B2U_LOG_PATH=...` controls the file path used when file logging is enabled.
 - `B2U_DEBUG=0` keeps normal log verbosity.
 - `B2U_DEVICE_IDS` is the precise alternative when you want to pin the runtime to specific event paths, Bluetooth MACs, or case-insensitive device-name fragments.
 - `B2U_UDC_PATH` is optional and only needed if you must pin UDC detection on a system with multiple gadget-capable controllers.
+
+The host-facing USB gadget is fixed to one layout:
+
+- boot-protocol keyboard interface first
+- mouse interface second
+- consumer-control interface third
+- `MaxPower=100`, `bmAttributes=0xa0`, and `max_speed=high-speed`
 
 After editing that file, restart the service:
 
@@ -177,28 +182,6 @@ sudo systemctl restart bluetooth_2_usb.service
 
 > [!NOTE]
 > Despite the project name, broad auto-discovery can also relay other suitable Linux input devices that are visible on the Pi; the intended primary use case remains Bluetooth keyboard and mouse bridging.
-
-### HID profiles
-
-Bluetooth-2-USB supports four host-facing HID layouts:
-
-- `boot_keyboard`
-  - default
-  - exposes a boot keyboard plus a nonboot mouse and a separate consumer-control function
-  - best starting point for stricter pre-OS hosts and firmware menus
-- `boot_mouse`
-  - exposes a boot mouse plus separate keyboard and consumer-control functions
-  - useful when mouse compatibility is the primary concern
-- `nonboot`
-  - exposes nonboot keyboard, mouse, and consumer-control functions
-  - suitable for hosts that do not require boot-protocol behavior
-- `cherry_combo`
-  - exposes the same three-function layout as `boot_keyboard`
-  - keeps the current mouse and consumer-control functions
-  - swaps in a Cherry-inspired boot-keyboard descriptor plus stricter USB power and remote-wakeup settings
-  - useful for hosts that are picky during pre-OS or resume flows
-
-For most installations, start with `boot_keyboard` and only switch profiles when you are diagnosing compatibility on a specific host.
 
 ## CLI reference
 
@@ -217,11 +200,6 @@ Use these runtime flags when running the CLI manually.
 | `--version, -v` | Print the installed Bluetooth-2-USB version and exit. |
 | `--validate-env` | Validate gadget runtime prerequisites and exit. On non-gadget systems this is expected to fail fast and report the missing prerequisites. |
 | `--output {text,json}` | Output format for `--list_devices` and `--validate-env`. Default: `text`. |
-<<<<<<< HEAD
-| `--hid-profile PROFILE` | USB HID profile to expose. Default: `boot_keyboard`. Supported values: `boot_keyboard`, `boot_mouse`, `nonboot`, `cherry_combo`. `boot_keyboard` exposes a boot keyboard plus a nonboot mouse and a separate consumer-control function, making it the preferred choice for stricter pre-OS hosts. `boot_mouse` exposes a boot mouse plus separate keyboard and consumer-control functions. `nonboot` uses nonboot keyboard, mouse, and consumer-control functions. `cherry_combo` keeps the same three-function layout and the current mouse and consumer-control functions, but swaps in a Cherry-inspired boot-keyboard descriptor plus stricter USB power and remote-wakeup settings for hosts that are picky during pre-OS or resume flows. Example: `--hid-profile cherry_combo`. |
-=======
-| `--hid-profile PROFILE` | USB HID profile to expose. Default: `boot_keyboard`. Supported values: `boot_keyboard`, `boot_mouse`, `nonboot`, `cherry_combo`. `boot_keyboard` exposes a boot keyboard plus a nonboot mouse and a separate consumer-control function, making it the preferred choice for stricter pre-OS hosts. `boot_mouse` exposes a boot mouse plus separate keyboard and consumer-control functions. `nonboot` uses nonboot keyboard, mouse, and consumer-control functions. `cherry_combo` keeps the same three-function layout and the current mouse and consumer-control functions, but swaps in a Cherry-inspired boot-keyboard descriptor plus stricter USB power and remote-wakeup settings for hosts that are picky during pre-OS or resume flows. Example: `--hid-profile cherry_combo`. |
->>>>>>> ae7977c (Add cherry combo profile and fix HID burst relay)
 | `--help, -h` | Show the built-in CLI help and exit. |
 
 ## Day-to-day usage
@@ -261,14 +239,12 @@ sudo systemctl restart bluetooth_2_usb.service
 Update the managed checkout and re-apply the system integration:
 
 ```bash
-sudo git -C /opt/bluetooth_2_usb pull --ff-only
-sudo /opt/bluetooth_2_usb/scripts/install.sh
+sudo /opt/bluetooth_2_usb/scripts/update.sh
 ```
 
-This keeps the operational model simple:
-
-- Git decides which commit or branch you are on.
-- `install.sh` reapplies boot config, the virtual environment, the service, and the wrapper for the current checkout.
+`update.sh` fast-forwards the current checked-out branch, refuses to overwrite a
+dirty managed checkout, and then runs `install.sh` to reapply boot config, the
+virtual environment, the service, and the wrapper.
 
 ## Uninstalling
 
@@ -425,6 +401,19 @@ If the service looks healthy but the target host still does not react, also chec
 
 If you need to isolate the relay path from Bluetooth pairing state, run the host/Pi loopback harness from `docs/pi-host-relay-loopback-test-playbook.md`.
 
+### Wake from host sleep remains limited
+
+The current fixed USB HID layout improves strict pre-OS behavior, including the
+ThinkPad cold-boot path to BitLocker, but wake from host sleep still does not
+work reliably.
+
+This appears to require kernel-side support in the Raspberry Pi USB HID gadget
+path rather than a further `bluetooth_2_usb` userspace change. Raspberry Pi
+Linux issue [#3977](https://github.com/raspberrypi/linux/issues/3977) suggests
+this may be possible with a kernel patch or equivalent gadget wakeup support.
+
+Treat this as a known platform limitation for now.
+
 ### Bluetooth pairing or scanning is flaky even though `bluetooth.service` is active
 
 Do not treat `systemctl status bluetooth` on its own as a health check. A running `bluetooth.service` can still leave the controller powered off or rfkill-blocked.
@@ -461,7 +450,11 @@ All managed deployment scripts live in `/opt/bluetooth_2_usb/scripts/` after ins
 
 ### `install.sh`
 
-Apply the current checkout in `/opt/bluetooth_2_usb` to the managed install. This is the main deployment entrypoint for first install and for later re-application after `git pull`.
+Apply the current checkout in `/opt/bluetooth_2_usb` to the managed install. This is the main deployment entrypoint for first install and for explicit re-application of the current checkout.
+
+### `update.sh`
+
+Fast-forward the managed checkout and then call `install.sh`. This is the supported update path for an existing managed deployment.
 
 ### `uninstall.sh`
 
@@ -503,9 +496,9 @@ The harness is single-run only and uses a lock file. If a previous run was inter
 - host: `/tmp/bluetooth_2_usb_test_harness.lock` on Linux and macOS
 - Pi: `/tmp/bluetooth_2_usb_test_harness.lock`
 
-Before each fresh Windows validation run after changing the Pi HID profile or descriptor layout:
+Before each fresh Windows validation run after changing the gadget descriptor layout or USB identity:
 
-1. set the target Pi HID profile
+1. set the target Pi to the intended software revision
 2. reboot the Pi
 3. perform a Windows PnP admin reset
 4. only then start the host capture

--- a/docs/doc-consistency-review-playbook.md
+++ b/docs/doc-consistency-review-playbook.md
@@ -49,6 +49,7 @@ wrapper entrypoints:
 ```bash
 for s in \
   scripts/install.sh \
+  scripts/update.sh \
   scripts/uninstall.sh \
   scripts/debug.sh \
   scripts/smoke_test.sh \

--- a/docs/pi-cli-service-test-playbook.md
+++ b/docs/pi-cli-service-test-playbook.md
@@ -71,6 +71,7 @@ PI_HOST="${PI_HOST:-your-pi-host}"
 
 ssh -4 "$PI_HOST" '
   bash /opt/bluetooth_2_usb/scripts/install.sh --help >/dev/null
+  bash /opt/bluetooth_2_usb/scripts/update.sh --help >/dev/null
   bash /opt/bluetooth_2_usb/scripts/uninstall.sh --help >/dev/null
   bash /opt/bluetooth_2_usb/scripts/smoke_test.sh --help >/dev/null
   bash /opt/bluetooth_2_usb/scripts/debug.sh --help >/dev/null
@@ -122,14 +123,13 @@ Interpret the smoke result conservatively:
 
 ## Update validation
 
-The supported update model is Git plus reinstall:
+The supported update model is the managed update wrapper:
 
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
 
 ssh -4 "$PI_HOST" '
-  sudo -n git -C /opt/bluetooth_2_usb pull --ff-only
-  sudo -n /opt/bluetooth_2_usb/scripts/install.sh
+  sudo -n /opt/bluetooth_2_usb/scripts/update.sh
 '
 ```
 

--- a/docs/pi-host-relay-loopback-test-playbook.md
+++ b/docs/pi-host-relay-loopback-test-playbook.md
@@ -99,10 +99,10 @@ If automatic detection is ambiguous, pin the nodes explicitly:
 
 Keep this command running while you trigger the Pi-side injection.
 
-Before each fresh Windows validation run after changing the Pi HID profile or
-descriptor layout:
+Before each fresh Windows validation run after changing the gadget descriptor
+layout or USB identity:
 
-1. set the Pi HID profile
+1. set the Pi to the intended software revision
 2. reboot the Pi
 3. perform a Windows PnP admin reset
 4. only then start the host capture

--- a/docs/pi-manual-test-plan.md
+++ b/docs/pi-manual-test-plan.md
@@ -62,8 +62,7 @@ Purpose:
 Steps:
 
 ```bash
-sudo git -C /opt/bluetooth_2_usb pull --ff-only
-sudo /opt/bluetooth_2_usb/scripts/install.sh
+sudo /opt/bluetooth_2_usb/scripts/update.sh
 ```
 
 After reboot if boot settings changed:

--- a/docs/release-versioning-policy.md
+++ b/docs/release-versioning-policy.md
@@ -90,7 +90,7 @@ For an official release:
 Release notes should describe the current supported product surface only:
 
 - clone-based installation into `/opt/bluetooth_2_usb`
-- updates via `git -C /opt/bluetooth_2_usb pull --ff-only` followed by `/opt/bluetooth_2_usb/scripts/install.sh`
+- updates via `/opt/bluetooth_2_usb/scripts/update.sh`
 - diagnostics via `--validate-env`, `smoke_test.sh`, and `debug.sh`
 - persistent read-only operation only when a separate writable ext4 filesystem
   is configured for Bluetooth state

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -78,6 +78,7 @@ ok "Virtual environment updated at ${VENV_DIR}"
 
 install_service_unit
 write_default_env_file
+normalize_runtime_env_file
 if ! "${VENV_DIR}/bin/python" -m bluetooth_2_usb.service_config --check >/dev/null; then
   fail "Runtime config validation failed for ${B2U_ENV_FILE}. Expected the structured B2U_* format."
 fi

--- a/scripts/lib/install.sh
+++ b/scripts/lib/install.sh
@@ -38,7 +38,6 @@ write_default_env_file() {
 B2U_AUTO_DISCOVER=1
 B2U_GRAB_DEVICES=1
 B2U_INTERRUPT_SHORTCUT=CTRL+SHIFT+F12
-B2U_HID_PROFILE=boot_keyboard
 B2U_LOG_TO_FILE=0
 B2U_LOG_PATH=/var/log/bluetooth_2_usb/bluetooth_2_usb.log
 B2U_DEBUG=0
@@ -47,6 +46,22 @@ B2U_UDC_PATH=
 EOF
     chmod 0644 "$B2U_ENV_FILE"
   fi
+}
+
+normalize_runtime_env_file() {
+  local tmp=""
+
+  [[ -f "$B2U_ENV_FILE" ]] || return 0
+  if ! grep -Eq '^[[:space:]]*B2U_HID_PROFILE=' "$B2U_ENV_FILE"; then
+    return 0
+  fi
+
+  backup_file "$B2U_ENV_FILE"
+  tmp="${B2U_ENV_FILE}.tmp.$$"
+  awk '!/^[[:space:]]*B2U_HID_PROFILE=/' "$B2U_ENV_FILE" >"$tmp"
+  chmod 0644 "$tmp"
+  mv "$tmp" "$B2U_ENV_FILE"
+  warn "Removed legacy B2U_HID_PROFILE from ${B2U_ENV_FILE}; the runtime now exposes a single fixed USB HID layout."
 }
 
 install_cli_wrapper() {

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd -- "$(dirname "$0")" && pwd)"
+# shellcheck source=./lib/paths.sh
+source "${SCRIPT_DIR}/lib/paths.sh"
+# shellcheck source=./lib/common.sh
+source "${SCRIPT_DIR}/lib/common.sh"
+
+usage() {
+  cat <<EOF
+Usage: sudo ./scripts/update.sh
+
+Fast-forward the current managed checkout in ${B2U_INSTALL_DIR} and then
+reapply the managed install via ${B2U_INSTALL_DIR}/scripts/install.sh.
+EOF
+}
+
+case "${1:-}" in
+  "") ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    fail "Unknown option: $1"
+    ;;
+esac
+
+ensure_root
+prepare_log "update"
+require_commands git
+
+[[ "$B2U_REPO_ROOT" == "$B2U_INSTALL_DIR" ]] || fail "Clone this repository to ${B2U_INSTALL_DIR} and run ./scripts/update.sh from there."
+[[ -d "${B2U_INSTALL_DIR}/.git" ]] || fail "Expected a git checkout at ${B2U_INSTALL_DIR}."
+
+if [[ -n "$(git -C "${B2U_INSTALL_DIR}" status --porcelain --untracked-files=all)" ]]; then
+  fail "Refusing to update a dirty managed checkout at ${B2U_INSTALL_DIR}. Commit, stash, or remove local changes first."
+fi
+
+CURRENT_BRANCH="$(git -C "${B2U_INSTALL_DIR}" symbolic-ref --quiet --short HEAD)" \
+  || fail "Refusing to update a detached HEAD in ${B2U_INSTALL_DIR}."
+
+info "Fetching origin for branch ${CURRENT_BRANCH}"
+git -C "${B2U_INSTALL_DIR}" fetch --tags --prune origin
+
+info "Fast-forwarding ${CURRENT_BRANCH}"
+git -C "${B2U_INSTALL_DIR}" pull --ff-only origin "${CURRENT_BRANCH}"
+
+info "Reapplying managed install"
+"${B2U_INSTALL_DIR}/scripts/install.sh"

--- a/src/bluetooth_2_usb/args.py
+++ b/src/bluetooth_2_usb/args.py
@@ -136,12 +136,6 @@ class CustomArgumentParser(argparse.ArgumentParser):
             help="Output format for --list_devices and --validate-env. Default: text",
         )
         self.add_argument(
-            "--hid-profile",
-            choices=["boot_keyboard", "boot_mouse", "nonboot", "cherry_combo"],
-            default="boot_keyboard",
-            help="USB HID profile to expose. Default: boot_keyboard",
-        )
-        self.add_argument(
             "--help",
             "-h",
             action="help",
@@ -169,7 +163,6 @@ class Arguments:
         "_version",
         "_validate_env",
         "_output",
-        "_hid_profile",
     ]
 
     def __init__(
@@ -185,7 +178,6 @@ class Arguments:
         version: bool,
         validate_env: bool,
         output: str,
-        hid_profile: str,
     ) -> None:
         self._device_ids = device_ids
         self._auto_discover = auto_discover
@@ -198,7 +190,6 @@ class Arguments:
         self._version = version
         self._validate_env = validate_env
         self._output = output
-        self._hid_profile = hid_profile
 
     @property
     def device_ids(self) -> list[str] | None:
@@ -244,10 +235,6 @@ class Arguments:
     def output(self) -> str:
         return self._output
 
-    @property
-    def hid_profile(self) -> str:
-        return self._hid_profile
-
     def __str__(self) -> str:
         slot_values = [f"{slot[1:]}={getattr(self, slot)}" for slot in self.__slots__]
         return ", ".join(slot_values)
@@ -281,5 +268,4 @@ def parse_args(argv: list[str] | None = None) -> Arguments:
         version=args.version,
         validate_env=args.validate_env,
         output=args.output,
-        hid_profile=args.hid_profile,
     )

--- a/src/bluetooth_2_usb/cli.py
+++ b/src/bluetooth_2_usb/cli.py
@@ -219,7 +219,6 @@ async def async_run(args: Arguments) -> int:
     configure_logging(args)
 
     logger.info(f"Launching {get_versioned_name()}")
-    logger.info(f"HID profile: {args.hid_profile}")
 
     if not env_status.ok:
         if not env_status.configfs:
@@ -239,7 +238,7 @@ async def async_run(args: Arguments) -> int:
         ShortcutToggler,
     )
 
-    gadget_manager = GadgetManager(hid_profile=args.hid_profile)
+    gadget_manager = GadgetManager()
     gadget_manager.enable_gadgets()
 
     shortcut_toggler = None

--- a/src/bluetooth_2_usb/gadget_config.py
+++ b/src/bluetooth_2_usb/gadget_config.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import usb_hid
 
-from .hid_descriptors import GadgetHidDevice, GadgetProfile
+from .hid_layout import GadgetHidDevice, GadgetLayout
 
 GADGET_ROOT = Path(usb_hid.gadget_root)
 CONFIG_NAME = "c.1"
@@ -72,7 +72,7 @@ def _resolve_udc_name() -> str:
     return controllers[0]
 
 
-def rebuild_gadget(profile: GadgetProfile) -> tuple[GadgetHidDevice, ...]:
+def rebuild_gadget(layout: GadgetLayout) -> tuple[GadgetHidDevice, ...]:
     _teardown_existing_gadget()
 
     function_root = GADGET_ROOT / "functions"
@@ -84,7 +84,7 @@ def rebuild_gadget(profile: GadgetProfile) -> tuple[GadgetHidDevice, ...]:
     config_strings.mkdir(parents=True, exist_ok=True)
     gadget_strings.mkdir(parents=True, exist_ok=True)
 
-    _write_text(GADGET_ROOT / "bcdDevice", profile.bcd_device)
+    _write_text(GADGET_ROOT / "bcdDevice", layout.bcd_device)
     _write_text(GADGET_ROOT / "bcdUSB", DEFAULT_BCD_USB)
     _write_text(GADGET_ROOT / "bDeviceClass", "0x00")
     _write_text(GADGET_ROOT / "bDeviceProtocol", "0x00")
@@ -92,17 +92,17 @@ def rebuild_gadget(profile: GadgetProfile) -> tuple[GadgetHidDevice, ...]:
     _write_text(GADGET_ROOT / "bMaxPacketSize0", DEFAULT_BMAX_PACKET_SIZE0)
     _write_text(GADGET_ROOT / "idProduct", DEFAULT_PRODUCT_ID)
     _write_text(GADGET_ROOT / "idVendor", DEFAULT_VENDOR_ID)
-    _write_text(gadget_strings / "serialnumber", profile.serial_number)
+    _write_text(gadget_strings / "serialnumber", layout.serial_number)
     _write_text(gadget_strings / "manufacturer", DEFAULT_MANUFACTURER)
-    _write_text(gadget_strings / "product", profile.product_name)
+    _write_text(gadget_strings / "product", layout.product_name)
 
-    _write_text(config_strings / "configuration", profile.configuration_name)
-    _write_text(config_root / "MaxPower", str(profile.max_power))
-    _write_text(config_root / "bmAttributes", hex(profile.bm_attributes))
-    if profile.max_speed is not None:
-        _write_text(GADGET_ROOT / "max_speed", profile.max_speed)
+    _write_text(config_strings / "configuration", layout.configuration_name)
+    _write_text(config_root / "MaxPower", str(layout.max_power))
+    _write_text(config_root / "bmAttributes", hex(layout.bm_attributes))
+    if layout.max_speed is not None:
+        _write_text(GADGET_ROOT / "max_speed", layout.max_speed)
 
-    for device in profile.devices:
+    for device in layout.devices:
         device_root = function_root / f"hid.usb{device.function_index}"
         device_root.mkdir(parents=True, exist_ok=True)
         _write_text(device_root / "protocol", str(device.protocol))
@@ -113,10 +113,10 @@ def rebuild_gadget(profile: GadgetProfile) -> tuple[GadgetHidDevice, ...]:
 
     _write_text(GADGET_ROOT / "UDC", _resolve_udc_name())
 
-    usb_hid.devices = list(profile.devices)
-    for device in profile.devices:
+    usb_hid.devices = list(layout.devices)
+    for device in layout.devices:
         try:
             device.path = device.get_device_path()
         except FileNotFoundError:
             device.path = None
-    return profile.devices
+    return layout.devices

--- a/src/bluetooth_2_usb/hid_layout.py
+++ b/src/bluetooth_2_usb/hid_layout.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import usb_hid
 
-CHERRY_KEYBOARD_DESCRIPTOR = bytes.fromhex(
+DEFAULT_KEYBOARD_DESCRIPTOR = bytes.fromhex(
     "05010906a101050719e029e715002501750195088102950175088101"
     "95037501050819012903910295057501910195067508150026ff0005"
     "0719002aff008100c0"
@@ -86,8 +86,7 @@ class GadgetHidDevice(usb_hid.Device):
 
 
 @dataclass(frozen=True, slots=True)
-class GadgetProfile:
-    name: str
+class GadgetLayout:
     devices: tuple[GadgetHidDevice, ...]
     bcd_device: str
     product_name: str
@@ -98,15 +97,15 @@ class GadgetProfile:
     max_speed: str | None = None
 
 
-def _build_boot_keyboard_profile() -> GadgetProfile:
-    return GadgetProfile(
-        name="boot_keyboard",
+def build_default_layout() -> GadgetLayout:
+    return GadgetLayout(
         devices=(
             GadgetHidDevice.from_existing(
                 usb_hid.Device.BOOT_KEYBOARD,
                 function_index=0,
                 protocol=1,
                 subclass=1,
+                descriptor=DEFAULT_KEYBOARD_DESCRIPTOR,
             ),
             GadgetHidDevice.from_existing(
                 usb_hid.Device.MOUSE,
@@ -121,110 +120,10 @@ def _build_boot_keyboard_profile() -> GadgetProfile:
                 subclass=0,
             ),
         ),
-        bcd_device="0x0201",
-        product_name="USB Combo Device (boot keyboard)",
-        serial_number="213374badcafe-bk",
-    )
-
-
-def _build_boot_mouse_profile() -> GadgetProfile:
-    return GadgetProfile(
-        name="boot_mouse",
-        devices=(
-            GadgetHidDevice.from_existing(
-                usb_hid.Device.BOOT_MOUSE,
-                function_index=0,
-                protocol=2,
-                subclass=1,
-            ),
-            GadgetHidDevice.from_existing(
-                usb_hid.Device.KEYBOARD,
-                function_index=1,
-                protocol=0,
-                subclass=0,
-            ),
-            GadgetHidDevice.from_existing(
-                usb_hid.Device.CONSUMER_CONTROL,
-                function_index=2,
-                protocol=0,
-                subclass=0,
-            ),
-        ),
-        bcd_device="0x0202",
-        product_name="USB Combo Device (boot mouse)",
-        serial_number="213374badcafe-bm",
-    )
-
-
-def _build_nonboot_profile() -> GadgetProfile:
-    return GadgetProfile(
-        name="nonboot",
-        devices=(
-            GadgetHidDevice.from_existing(
-                usb_hid.Device.KEYBOARD,
-                function_index=0,
-                protocol=0,
-                subclass=0,
-            ),
-            GadgetHidDevice.from_existing(
-                usb_hid.Device.MOUSE,
-                function_index=1,
-                protocol=0,
-                subclass=0,
-            ),
-            GadgetHidDevice.from_existing(
-                usb_hid.Device.CONSUMER_CONTROL,
-                function_index=2,
-                protocol=0,
-                subclass=0,
-            ),
-        ),
-        bcd_device="0x0203",
-        product_name="USB Combo Device (nonboot)",
-        serial_number="213374badcafe-nb",
-    )
-
-
-def _build_cherry_combo_profile() -> GadgetProfile:
-    return GadgetProfile(
-        name="cherry_combo",
-        devices=(
-            GadgetHidDevice.from_existing(
-                usb_hid.Device.BOOT_KEYBOARD,
-                function_index=0,
-                protocol=1,
-                subclass=1,
-                descriptor=CHERRY_KEYBOARD_DESCRIPTOR,
-                name="cherry keyboard gadget",
-            ),
-            GadgetHidDevice.from_existing(
-                usb_hid.Device.MOUSE,
-                function_index=1,
-                protocol=0,
-                subclass=0,
-            ),
-            GadgetHidDevice.from_existing(
-                usb_hid.Device.CONSUMER_CONTROL,
-                function_index=2,
-                protocol=0,
-                subclass=0,
-            ),
-        ),
-        bcd_device="0x0204",
-        product_name="USB Combo Device (cherry combo)",
-        serial_number="213374badcafe-cc",
+        bcd_device="0x0205",
+        product_name="USB Combo Device",
+        serial_number="213374badcafe",
         max_power=100,
         bm_attributes=0xA0,
+        max_speed="high-speed",
     )
-
-
-def build_profile(name: str) -> GadgetProfile:
-    if name == "boot_keyboard":
-        return _build_boot_keyboard_profile()
-    if name == "boot_mouse":
-        return _build_boot_mouse_profile()
-    if name == "nonboot":
-        return _build_nonboot_profile()
-    if name == "cherry_combo":
-        return _build_cherry_combo_profile()
-    raise ValueError(f"Unsupported HID profile: {name}")

--- a/src/bluetooth_2_usb/relay.py
+++ b/src/bluetooth_2_usb/relay.py
@@ -50,7 +50,7 @@ from .evdev import (
     is_mouse_button,
 )
 from .gadget_config import rebuild_gadget
-from .hid_descriptors import build_profile
+from .hid_layout import build_default_layout
 from .inventory import (
     DEFAULT_SKIP_NAME_PREFIXES,
     DeviceEnumerationError,
@@ -107,7 +107,7 @@ class GadgetManager:
     HIDG_NODE_READY_TIMEOUT_SEC = 2.0
     HIDG_NODE_POLL_INTERVAL_SEC = 0.05
 
-    def __init__(self, hid_profile: str = "boot_keyboard") -> None:
+    def __init__(self) -> None:
         """
         Initialize without enabling devices. Call enable_gadgets() to enable them.
         """
@@ -117,35 +117,9 @@ class GadgetManager:
             "consumer": None,
         }
         self._enabled = False
-        self._hid_profile = hid_profile
 
     def _requested_devices(self):
-        return list(build_profile(self._hid_profile).devices)
-
-    def _usb_identity_overrides(self) -> dict[str, str]:
-        profile_code = {
-            "boot_keyboard": "0x0201",
-            "boot_mouse": "0x0202",
-            "nonboot": "0x0203",
-            "cherry_combo": "0x0204",
-        }[self._hid_profile]
-        serial_suffix = {
-            "boot_keyboard": "bk",
-            "boot_mouse": "bm",
-            "nonboot": "nb",
-            "cherry_combo": "cc",
-        }[self._hid_profile]
-        product_name = {
-            "boot_keyboard": "USB Combo Device (boot keyboard)",
-            "boot_mouse": "USB Combo Device (boot mouse)",
-            "nonboot": "USB Combo Device (nonboot)",
-            "cherry_combo": "USB Combo Device (cherry combo)",
-        }[self._hid_profile]
-        return {
-            "B2U_USB_BCD_DEVICE": profile_code,
-            "B2U_USB_PRODUCT": product_name,
-            "B2U_USB_SERIALNUMBER": f"213374badcafe-{serial_suffix}",
-        }
+        return list(build_default_layout().devices)
 
     def _expected_hidg_paths(self) -> tuple[Path, ...]:
         return tuple(
@@ -223,7 +197,7 @@ class GadgetManager:
         to the new Keyboard, Mouse, and ConsumerControl gadgets.
         """
         self._prune_stale_hidg_nodes(remove_character_devices=True)
-        enabled_devices = list(rebuild_gadget(build_profile(self._hid_profile)))
+        enabled_devices = list(rebuild_gadget(build_default_layout()))
         try:
             self._validate_hidg_nodes()
         except RuntimeError:
@@ -231,7 +205,7 @@ class GadgetManager:
                 "Retrying HID gadget initialization after stale node validation failure"
             )
             self._prune_stale_hidg_nodes(remove_character_devices=True)
-            enabled_devices = list(rebuild_gadget(build_profile(self._hid_profile)))
+            enabled_devices = list(rebuild_gadget(build_default_layout()))
             self._validate_hidg_nodes()
 
         from adafruit_hid.consumer_control import ConsumerControl
@@ -243,11 +217,7 @@ class GadgetManager:
         self._gadgets["consumer"] = ConsumerControl(enabled_devices)
         self._enabled = True
 
-        _logger.debug(
-            "USB HID gadgets re-initialized for profile %s: %s",
-            self._hid_profile,
-            enabled_devices,
-        )
+        _logger.debug("USB HID gadgets initialized: %s", enabled_devices)
 
     def get_keyboard(self) -> Keyboard | None:
         """

--- a/src/bluetooth_2_usb/service_config.py
+++ b/src/bluetooth_2_usb/service_config.py
@@ -20,7 +20,6 @@ class ServiceConfig:
     auto_discover: bool = True
     grab_devices: bool = True
     interrupt_shortcut: str = "CTRL+SHIFT+F12"
-    hid_profile: str = "boot_keyboard"
     log_to_file: bool = False
     log_path: str = DEFAULT_LOG_PATH
     debug: bool = False
@@ -70,7 +69,6 @@ def load_service_config(env_file: Path = DEFAULT_ENV_FILE) -> ServiceConfig:
         "B2U_AUTO_DISCOVER",
         "B2U_GRAB_DEVICES",
         "B2U_INTERRUPT_SHORTCUT",
-        "B2U_HID_PROFILE",
         "B2U_LOG_TO_FILE",
         "B2U_LOG_PATH",
         "B2U_DEBUG",
@@ -104,17 +102,6 @@ def load_service_config(env_file: Path = DEFAULT_ENV_FILE) -> ServiceConfig:
             config.grab_devices = _parse_bool(value, key)
         elif key == "B2U_INTERRUPT_SHORTCUT":
             config.interrupt_shortcut = value
-        elif key == "B2U_HID_PROFILE":
-            if value not in {
-                "boot_keyboard",
-                "boot_mouse",
-                "nonboot",
-                "cherry_combo",
-            }:
-                raise ServiceConfigError(
-                    f"{env_file}:{line_number}: invalid B2U_HID_PROFILE {value!r}"
-                )
-            config.hid_profile = value
         elif key == "B2U_LOG_TO_FILE":
             config.log_to_file = _parse_bool(value, key)
         elif key == "B2U_LOG_PATH":
@@ -145,7 +132,6 @@ def build_cli_argv(config: ServiceConfig, *, append_debug: bool = False) -> list
         argv.extend(["--log_path", config.log_path])
     if config.debug or append_debug:
         argv.append("--debug")
-    argv.extend(["--hid-profile", config.hid_profile])
     return argv
 
 

--- a/src/bluetooth_2_usb/test_harness_capture.py
+++ b/src/bluetooth_2_usb/test_harness_capture.py
@@ -381,14 +381,6 @@ def _role_for_device(info: HidDeviceInfo) -> str | None:
     if info.usage_page == CONSUMER_USAGE_PAGE and info.usage == CONSUMER_USAGE:
         return "consumer"
     if info.vendor_id == GADGET_VENDOR_ID and info.product_id == GADGET_PRODUCT_ID:
-        product_name = info.name.lower()
-        if "boot mouse" in product_name:
-            if info.interface_number == 0:
-                return "mouse"
-            if info.interface_number == 1:
-                return "keyboard"
-            if info.interface_number == 2:
-                return "consumer"
         if info.interface_number == 0:
             return "keyboard"
         if info.interface_number == 1:

--- a/src/bluetooth_2_usb/test_harness_common.py
+++ b/src/bluetooth_2_usb/test_harness_common.py
@@ -318,7 +318,7 @@ def _append_text_steps(steps: list[ExpectedEvent], text: str) -> None:
 _TEXT_BURST_STEPS: list[ExpectedEvent] = []
 _append_text_steps(
     _TEXT_BURST_STEPS,
-    "boot_keyboard BOOT_KEYBOARD boot_keyboard BOOT_KEYBOARD",
+    "KEYBOARD KEYBOARD keyboard KEYBOARD",
 )
 TEXT_BURST_STEPS = tuple(_TEXT_BURST_STEPS)
 

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -23,22 +23,8 @@ class ParseArgsTest(unittest.TestCase):
             ["KEY_LEFTCTRL", "KEY_LEFTSHIFT", "KEY_F12"],
         )
 
-    def test_boot_keyboard_profile_is_default(self) -> None:
+    def test_version_flag_parses_without_hid_profile(self) -> None:
         args = parse_args(["--version"])
 
-        self.assertEqual(args.hid_profile, "boot_keyboard")
-
-    def test_boot_mouse_profile_is_accepted(self) -> None:
-        args = parse_args(["--hid-profile", "boot_mouse"])
-
-        self.assertEqual(args.hid_profile, "boot_mouse")
-
-    def test_nonboot_profile_is_accepted(self) -> None:
-        args = parse_args(["--hid-profile", "nonboot"])
-
-        self.assertEqual(args.hid_profile, "nonboot")
-
-    def test_cherry_combo_profile_is_accepted(self) -> None:
-        args = parse_args(["--hid-profile", "cherry_combo"])
-
-        self.assertEqual(args.hid_profile, "cherry_combo")
+        self.assertTrue(args.version)
+        self.assertFalse(hasattr(args, "hid_profile"))

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -11,10 +11,10 @@ from unittest.mock import patch
 import usb_hid
 
 from bluetooth_2_usb.gadget_config import rebuild_gadget
-from bluetooth_2_usb.hid_descriptors import (
-    CHERRY_KEYBOARD_DESCRIPTOR,
+from bluetooth_2_usb.hid_layout import (
+    DEFAULT_KEYBOARD_DESCRIPTOR,
     GadgetHidDevice,
-    build_profile,
+    build_default_layout,
 )
 from bluetooth_2_usb.relay import (
     DeviceRelay,
@@ -133,7 +133,7 @@ class _FakeGrabInputDevice:
         self.close_calls += 1
 
 
-class _QueueTestKeyEvent:
+class _TestKeyEvent:
     key_down = 1
     key_hold = 2
     key_up = 0
@@ -143,10 +143,10 @@ class _QueueTestKeyEvent:
         self.keystate = keystate
 
 
-class _QueueInputDevice:
+class _TestInputDevice:
     def __init__(self, events, *, removal_errno: int | None = None) -> None:
         self.path = "/dev/input/event-test"
-        self.name = "queue-test-device"
+        self.name = "test-input-device"
         self._events = list(events)
         self._removal_errno = removal_errno
 
@@ -223,54 +223,38 @@ class RuntimeMonitorTest(unittest.TestCase):
         self.assertEqual(relay_controller.removed, ["/dev/input/event7"])
 
 
-class GadgetManagerProfileTest(unittest.TestCase):
-    def test_boot_mouse_profile_uses_boot_mouse_then_keyboard(self) -> None:
+class GadgetManagerLayoutTest(unittest.TestCase):
+    def test_requested_devices_use_default_layout(self) -> None:
         with patch(
-            "bluetooth_2_usb.relay.build_profile",
-            return_value=SimpleNamespace(
-                devices=("boot-mouse", "keyboard", "consumer")
-            ),
-        ):
-            devices = GadgetManager("boot_mouse")._requested_devices()
-
-        self.assertEqual(devices, ["boot-mouse", "keyboard", "consumer"])
-
-    def test_nonboot_profile_uses_nonboot_devices(self) -> None:
-        with patch(
-            "bluetooth_2_usb.relay.build_profile",
+            "bluetooth_2_usb.relay.build_default_layout",
             return_value=SimpleNamespace(devices=("keyboard", "mouse", "consumer")),
         ):
-            devices = GadgetManager("nonboot")._requested_devices()
+            devices = GadgetManager()._requested_devices()
 
         self.assertEqual(devices, ["keyboard", "mouse", "consumer"])
 
-    def test_boot_keyboard_profile_uses_boot_keyboard_then_nonboot_mouse(self) -> None:
-        with patch(
-            "bluetooth_2_usb.relay.build_profile",
-            return_value=SimpleNamespace(
-                devices=("boot-keyboard", "mouse", "consumer")
-            ),
-        ):
-            devices = GadgetManager("boot_keyboard")._requested_devices()
-
-        self.assertEqual(devices, ["boot-keyboard", "mouse", "consumer"])
-
-    def test_cherry_combo_profile_uses_cherry_keyboard_then_existing_mouse_and_consumer(
+    def test_default_layout_uses_strict_keyboard_and_existing_mouse_consumer(
         self,
     ) -> None:
-        profile = build_profile("cherry_combo")
+        layout = build_default_layout()
 
-        self.assertEqual(len(profile.devices), 3)
+        self.assertEqual(len(layout.devices), 3)
         self.assertEqual(
-            bytes(profile.devices[0].descriptor), CHERRY_KEYBOARD_DESCRIPTOR
+            bytes(layout.devices[0].descriptor), DEFAULT_KEYBOARD_DESCRIPTOR
         )
         self.assertEqual(
-            bytes(profile.devices[1].descriptor), bytes(usb_hid.Device.MOUSE.descriptor)
+            bytes(layout.devices[1].descriptor), bytes(usb_hid.Device.MOUSE.descriptor)
         )
         self.assertEqual(
-            bytes(profile.devices[2].descriptor),
+            bytes(layout.devices[2].descriptor),
             bytes(usb_hid.Device.CONSUMER_CONTROL.descriptor),
         )
+        self.assertEqual(layout.bcd_device, "0x0205")
+        self.assertEqual(layout.product_name, "USB Combo Device")
+        self.assertEqual(layout.serial_number, "213374badcafe")
+        self.assertEqual(layout.max_power, 100)
+        self.assertEqual(layout.bm_attributes, 0xA0)
+        self.assertEqual(layout.max_speed, "high-speed")
 
     def test_gadget_hid_device_passes_protocol_and_subclass_when_required(self) -> None:
         init_calls = []
@@ -295,38 +279,8 @@ class GadgetManagerProfileTest(unittest.TestCase):
         self.assertEqual(init_calls[0]["protocol"], 1)
         self.assertEqual(init_calls[0]["subclass"], 1)
 
-    def test_boot_keyboard_profile_sets_distinct_usb_identity(self) -> None:
-        identity = GadgetManager("boot_keyboard")._usb_identity_overrides()
-
-        self.assertEqual(identity["B2U_USB_BCD_DEVICE"], "0x0201")
-        self.assertEqual(identity["B2U_USB_SERIALNUMBER"], "213374badcafe-bk")
-        self.assertEqual(
-            identity["B2U_USB_PRODUCT"], "USB Combo Device (boot keyboard)"
-        )
-
-    def test_boot_mouse_profile_sets_distinct_usb_identity(self) -> None:
-        identity = GadgetManager("boot_mouse")._usb_identity_overrides()
-
-        self.assertEqual(identity["B2U_USB_BCD_DEVICE"], "0x0202")
-        self.assertEqual(identity["B2U_USB_SERIALNUMBER"], "213374badcafe-bm")
-        self.assertEqual(identity["B2U_USB_PRODUCT"], "USB Combo Device (boot mouse)")
-
-    def test_nonboot_profile_sets_distinct_usb_identity(self) -> None:
-        identity = GadgetManager("nonboot")._usb_identity_overrides()
-
-        self.assertEqual(identity["B2U_USB_BCD_DEVICE"], "0x0203")
-        self.assertEqual(identity["B2U_USB_SERIALNUMBER"], "213374badcafe-nb")
-        self.assertEqual(identity["B2U_USB_PRODUCT"], "USB Combo Device (nonboot)")
-
-    def test_cherry_combo_profile_sets_distinct_usb_identity(self) -> None:
-        identity = GadgetManager("cherry_combo")._usb_identity_overrides()
-
-        self.assertEqual(identity["B2U_USB_BCD_DEVICE"], "0x0204")
-        self.assertEqual(identity["B2U_USB_SERIALNUMBER"], "213374badcafe-cc")
-        self.assertEqual(identity["B2U_USB_PRODUCT"], "USB Combo Device (cherry combo)")
-
     def test_prune_stale_hidg_nodes_removes_regular_files(self) -> None:
-        manager = GadgetManager("boot_mouse")
+        manager = GadgetManager()
         with tempfile.TemporaryDirectory() as tmp:
             stale = Path(tmp) / "hidg1"
             stale.write_text("stale", encoding="utf-8")
@@ -335,7 +289,7 @@ class GadgetManagerProfileTest(unittest.TestCase):
             self.assertFalse(stale.exists())
 
     def test_validate_hidg_nodes_rejects_regular_files(self) -> None:
-        manager = GadgetManager("boot_mouse")
+        manager = GadgetManager()
         with tempfile.TemporaryDirectory() as tmp:
             bad = Path(tmp) / "hidg1"
             bad.write_text("not-a-device", encoding="utf-8")
@@ -347,7 +301,7 @@ class GadgetManagerProfileTest(unittest.TestCase):
                     )
 
     def test_validate_hidg_nodes_waits_for_delayed_nodes(self) -> None:
-        manager = GadgetManager("boot_mouse")
+        manager = GadgetManager()
 
         with patch.object(
             manager,
@@ -363,7 +317,7 @@ class GadgetManagerProfileTest(unittest.TestCase):
     def test_collect_invalid_hidg_nodes_rejects_unopenable_character_devices(
         self,
     ) -> None:
-        manager = GadgetManager("boot_mouse")
+        manager = GadgetManager()
         path = Path("/dev/hidg0")
         stats = SimpleNamespace(st_mode=stat.S_IFCHR | 0o600, st_rdev=0)
 
@@ -383,8 +337,8 @@ class GadgetManagerProfileTest(unittest.TestCase):
 
         self.assertEqual(invalid_paths, [f"{path} (No such device)"])
 
-    def test_rebuild_gadget_writes_cherry_combo_power_and_identity(self) -> None:
-        profile = build_profile("cherry_combo")
+    def test_rebuild_gadget_writes_default_power_and_identity(self) -> None:
+        layout = build_default_layout()
         with tempfile.TemporaryDirectory() as tmpdir:
             gadget_root = Path(tmpdir) / "usb_gadget" / "adafruit-blinka"
             with patch("bluetooth_2_usb.gadget_config.GADGET_ROOT", gadget_root):
@@ -393,23 +347,23 @@ class GadgetManagerProfileTest(unittest.TestCase):
                     return_value="dummy.udc",
                 ):
                     with patch.object(usb_hid, "gadget_root", str(gadget_root)):
-                        rebuild_gadget(profile)
+                        rebuild_gadget(layout)
 
             self.assertEqual(
                 (gadget_root / "strings/0x409/product")
                 .read_text(encoding="utf-8")
                 .strip(),
-                "USB Combo Device (cherry combo)",
+                "USB Combo Device",
             )
             self.assertEqual(
                 (gadget_root / "strings/0x409/serialnumber")
                 .read_text(encoding="utf-8")
                 .strip(),
-                "213374badcafe-cc",
+                "213374badcafe",
             )
             self.assertEqual(
                 (gadget_root / "bcdDevice").read_text(encoding="utf-8").strip(),
-                "0x0204",
+                "0x0205",
             )
             self.assertEqual(
                 (gadget_root / "configs/c.1/MaxPower")
@@ -429,6 +383,10 @@ class GadgetManagerProfileTest(unittest.TestCase):
                 .strip(),
                 "Config 1: HID relay",
             )
+            self.assertEqual(
+                (gadget_root / "max_speed").read_text(encoding="utf-8").strip(),
+                "high-speed",
+            )
 
 
 class DeviceRelayTest(unittest.IsolatedAsyncioTestCase):
@@ -436,12 +394,12 @@ class DeviceRelayTest(unittest.IsolatedAsyncioTestCase):
         relaying_active = asyncio.Event()
         relaying_active.set()
         seen: list[tuple[int, int]] = []
-        input_device = _QueueInputDevice(
+        input_device = _TestInputDevice(
             [
-                _QueueTestKeyEvent(183, _QueueTestKeyEvent.key_down),
-                _QueueTestKeyEvent(183, _QueueTestKeyEvent.key_up),
-                _QueueTestKeyEvent(184, _QueueTestKeyEvent.key_down),
-                _QueueTestKeyEvent(184, _QueueTestKeyEvent.key_up),
+                _TestKeyEvent(183, _TestKeyEvent.key_down),
+                _TestKeyEvent(183, _TestKeyEvent.key_up),
+                _TestKeyEvent(184, _TestKeyEvent.key_down),
+                _TestKeyEvent(184, _TestKeyEvent.key_up),
             ]
         )
         relay = DeviceRelay(
@@ -454,7 +412,7 @@ class DeviceRelayTest(unittest.IsolatedAsyncioTestCase):
             seen.append((event.scancode, event.keystate))
             await asyncio.sleep(0.001)
 
-        with patch("bluetooth_2_usb.relay.KeyEvent", _QueueTestKeyEvent):
+        with patch("bluetooth_2_usb.relay.KeyEvent", _TestKeyEvent):
             with patch(
                 "bluetooth_2_usb.relay.categorize", side_effect=lambda event: event
             ):
@@ -489,10 +447,10 @@ class DeviceRelayTest(unittest.IsolatedAsyncioTestCase):
         relaying_active = asyncio.Event()
         relaying_active.set()
         seen: list[tuple[int, int]] = []
-        input_device = _QueueInputDevice(
+        input_device = _TestInputDevice(
             [
-                _QueueTestKeyEvent(183, _QueueTestKeyEvent.key_down),
-                _QueueTestKeyEvent(183, _QueueTestKeyEvent.key_up),
+                _TestKeyEvent(183, _TestKeyEvent.key_down),
+                _TestKeyEvent(183, _TestKeyEvent.key_up),
             ],
             removal_errno=errno.ENODEV,
         )
@@ -505,7 +463,7 @@ class DeviceRelayTest(unittest.IsolatedAsyncioTestCase):
         async def _record_process(event) -> None:
             seen.append((event.scancode, event.keystate))
 
-        with patch("bluetooth_2_usb.relay.KeyEvent", _QueueTestKeyEvent):
+        with patch("bluetooth_2_usb.relay.KeyEvent", _TestKeyEvent):
             with patch(
                 "bluetooth_2_usb.relay.categorize", side_effect=lambda event: event
             ):
@@ -517,21 +475,19 @@ class DeviceRelayTest(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(seen, [(183, 1), (183, 0)])
 
-    async def test_broken_pipe_clears_relaying_active_without_queue_helpers(
+    async def test_broken_pipe_clears_relaying_active_when_hid_write_fails(
         self,
     ) -> None:
         relaying_active = asyncio.Event()
         relaying_active.set()
-        input_device = _QueueInputDevice(
-            [_QueueTestKeyEvent(183, _QueueTestKeyEvent.key_down)]
-        )
+        input_device = _TestInputDevice([_TestKeyEvent(183, _TestKeyEvent.key_down)])
         relay = DeviceRelay(
             input_device,
             _FakeGadgetManager(),
             relaying_active=relaying_active,
         )
 
-        with patch("bluetooth_2_usb.relay.KeyEvent", _QueueTestKeyEvent):
+        with patch("bluetooth_2_usb.relay.KeyEvent", _TestKeyEvent):
             with patch(
                 "bluetooth_2_usb.relay.categorize", side_effect=lambda event: event
             ):

--- a/tests/test_service_config.py
+++ b/tests/test_service_config.py
@@ -20,7 +20,6 @@ class ServiceConfigTest(unittest.TestCase):
                         "B2U_AUTO_DISCOVER=0",
                         "B2U_GRAB_DEVICES=1",
                         "B2U_INTERRUPT_SHORTCUT=CTRL+SHIFT+F12",
-                        "B2U_HID_PROFILE=nonboot",
                         "B2U_LOG_TO_FILE=1",
                         "B2U_LOG_PATH='/tmp/custom log.txt'",
                         "B2U_DEBUG=1",
@@ -36,7 +35,6 @@ class ServiceConfigTest(unittest.TestCase):
 
         self.assertFalse(config.auto_discover)
         self.assertTrue(config.grab_devices)
-        self.assertEqual(config.hid_profile, "nonboot")
         self.assertTrue(config.log_to_file)
         self.assertEqual(config.log_path, "/tmp/custom log.txt")
         self.assertTrue(config.debug)
@@ -60,7 +58,6 @@ class ServiceConfigTest(unittest.TestCase):
                         "B2U_AUTO_DISCOVER=1",
                         "B2U_GRAB_DEVICES=1",
                         "B2U_INTERRUPT_SHORTCUT=CTRL+SHIFT+F12",
-                        "B2U_HID_PROFILE=boot_mouse",
                         "B2U_LOG_TO_FILE=1",
                         "B2U_LOG_PATH='/tmp/debug log.txt'",
                         "B2U_DEBUG=0",
@@ -84,7 +81,7 @@ class ServiceConfigTest(unittest.TestCase):
         self.assertIn("/tmp/debug log.txt", argv)
         self.assertIn("'MX Keys'", command)
 
-    def test_accepts_boot_keyboard_hid_profile(self) -> None:
+    def test_legacy_hid_profile_key_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             env_file = Path(tmpdir) / "bluetooth_2_usb"
             env_file.write_text(
@@ -92,30 +89,14 @@ class ServiceConfigTest(unittest.TestCase):
                 encoding="utf-8",
             )
 
-            config = load_service_config(env_file)
-            argv = build_cli_argv(config)
+            with self.assertRaises(ServiceConfigError):
+                load_service_config(env_file)
 
-        self.assertEqual(config.hid_profile, "boot_keyboard")
-        self.assertIn("boot_keyboard", argv)
-
-    def test_defaults_to_boot_keyboard_profile(self) -> None:
+    def test_defaults_do_not_emit_removed_hid_profile_flag(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             env_file = Path(tmpdir) / "missing"
 
             config = load_service_config(env_file)
-
-        self.assertEqual(config.hid_profile, "boot_keyboard")
-
-    def test_accepts_cherry_combo_hid_profile(self) -> None:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            env_file = Path(tmpdir) / "bluetooth_2_usb"
-            env_file.write_text(
-                "B2U_HID_PROFILE=cherry_combo\n",
-                encoding="utf-8",
-            )
-
-            config = load_service_config(env_file)
             argv = build_cli_argv(config)
 
-        self.assertEqual(config.hid_profile, "cherry_combo")
-        self.assertIn("cherry_combo", argv)
+        self.assertNotIn("--hid-profile", argv)

--- a/tests/test_test_harness.py
+++ b/tests/test_test_harness.py
@@ -229,15 +229,15 @@ class GadgetNodeDiscoveryTest(unittest.TestCase):
             [info.node for info in candidates.consumer_nodes], ["1-2.1.2:1.2"]
         )
 
-    def test_discovery_maps_boot_mouse_linux_gadget_interfaces_by_product_name(
+    def test_discovery_maps_default_linux_gadget_interfaces_by_interface_number(
         self,
     ) -> None:
         hid_module = _FakeHidModule(
             [
                 _hid_entry(
                     "1-2.1.2:1.0",
-                    device_name="USB Combo Device (boot mouse)",
-                    serial="213374badcafe-bm",
+                    device_name="USB Combo Device",
+                    serial="213374badcafe",
                     vendor_id=0x1D6B,
                     product_id=0x0104,
                     interface_number=0,
@@ -246,8 +246,8 @@ class GadgetNodeDiscoveryTest(unittest.TestCase):
                 ),
                 _hid_entry(
                     "1-2.1.2:1.1",
-                    device_name="USB Combo Device (boot mouse)",
-                    serial="213374badcafe-bm",
+                    device_name="USB Combo Device",
+                    serial="213374badcafe",
                     vendor_id=0x1D6B,
                     product_id=0x0104,
                     interface_number=1,
@@ -256,8 +256,8 @@ class GadgetNodeDiscoveryTest(unittest.TestCase):
                 ),
                 _hid_entry(
                     "1-2.1.2:1.2",
-                    device_name="USB Combo Device (boot mouse)",
-                    serial="213374badcafe-bm",
+                    device_name="USB Combo Device",
+                    serial="213374badcafe",
                     vendor_id=0x1D6B,
                     product_id=0x0104,
                     interface_number=2,
@@ -270,24 +270,24 @@ class GadgetNodeDiscoveryTest(unittest.TestCase):
         candidates = discover_gadget_node_candidates(hid_module=hid_module)
 
         self.assertEqual(
-            [info.node for info in candidates.keyboard_nodes], ["1-2.1.2:1.1"]
+            [info.node for info in candidates.keyboard_nodes], ["1-2.1.2:1.0"]
         )
         self.assertEqual(
-            [info.node for info in candidates.mouse_nodes], ["1-2.1.2:1.0"]
+            [info.node for info in candidates.mouse_nodes], ["1-2.1.2:1.1"]
         )
         self.assertEqual(
             [info.node for info in candidates.consumer_nodes], ["1-2.1.2:1.2"]
         )
 
-    def test_explicit_override_accepts_boot_mouse_linux_gadget_interfaces(
+    def test_explicit_override_accepts_default_linux_gadget_interfaces(
         self,
     ) -> None:
         hid_module = _FakeHidModule(
             [
                 _hid_entry(
                     "1-2.1.2:1.0",
-                    device_name="USB Combo Device (boot mouse)",
-                    serial="213374badcafe-bm",
+                    device_name="USB Combo Device",
+                    serial="213374badcafe",
                     vendor_id=0x1D6B,
                     product_id=0x0104,
                     interface_number=0,
@@ -296,8 +296,8 @@ class GadgetNodeDiscoveryTest(unittest.TestCase):
                 ),
                 _hid_entry(
                     "1-2.1.2:1.1",
-                    device_name="USB Combo Device (boot mouse)",
-                    serial="213374badcafe-bm",
+                    device_name="USB Combo Device",
+                    serial="213374badcafe",
                     vendor_id=0x1D6B,
                     product_id=0x0104,
                     interface_number=1,
@@ -306,8 +306,8 @@ class GadgetNodeDiscoveryTest(unittest.TestCase):
                 ),
                 _hid_entry(
                     "1-2.1.2:1.2",
-                    device_name="USB Combo Device (boot mouse)",
-                    serial="213374badcafe-bm",
+                    device_name="USB Combo Device",
+                    serial="213374badcafe",
                     vendor_id=0x1D6B,
                     product_id=0x0104,
                     interface_number=2,
@@ -330,7 +330,7 @@ class GadgetNodeDiscoveryTest(unittest.TestCase):
 
 
 class KeyboardSequenceMatcherTest(unittest.TestCase):
-    def test_keyboard_matcher_accepts_boot_keyboard_reports(self) -> None:
+    def test_keyboard_matcher_accepts_eight_byte_keyboard_reports(self) -> None:
         matcher = KeyboardSequenceMatcher(SCENARIOS["keyboard"].keyboard_steps)
 
         reports = (
@@ -529,7 +529,7 @@ class WindowsRawInputHelpersTest(unittest.TestCase):
             )
         )
 
-    def test_keyboard_event_to_report_builds_boot_keyboard_reports(self) -> None:
+    def test_keyboard_event_to_report_builds_eight_byte_keyboard_reports(self) -> None:
         self.assertEqual(
             _keyboard_event_to_report(0x7C, is_key_up=False),
             bytes([0x00, 0x00, 104, 0, 0, 0, 0, 0]),


### PR DESCRIPTION
## Summary
- remove the old HID profile surface and keep a single fixed strict-host USB HID layout
- rename the descriptor module to `hid_layout.py`, keep the working keyboard/mouse/consumer ordering, and preserve the `high-speed`/`MaxPower=100`/`bmAttributes=0xa0` gadget settings
- add `scripts/update.sh`, normalize legacy runtime env files during install, and update docs/tests to match the new single-layout model
- document the host sleep wake limitation in the README and link Raspberry Pi Linux issue #3977

## Why
The project no longer needs multiple host HID variants. The current fixed layout is the only supported path, it resolves the ThinkPad pre-OS boot-loop case, and removing the profile layer reduces code and documentation drift. The update wrapper also gives the managed install a single supported update entrypoint.

## Validation
- `black --check src tests`
- `ruff check src tests`
- `python -m compileall src tests`
- `python -m unittest discover -s tests -v`
- `python -m bluetooth_2_usb --help`
- `python -m bluetooth_2_usb --version`
- `python -m bluetooth_2_usb --validate-env`
- `bash -n scripts/*.sh scripts/lib/*.sh`
- `shfmt -d -i 2 -ci -bn scripts/*.sh scripts/lib/*.sh`
- `shellcheck -x scripts/*.sh scripts/lib/*.sh`
- `python -m build`
- `pi4b`: `sudo /opt/bluetooth_2_usb/scripts/install.sh`
- `pi4b`: `sudo /opt/bluetooth_2_usb/scripts/update.sh --help`
- `pi4b`: `sudo /opt/bluetooth_2_usb/scripts/smoke_test.sh --verbose`

## Hardware notes
- user validated that the ThinkPad cold-boot path still works with this single-layout configuration
- wake from host sleep remains documented as a known platform limitation rather than a userspace fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Added streamlined update script (`scripts/update.sh`) for managed deployments

* **Changes**
  - Removed configurable HID profile option; system now uses a single fixed USB gadget layout (keyboard, mouse, consumer control)
  - Simplified update workflow to single script invocation instead of manual git operations
  - Automatic cleanup of legacy HID profile settings from environment files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->