### PR TITLE
Improve managed updates and operational docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,8 @@ Preserve these unless the task explicitly redesigns them:
   - run `sudo /opt/bluetooth_2_usb/scripts/install.sh`
 - Supported update flow:
   - `sudo /opt/bluetooth_2_usb/scripts/update.sh`
+  - when the checkout is already current, `update.sh` must exit successfully
+    without rebuilding the managed venv or restarting the service
 - Shell scripts should fail loudly on ambiguous or unsafe input.
 - Boot changes should be conservative and leave timestamped backups, but scripts
   should not attempt automatic rollback restores.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,9 @@ The operational update flow is:
 sudo /opt/bluetooth_2_usb/scripts/update.sh
 ```
 
+If the checkout is already current, `update.sh` should complete successfully
+without triggering a reinstall.
+
 Keep code and docs aligned with that model.
 
 ## Quality expectations

--- a/README.md
+++ b/README.md
@@ -147,24 +147,24 @@ Default content:
 
 ```bash
 B2U_AUTO_DISCOVER=1
+B2U_DEVICE_IDS=
 B2U_GRAB_DEVICES=1
 B2U_INTERRUPT_SHORTCUT=CTRL+SHIFT+F12
 B2U_LOG_TO_FILE=0
 B2U_LOG_PATH=/var/log/bluetooth_2_usb/bluetooth_2_usb.log
 B2U_DEBUG=0
-B2U_DEVICE_IDS=
 B2U_UDC_PATH=
 ```
 
 Meaning:
 
 - `B2U_AUTO_DISCOVER=1` relays all suitable readable input devices except known excluded platform devices.
+- `B2U_DEVICE_IDS` is the precise alternative when you want to pin the runtime to specific event paths, Bluetooth MACs, or case-insensitive device-name fragments.
 - `B2U_GRAB_DEVICES=1` grabs the selected input devices so the Pi stops consuming their local events.
 - `B2U_INTERRUPT_SHORTCUT=CTRL+SHIFT+F12` defines a plus-separated key chord that toggles relaying on and off at runtime.
 - `B2U_LOG_TO_FILE=0` disables file logging by default.
 - `B2U_LOG_PATH=...` controls the file path used when file logging is enabled.
 - `B2U_DEBUG=0` keeps normal log verbosity.
-- `B2U_DEVICE_IDS` is the precise alternative when you want to pin the runtime to specific event paths, Bluetooth MACs, or case-insensitive device-name fragments.
 - `B2U_UDC_PATH` is optional and only needed if you must pin UDC detection on a system with multiple gadget-capable controllers.
 
 After editing that file, restart the service:
@@ -182,8 +182,8 @@ Use these runtime flags when running the CLI manually.
 
 | Argument | Explanation / Example |
 | --- | --- |
-| `--device_ids DEVICE_IDS, -i DEVICE_IDS` | Comma-separated identifiers for the devices to relay. Each identifier may be an event path, a Bluetooth MAC address, or a case-insensitive name fragment. The matcher accepts all three kinds in the same comma-separated list. Default: none. Examples: `-i /dev/input/event4`, `-i A1:B2:C3:D4:E5:F6`, `-i logi`, `-i '/dev/input/event4,A1:B2:C3:D4:E5:F6,MX Keys'`. |
 | `--auto_discover, -a` | Relay all readable suitable input devices automatically, except known excluded platform devices. Good default for appliance-style setups where you do not want to curate a static device list. |
+| `--device_ids DEVICE_IDS, -i DEVICE_IDS` | Comma-separated identifiers for the devices to relay. Each identifier may be an event path, a Bluetooth MAC address, or a case-insensitive name fragment. The matcher accepts all three kinds in the same comma-separated list. Default: none. Examples: `-i /dev/input/event4`, `-i A1:B2:C3:D4:E5:F6`, `-i logi`, `-i '/dev/input/event4,A1:B2:C3:D4:E5:F6,MX Keys'`. |
 | `--grab_devices, -g` | Grab the selected input devices so the Pi no longer consumes their local events. |
 | `--interrupt_shortcut INTERRUPT_SHORTCUT, -s INTERRUPT_SHORTCUT` | Plus-separated key chord that toggles relaying on and off at runtime. Default: none when unset at the CLI. Example: `-s CTRL+SHIFT+F12`. |
 | `--list_devices, -l` | List readable input devices and exit without starting the relay. Useful before setting `DEVICE_IDS`. |
@@ -234,8 +234,6 @@ Update the managed checkout:
 ```bash
 sudo /opt/bluetooth_2_usb/scripts/update.sh
 ```
-
-This is the supported update path for an existing managed deployment.
 
 ## Uninstalling
 
@@ -303,9 +301,10 @@ sudo /opt/bluetooth_2_usb/scripts/smoke_test.sh --verbose
 > In principle you can also take the writable space from the same physical
 > device that holds the root filesystem, for example by carving out a separate
 > ext4 partition on that SD card or SSD. That avoids extra physical media, but
-> it increases the risk of partitioning mistakes and gives you less separation
-> between the read-only appliance system and the persistent Bluetooth state
-> during maintenance or recovery.
+> it does not reduce SD-card wear the way moving that writable state to a USB
+> stick or other separate storage can. It also increases the risk of
+> partitioning mistakes and gives you less separation during maintenance or
+> recovery.
 
 ### Preparing the persistent filesystem
 
@@ -384,8 +383,6 @@ If the service looks healthy but the target host still does not react, also chec
 - on Pi Zero boards, prefer separate stable power and use only the data port for the host connection
 - on Pi 4B and Pi 5, try a different USB-C cable or a different host port
 - confirm the service is actually active with `systemctl is-active bluetooth_2_usb.service`
-- inspect logs with `journalctl -u bluetooth_2_usb.service -n 100 --no-pager`
-- after boot-config changes, rerun `sudo /opt/bluetooth_2_usb/scripts/install.sh` and reboot before concluding the relay path is broken
 
 If you need to isolate the relay path from Bluetooth pairing state, run the host/Pi loopback harness from `docs/pi-host-relay-loopback-test-playbook.md`.
 
@@ -433,17 +430,11 @@ For stubborn bonding or connect/disconnect flip-flops, use a conservative reset 
 
 1. Run `sudo bluetoothctl`.
 2. Inside `bluetoothctl`, run `power off`.
-3. In another shell, run:
-
-```bash
-sudo rfkill block bluetooth
-sudo rfkill unblock bluetooth
-```
-
-4. Back in `bluetoothctl`, run:
+3. Back in `bluetoothctl`, run:
 
 ```text
 power on
+block A1:B2:C3:D4:E5:F6
 remove A1:B2:C3:D4:E5:F6
 scan on
 trust A1:B2:C3:D4:E5:F6
@@ -460,7 +451,6 @@ This is destructive for saved pairings:
 
 ```bash
 sudo systemctl stop bluetooth
-sudo ls /var/lib/bluetooth
 sudo find /var/lib/bluetooth -maxdepth 2 -type d
 ```
 
@@ -505,14 +495,6 @@ managed deployment.
 
 Remove the managed system integration while deliberately leaving the checkout in place for inspection or later reuse.
 
-### `debug.sh`
-
-Collect a deeper redacted diagnostics bundle when `smoke_test.sh` is not enough. It records service, boot, Bluetooth, mount, and runtime state, then runs a bounded live foreground debug session. The report includes the detected UDC state and shows whether it is currently `configured`.
-
-| Argument | Explanation / Example |
-| --- | --- |
-| `--duration DURATION_SEC` | Limit the live foreground debug run. Default: unbounded until interrupted. Example: `sudo /opt/bluetooth_2_usb/scripts/debug.sh --duration 10`. |
-
 ### `smoke_test.sh`
 
 Run the fast health check for the supported managed deployment. This is the first script to use after install, reboot, update, or read-only changes. It fails on broken platform, runtime, or Bluetooth-controller prerequisites, and warns when no paired or relayable devices are currently visible. In that case the final line stays successful but is rendered as `PASSED (with warnings)`. It also checks the detected UDC state and warns when the gadget controller is present but not currently `configured`.
@@ -520,6 +502,14 @@ Run the fast health check for the supported managed deployment. This is the firs
 | Argument | Explanation / Example |
 | --- | --- |
 | `--verbose` | Print the fuller health-check output instead of the compact pass/fail view. Default: disabled. Example: `sudo /opt/bluetooth_2_usb/scripts/smoke_test.sh --verbose`. |
+
+### `debug.sh`
+
+Collect a deeper redacted diagnostics bundle when `smoke_test.sh` is not enough. It records service, boot, Bluetooth, mount, and runtime state, then runs a bounded live foreground debug session. The report includes the detected UDC state and shows whether it is currently `configured`.
+
+| Argument | Explanation / Example |
+| --- | --- |
+| `--duration DURATION_SEC` | Limit the live foreground debug run. Default: unbounded until interrupted. Example: `sudo /opt/bluetooth_2_usb/scripts/debug.sh --duration 10`. |
 
 ### `pi_relay_test_inject.sh`
 

--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ If the service looks healthy but the target host still does not react, also chec
 
 If you need to isolate the relay path from Bluetooth pairing state, run the host/Pi loopback harness from `docs/pi-host-relay-loopback-test-playbook.md`.
 
-### Wake from host sleep is not currently supported
+### Can't wake sleeping or suspended hosts
 
 Wake from host sleep is currently not supported.
 
@@ -468,7 +468,7 @@ Remove only the affected device directory under the adapter first, then start
 Bluetooth again:
 
 ```bash
-sudo rm -rf /var/lib/bluetooth/AA:BB:CC:DD:EE:FF/A1:B2:C3:D4:E5:F6
+sudo rm -rf '/var/lib/bluetooth/AA:BB:CC:DD:EE:FF/A1:B2:C3:D4:E5:F6'
 sudo systemctl start bluetooth
 ```
 

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Bluetooth-2-USB supports the normal writable mode and one persistent read-only m
 ### What persistent read-only mode does
 
 - enables Raspberry Pi OS OverlayFS for the root filesystem
-- keeps Bluetooth state on a separate writable ext4 filesystem, typically on its own partition or storage area
+- keeps Bluetooth state on a separate writable ext4 filesystem
 - bind-mounts that Bluetooth state to `/var/lib/bluetooth`
 
 ### What it does not do
@@ -428,12 +428,22 @@ Inside `bluetoothctl`, watch for agent prompts and answer them explicitly. Some 
 
 For stubborn bonding or connect/disconnect flip-flops, use a conservative reset flow:
 
-1. Run `sudo bluetoothctl`.
-2. Inside `bluetoothctl`, run `power off`.
-3. Back in `bluetoothctl`, run:
+1. Start an interactive session:
+
+```bash
+sudo bluetoothctl
+```
+
+2. Reset the adapter state:
 
 ```text
+power off
 power on
+```
+
+3. Clear the stale device state and pair again:
+
+```text
 block A1:B2:C3:D4:E5:F6
 remove A1:B2:C3:D4:E5:F6
 scan on

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ This is the shortest supported path to a working setup.
 ### 1. Clone the project to the managed install path
 
 ```bash
-sudo apt update
-sudo apt install -y git
+sudo apt update && sudo apt install -y git
 sudo git clone https://github.com/quaxalber/bluetooth_2_usb.git /opt/bluetooth_2_usb
 ```
 
@@ -53,6 +52,7 @@ Use the desktop UI or `bluetoothctl`.
 
 ```bash
 bluetoothctl
+power on
 scan on
 ```
 
@@ -110,7 +110,7 @@ If possible, power the Pi from a separate stable power supply using the power-on
 - Bluetooth keyboard and mouse input relayed as standard USB HID
 - Auto-discovery and auto-reconnect for supported input devices
 - Optional input grabbing so the Pi does not also consume local keyboard and mouse events
-- A fixed strict-host USB HID layout aimed at pre-OS environments and picky hosts
+- A conservative USB HID gadget setup aimed at broad host compatibility
 - A small, well-supported diagnostics surface built around `--validate-env`, `smoke_test.sh`, and `debug.sh`
 - Optional persistent read-only operation with writable Bluetooth state on a separate ext4 filesystem
 - A single supported managed-install workflow in `/opt/bluetooth_2_usb`
@@ -166,13 +166,6 @@ Meaning:
 - `B2U_DEBUG=0` keeps normal log verbosity.
 - `B2U_DEVICE_IDS` is the precise alternative when you want to pin the runtime to specific event paths, Bluetooth MACs, or case-insensitive device-name fragments.
 - `B2U_UDC_PATH` is optional and only needed if you must pin UDC detection on a system with multiple gadget-capable controllers.
-
-The host-facing USB gadget is fixed to one layout:
-
-- boot-protocol keyboard interface first
-- mouse interface second
-- consumer-control interface third
-- `MaxPower=100`, `bmAttributes=0xa0`, and `max_speed=high-speed`
 
 After editing that file, restart the service:
 
@@ -236,44 +229,37 @@ sudo systemctl restart bluetooth_2_usb.service
 
 ## Updating
 
-Update the managed checkout and re-apply the system integration:
+Update the managed checkout:
 
 ```bash
 sudo /opt/bluetooth_2_usb/scripts/update.sh
 ```
 
-`update.sh` fast-forwards the current checked-out branch, refuses to overwrite a
-dirty managed checkout, and only runs `install.sh` when the checkout actually
-changed. If the current branch is already up to date, it exits successfully
-without rebuilding the virtual environment or restarting the service.
+This is the supported update path for an existing managed deployment.
 
 ## Uninstalling
 
-Remove the managed service, wrapper, env files, and persistent Bluetooth-state mount integration:
+Remove the managed system integration:
 
 ```bash
 sudo /opt/bluetooth_2_usb/scripts/uninstall.sh
 ```
 
-The checkout at `/opt/bluetooth_2_usb` is intentionally left in place.
-
 ## Diagnostics
 
-Quick health check:
+Start with the quick health check:
 
 ```bash
 sudo /opt/bluetooth_2_usb/scripts/smoke_test.sh --verbose
 ```
 
-Deeper issue report with a live foreground debug run:
+If that is not enough, collect the fuller debug report:
 
 ```bash
 sudo /opt/bluetooth_2_usb/scripts/debug.sh --duration 10
 ```
 
-`debug.sh` temporarily stops the service if it is running, launches a foreground Bluetooth-2-USB `--debug` session, and restores the service afterward. Host identifiers such as the hostname, `machine-id`, UUIDs, PARTUUIDs, and Bluetooth MAC addresses are redacted automatically in the saved report.
-
-For most problems, these are the first two commands to run and the first outputs worth attaching to an issue.
+For most problems, these are the first two commands to run.
 
 ## Persistent read-only operation
 
@@ -282,7 +268,7 @@ Bluetooth-2-USB supports the normal writable mode and one persistent read-only m
 ### What persistent read-only mode does
 
 - enables Raspberry Pi OS OverlayFS for the root filesystem
-- keeps Bluetooth state on a separate writable ext4 filesystem
+- keeps Bluetooth state on a separate writable ext4 filesystem, typically on its own partition or storage area
 - bind-mounts that Bluetooth state to `/var/lib/bluetooth`
 
 ### What it does not do
@@ -312,6 +298,14 @@ sudo /opt/bluetooth_2_usb/scripts/smoke_test.sh --verbose
 > [!IMPORTANT]
 > Replace `/dev/YOUR-PARTITION` with the real ext4 partition you intend to use.
 > Double-check the target with `lsblk -f` before formatting or enabling persistent Bluetooth state.
+
+> [!NOTE]
+> In principle you can also take the writable space from the same physical
+> device that holds the root filesystem, for example by carving out a separate
+> ext4 partition on that SD card or SSD. That avoids extra physical media, but
+> it increases the risk of partitioning mistakes and gives you less separation
+> between the read-only appliance system and the persistent Bluetooth state
+> during maintenance or recovery.
 
 ### Preparing the persistent filesystem
 
@@ -373,13 +367,6 @@ Interpret those checks conservatively:
 - On newer 64-bit Bookworm and aarch64 kernels, `CONFIG_USB_DWC2=y` often means `dwc2` is built into the kernel. In that case, the absence of a separate loadable `dwc2` module is normal and not itself a failure.
 - Treat missing USB gadget support as the problem, not merely the absence of a loadable module: if `CONFIG_USB_DWC2=y` is present, built-in `dwc2` is fine; otherwise make sure `dtoverlay=dwc2` is set and that `dwc2` is loaded on kernels that require it as a module.
 
-Then reboot after fixing the install:
-
-```bash
-sudo /opt/bluetooth_2_usb/scripts/install.sh
-sudo reboot
-```
-
 ### Specific devices are not being relayed
 
 Check what the runtime can actually see:
@@ -402,11 +389,9 @@ If the service looks healthy but the target host still does not react, also chec
 
 If you need to isolate the relay path from Bluetooth pairing state, run the host/Pi loopback harness from `docs/pi-host-relay-loopback-test-playbook.md`.
 
-### Wake from host sleep remains limited
+### Wake from host sleep is not currently supported
 
-The current fixed USB HID layout improves strict pre-OS behavior, including the
-ThinkPad cold-boot path to BitLocker, but wake from host sleep still does not
-work reliably.
+Wake from host sleep is currently not supported.
 
 This appears to require kernel-side support in the Raspberry Pi USB HID gadget
 path rather than a further `bluetooth_2_usb` userspace change. Raspberry Pi
@@ -418,6 +403,15 @@ Treat this as a known platform limitation for now.
 ### Bluetooth pairing or scanning is flaky even though `bluetooth.service` is active
 
 Do not treat `systemctl status bluetooth` on its own as a health check. A running `bluetooth.service` can still leave the controller powered off or rfkill-blocked.
+
+Check the real controller state first:
+
+```bash
+sudo bluetoothctl show
+sudo btmgmt info
+rfkill list
+grep -H . /sys/class/rfkill/rfkill*/{soft,hard,state} 2>/dev/null
+```
 
 If `smoke_test.sh` or `debug.sh` already show the adapter as healthy, switch to an interactive `bluetoothctl` session and complete the actual bonding flow there. The common failure mode is not missing BlueZ, but an unanswered pairing prompt or a bonding handshake that never completes.
 
@@ -434,6 +428,52 @@ sudo bluetoothctl
 ```
 
 Inside `bluetoothctl`, watch for agent prompts and answer them explicitly. Some BLE devices connect briefly, then drop again unless the authorization prompt is accepted in time. Repeated short `Connected: yes` / `Connected: no` transitions without a durable bonded state usually mean the pairing handshake is not completing, not that the device is already usable.
+
+For stubborn bonding or connect/disconnect flip-flops, use a conservative reset flow:
+
+1. Run `sudo bluetoothctl`.
+2. Inside `bluetoothctl`, run `power off`.
+3. In another shell, run:
+
+```bash
+sudo rfkill block bluetooth
+sudo rfkill unblock bluetooth
+```
+
+4. Back in `bluetoothctl`, run:
+
+```text
+power on
+remove A1:B2:C3:D4:E5:F6
+scan on
+trust A1:B2:C3:D4:E5:F6
+pair A1:B2:C3:D4:E5:F6
+connect A1:B2:C3:D4:E5:F6
+```
+
+`remove` clears the stored BlueZ device record for that device and is often the
+right next step when you have a half-broken bonding state. This is a recovery
+flow for hard failures, not the normal first pairing attempt.
+
+If the BlueZ device cache itself looks stale, you can clear it more directly.
+This is destructive for saved pairings:
+
+```bash
+sudo systemctl stop bluetooth
+sudo ls /var/lib/bluetooth
+sudo find /var/lib/bluetooth -maxdepth 2 -type d
+```
+
+Remove only the affected device directory under the adapter first, then start
+Bluetooth again:
+
+```bash
+sudo rm -rf /var/lib/bluetooth/AA:BB:CC:DD:EE:FF/A1:B2:C3:D4:E5:F6
+sudo systemctl start bluetooth
+```
+
+Only remove larger parts of `/var/lib/bluetooth` if targeted cleanup does not
+help and you are prepared to pair devices again from scratch.
 
 ### Persistent read-only mode does not keep Bluetooth pairings
 
@@ -457,8 +497,9 @@ Apply the current checkout in `/opt/bluetooth_2_usb` to the managed install. Thi
 
 Fast-forward the managed checkout and call `install.sh` only when the checkout
 changed. If the current branch is already up to date, the script exits
-successfully without reinstalling anything. This is the supported update path
-for an existing managed deployment.
+successfully without reinstalling anything. The script refuses to update a
+dirty managed checkout. This is the supported update path for an existing
+managed deployment.
 
 ### `uninstall.sh`
 
@@ -492,7 +533,11 @@ Create temporary virtual keyboard and mouse devices on the Pi and inject a deter
 
 ### `host_relay_test_capture.sh`
 
-Capture host-side gadget HID reports and verify that the relay emitted the expected sequence. The host Python environment must have `hidapi` installed, for example via `python3 -m pip install -r requirements-host-capture.txt`. On Windows, `hidapi` is used for gadget discovery and candidate enumeration, while strict event capture for `keyboard`, `mouse`, `consumer`, and `combo` runs through Raw Input. On Linux, unprivileged access also needs the host-side USB udev rule. Depending on the host HID stack, opening the gadget interfaces for capture can temporarily claim them while the test is running, so do not assume the local desktop will continue to process the same keyboard, mouse, or consumer inputs during the capture window. The default test sequence therefore uses non-text keyboard keys and tiny mouse-relative movements.
+Capture host-side gadget HID reports and verify that the relay emitted the expected sequence. Use this wrapper on Linux and macOS. The host Python environment must have `hidapi` installed, for example via `python3 -m pip install -r requirements-host-capture.txt`. On Linux, unprivileged access also needs the host-side USB udev rule. Depending on the host HID stack, opening the gadget interfaces for capture can temporarily claim them while the test is running, so do not assume the local desktop will continue to process the same keyboard, mouse, or consumer inputs during the capture window. The default test sequence therefore uses non-text keyboard keys and tiny mouse-relative movements. On Windows, use the PowerShell wrapper below; it uses `hidapi` for gadget discovery and Raw Input for strict event capture.
+
+> [!NOTE]
+> The Linux host flow is actively exercised. The macOS wrapper path is
+> documented for parity, but it has not yet been validated on a real macOS host.
 
 The harness is single-run only and uses a lock file. If a previous run was interrupted, clear stale lock files before retrying:
 
@@ -514,14 +559,6 @@ Before each fresh Windows validation run after changing the gadget descriptor la
 | `--keyboard-node PATH` | Override the detected host keyboard HID device path. |
 | `--mouse-node PATH` | Override the detected host mouse HID device path. |
 | `--consumer-node PATH` | Override the detected host consumer-control HID device path. |
-
-### `host_relay_test_capture.command`
-
-macOS wrapper for the same host-capture flow.
-
-| Argument | Explanation / Example |
-| --- | --- |
-| same as `host_relay_test_capture.sh` | Example: `./scripts/host_relay_test_capture.command --scenario combo`. |
 
 ### `host_relay_test_capture.ps1`
 

--- a/README.md
+++ b/README.md
@@ -243,8 +243,9 @@ sudo /opt/bluetooth_2_usb/scripts/update.sh
 ```
 
 `update.sh` fast-forwards the current checked-out branch, refuses to overwrite a
-dirty managed checkout, and then runs `install.sh` to reapply boot config, the
-virtual environment, the service, and the wrapper.
+dirty managed checkout, and only runs `install.sh` when the checkout actually
+changed. If the current branch is already up to date, it exits successfully
+without rebuilding the virtual environment or restarting the service.
 
 ## Uninstalling
 
@@ -454,7 +455,10 @@ Apply the current checkout in `/opt/bluetooth_2_usb` to the managed install. Thi
 
 ### `update.sh`
 
-Fast-forward the managed checkout and then call `install.sh`. This is the supported update path for an existing managed deployment.
+Fast-forward the managed checkout and call `install.sh` only when the checkout
+changed. If the current branch is already up to date, the script exits
+successfully without reinstalling anything. This is the supported update path
+for an existing managed deployment.
 
 ### `uninstall.sh`
 

--- a/docs/doc-consistency-review-playbook.md
+++ b/docs/doc-consistency-review-playbook.md
@@ -65,10 +65,6 @@ do
   echo
 done
 
-echo "==== scripts/host_relay_test_capture.command"
-./scripts/host_relay_test_capture.command --help
-echo
-
 echo "==== scripts/host_relay_test_capture.ps1"
 powershell -ExecutionPolicy Bypass -File .\\scripts\\host_relay_test_capture.ps1 --help
 echo

--- a/docs/pi-cli-service-test-playbook.md
+++ b/docs/pi-cli-service-test-playbook.md
@@ -133,6 +133,9 @@ ssh -4 "$PI_HOST" '
 '
 ```
 
+If no new commit is available on the checked-out branch, this should exit `0`
+without rebuilding the managed virtual environment or restarting the service.
+
 Reboot and wait for SSH so the update path is validated against the next boot:
 
 ```bash

--- a/docs/pi-host-relay-loopback-test-playbook.md
+++ b/docs/pi-host-relay-loopback-test-playbook.md
@@ -48,17 +48,15 @@ sudo /opt/bluetooth_2_usb/scripts/debug.sh --duration 5
 
 ## 1. Confirm host-side enumeration
 
-On Linux:
+On Linux or macOS:
 
 ```bash
 ./scripts/host_relay_test_capture.sh --scenario keyboard --timeout-sec 1 --output json
 ```
 
-On macOS:
-
-```bash
-./scripts/host_relay_test_capture.command --scenario keyboard --timeout-sec 1 --output json
-```
+> [!NOTE]
+> The Linux host flow is exercised regularly. The macOS variant uses the same
+> shell wrapper, but it has not yet been validated on a real macOS host.
 
 On Windows:
 

--- a/docs/pi-host-relay-loopback-test-playbook.md
+++ b/docs/pi-host-relay-loopback-test-playbook.md
@@ -48,15 +48,21 @@ sudo /opt/bluetooth_2_usb/scripts/debug.sh --duration 5
 
 ## 1. Confirm host-side enumeration
 
-On Linux or macOS:
+On Linux:
+
+```bash
+./scripts/host_relay_test_capture.sh --scenario keyboard --timeout-sec 1 --output json
+```
+
+Experimental: macOS
 
 ```bash
 ./scripts/host_relay_test_capture.sh --scenario keyboard --timeout-sec 1 --output json
 ```
 
 > [!NOTE]
-> The Linux host flow is exercised regularly. The macOS variant uses the same
-> shell wrapper, but it has not yet been validated on a real macOS host.
+> Experimental - unvalidated on real macOS hosts. The macOS variant uses the
+> same shell wrapper, but it has not yet been validated on real macOS hardware.
 
 On Windows:
 

--- a/docs/pi-manual-test-plan.md
+++ b/docs/pi-manual-test-plan.md
@@ -65,6 +65,9 @@ Steps:
 sudo /opt/bluetooth_2_usb/scripts/update.sh
 ```
 
+If the checkout is already current, expect a successful no-op rather than a
+forced reinstall.
+
 After reboot if boot settings changed:
 
 ```bash

--- a/scripts/host_relay_test_capture.command
+++ b/scripts/host_relay_test_capture.command
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -Eeuo pipefail
-IFS=$'\n\t'
-
-SCRIPT_DIR="$(cd -- "$(dirname "$0")" && pwd)"
-exec "${SCRIPT_DIR}/host_relay_test_capture.sh" "$@"

--- a/scripts/lib/install.sh
+++ b/scripts/lib/install.sh
@@ -107,8 +107,7 @@ rebuild_venv_atomically() {
   local venv_dir="$1"
   local package_dir="$2"
   local staging_dir="${venv_dir}.new"
-  local backup_dir=""
-  local backup_path=""
+  local previous_dir="${venv_dir}.old.$$"
 
   rm -rf "$staging_dir"
   recreate_venv "$staging_dir" || {
@@ -126,8 +125,8 @@ rebuild_venv_atomically() {
   fi
 
   if [[ -e "$venv_dir" ]]; then
-    backup_dir="${venv_dir}.bak.$(timestamp)"
-    mv "$venv_dir" "$backup_dir" || {
+    rm -rf "$previous_dir"
+    mv "$venv_dir" "$previous_dir" || {
       rm -rf "$staging_dir"
       return 1
     }
@@ -135,20 +134,14 @@ rebuild_venv_atomically() {
 
   if mv "$staging_dir" "$venv_dir"; then
     repair_venv_shebangs "$venv_dir" "$staging_dir"
-    if [[ -n "$backup_dir" ]]; then
-      info "Previous virtual environment backed up to ${backup_dir}"
-      for backup_path in "${venv_dir}".bak.*; do
-        [[ -e "$backup_path" ]] || break
-        [[ "$backup_path" == "$backup_dir" ]] && continue
-        rm -rf "$backup_path"
-      done
-    fi
+    rm -rf "$previous_dir"
     return 0
   fi
 
   warn "Failed to activate the new virtual environment."
-  if [[ -n "$backup_dir" ]]; then
-    warn "Previous virtual environment remains available at ${backup_dir}."
+  rm -rf "$venv_dir"
+  if [[ -e "$previous_dir" ]]; then
+    mv "$previous_dir" "$venv_dir" || warn "Failed to restore the previous virtual environment."
   fi
   return 1
 }

--- a/scripts/lib/install.sh
+++ b/scripts/lib/install.sh
@@ -36,12 +36,12 @@ write_default_env_file() {
     cat >"$B2U_ENV_FILE" <<'EOF'
 # Structured runtime configuration for bluetooth_2_usb.service.
 B2U_AUTO_DISCOVER=1
+B2U_DEVICE_IDS=
 B2U_GRAB_DEVICES=1
 B2U_INTERRUPT_SHORTCUT=CTRL+SHIFT+F12
 B2U_LOG_TO_FILE=0
 B2U_LOG_PATH=/var/log/bluetooth_2_usb/bluetooth_2_usb.log
 B2U_DEBUG=0
-B2U_DEVICE_IDS=
 B2U_UDC_PATH=
 EOF
     chmod 0644 "$B2U_ENV_FILE"

--- a/scripts/lib/install.sh
+++ b/scripts/lib/install.sh
@@ -108,8 +108,10 @@ rebuild_venv_atomically() {
   local package_dir="$2"
   local staging_dir="${venv_dir}.new"
   local previous_dir="${venv_dir}.old.$$"
+  local moved_previous=0
 
   rm -rf "$staging_dir"
+  rm -rf "$previous_dir"
   recreate_venv "$staging_dir" || {
     rm -rf "$staging_dir"
     return 1
@@ -125,11 +127,11 @@ rebuild_venv_atomically() {
   fi
 
   if [[ -e "$venv_dir" ]]; then
-    rm -rf "$previous_dir"
     mv "$venv_dir" "$previous_dir" || {
       rm -rf "$staging_dir"
       return 1
     }
+    moved_previous=1
   fi
 
   if mv "$staging_dir" "$venv_dir"; then
@@ -140,7 +142,7 @@ rebuild_venv_atomically() {
 
   warn "Failed to activate the new virtual environment."
   rm -rf "$venv_dir"
-  if [[ -e "$previous_dir" ]]; then
+  if [[ $moved_previous -eq 1 && -e "$previous_dir" ]]; then
     mv "$previous_dir" "$venv_dir" || warn "Failed to restore the previous virtual environment."
   fi
   return 1

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -12,8 +12,8 @@ usage() {
   cat <<EOF
 Usage: sudo ./scripts/update.sh
 
-Fast-forward the current managed checkout in ${B2U_INSTALL_DIR} and then
-reapply the managed install via ${B2U_INSTALL_DIR}/scripts/install.sh.
+Fast-forward the current managed checkout in ${B2U_INSTALL_DIR}. If the checkout
+changes, reapply the managed install via ${B2U_INSTALL_DIR}/scripts/install.sh.
 EOF
 }
 
@@ -41,12 +41,19 @@ fi
 
 CURRENT_BRANCH="$(git -C "${B2U_INSTALL_DIR}" symbolic-ref --quiet --short HEAD)" \
   || fail "Refusing to update a detached HEAD in ${B2U_INSTALL_DIR}."
+BEFORE_HEAD="$(git -C "${B2U_INSTALL_DIR}" rev-parse HEAD)"
 
 info "Fetching origin for branch ${CURRENT_BRANCH}"
 git -C "${B2U_INSTALL_DIR}" fetch --tags --prune origin
 
 info "Fast-forwarding ${CURRENT_BRANCH}"
 git -C "${B2U_INSTALL_DIR}" pull --ff-only origin "${CURRENT_BRANCH}"
+AFTER_HEAD="$(git -C "${B2U_INSTALL_DIR}" rev-parse HEAD)"
+
+if [[ "$BEFORE_HEAD" == "$AFTER_HEAD" ]]; then
+  ok "Managed checkout is already up to date; skipping reinstall."
+  exit 0
+fi
 
 info "Reapplying managed install"
 "${B2U_INSTALL_DIR}/scripts/install.sh"

--- a/src/bluetooth_2_usb/args.py
+++ b/src/bluetooth_2_usb/args.py
@@ -57,18 +57,18 @@ class CustomArgumentParser(argparse.ArgumentParser):
 
     def _add_arguments(self) -> None:
         self.add_argument(
-            "--device_ids",
-            "-i",
-            type=_parse_device_ids,
-            default=None,
-            help="Comma-separated list of identifiers for input devices to be relayed.\nAn identifier is either the input device path, the MAC address or any case-insensitive substring of the device name.\nExample: --device_ids '/dev/input/event2,a1:b2:c3:d4:e5:f6,0A-1B-2C-3D-4E-5F,logi'\nDefault: None",
-        )
-        self.add_argument(
             "--auto_discover",
             "-a",
             action="store_true",
             default=False,
             help="Enable auto-discovery mode. All readable input devices will be relayed automatically.\nDefault: disabled",
+        )
+        self.add_argument(
+            "--device_ids",
+            "-i",
+            type=_parse_device_ids,
+            default=None,
+            help="Comma-separated list of identifiers for input devices to be relayed.\nAn identifier is either the input device path, the MAC address or any case-insensitive substring of the device name.\nExample: --device_ids '/dev/input/event2,a1:b2:c3:d4:e5:f6,0A-1B-2C-3D-4E-5F,logi'\nDefault: None",
         )
         self.add_argument(
             "--grab_devices",

--- a/src/bluetooth_2_usb/service_config.py
+++ b/src/bluetooth_2_usb/service_config.py
@@ -18,12 +18,12 @@ class ServiceConfigError(ValueError):
 @dataclass(slots=True)
 class ServiceConfig:
     auto_discover: bool = True
+    device_ids: list[str] = field(default_factory=list)
     grab_devices: bool = True
     interrupt_shortcut: str = "CTRL+SHIFT+F12"
     log_to_file: bool = False
     log_path: str = DEFAULT_LOG_PATH
     debug: bool = False
-    device_ids: list[str] = field(default_factory=list)
     udc_path: str = ""
 
     def to_dict(self) -> dict[str, object]:


### PR DESCRIPTION
## Summary
- make `scripts/update.sh` skip `install.sh` when the checked-out branch is already at the current commit
- stop keeping persistent `venv.bak.*` backups during managed venv rebuilds and use only a temporary swap/restore path during the atomic replace
- update the repo docs to describe the new `update.sh` no-op behavior for already-current checkouts

## Why
The managed update path should not rebuild the virtual environment or restart the service when nothing changed. The extra reinstall was unnecessary churn, and persistent venv backup directories were also not wanted. This follow-up keeps the update flow idempotent in the practical sense: success without side effects when the checkout is already current.

## Validation
- `shfmt -d -i 2 -ci -bn scripts/*.sh scripts/lib/*.sh`
- `shellcheck -x scripts/*.sh scripts/lib/*.sh`
- `bash -n scripts/*.sh scripts/lib/*.sh`
- `pi4b`: install branch and run `sudo /opt/bluetooth_2_usb/scripts/update.sh` on an already current checkout
- `pi4b`: verified `Managed checkout is already up to date; skipping reinstall.`
- `pi4b`: verified `MainPID` unchanged across the no-op update run
- `pi4b`: verified no `venv.bak.*` or `venv.old.*` directories remain after install

## Notes
- the separate `fetch` before `pull` remains unchanged in this PR by request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified update/install/uninstall flows: running update on an already-current checkout now exits successfully as a no-op; condensed quick-starts; added pairing power-on step; macOS host-relay marked experimental; expanded diagnostics, troubleshooting, bonding/recovery, and host-relay usage notes (Linux/macOS/Windows); reordered CLI examples.

* **Improvements**
  * No-op updates skip reinstall/restart for faster updates.
  * More robust virtual-environment replace/rollback behavior.
  * Simplified macOS host-relay wrapper usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->