### PR TITLE
docs: define branch, commit, and PR scope conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,8 +254,18 @@ summary.
 ## Git and change scope
 
 - Keep changes focused.
+- Prefer one logical feature, fix, or documentation change per branch and per
+  pull request when the work can be separated cleanly.
+- Use descriptive branch names rooted in the change type, for example:
+  `feat/...`, `fix/...`, `docs/...`, `refactor/...`, `test/...`, or
+  `chore/...`.
+- Do not use `codex/...` branch prefixes for normal project work.
+- Start new commit subjects with a conventional type prefix such as `feat:`,
+  `fix:`, `docs:`, `refactor:`, `test:`, or `chore:`.
 - Update docs when behavior, commands, paths, defaults, or validation guidance
   change.
+- Keep behavior or operator-facing documentation updates in the same change as
+  the code that introduced them.
 - Do not amend commits unless explicitly asked.
 - Do not revert user changes you did not make.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,10 +160,33 @@ running.
 When you open a pull request:
 
 - keep the scope focused
+- prefer one logical feature, fix, or documentation change per PR when the work
+  can be separated cleanly
 - explain what changed and why
 - describe how you tested it
 - include the target host type used for validation when it matters
 - update docs when behavior, commands, paths, or defaults change
+
+Use branch names that describe the change and start with the change type, for
+example:
+
+- `feat/...`
+- `fix/...`
+- `docs/...`
+- `refactor/...`
+- `test/...`
+- `chore/...`
+
+Do not use `codex/...` branch prefixes for normal project work.
+
+Start commit subjects with the same conventional type prefixes:
+
+- `feat:`
+- `fix:`
+- `docs:`
+- `refactor:`
+- `test:`
+- `chore:`
 
 If you address review feedback, verify each point against the current code.
 Do not assume an old resolved thread is still satisfied after later commits.


### PR DESCRIPTION
## Summary
- document the standard branch naming scheme without `codex/`
- require conventional commit prefixes such as `feat:` and `fix:`
- require focused PR scope and matching docs updates for behavior changes

## Testing
- documentation consistency review

## Notes
- docs-only change
- no product, installer, or CLI logic changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines with standardized branch naming conventions using conventional prefixes (feat/, fix/, docs/, refactor/, test/, chore/).
  * Established Conventional Commits-style commit message format requirements for consistency.
  * Added requirements to scope pull requests to single logical changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->