### PR TITLE
feat: render device inventory as a responsive table

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ relay   HID 046d:c548 Consumer Control usb-0000:03:00.0-2.2/input1 /dev/input/ev
 skip    HD-Audio Generic Line          ALSA                          /dev/input/event20  missing EV_KEY/EV_REL capabilities
 ```
 
+On narrower terminals, columns such as `Device` and `Exclusion Reason` may wrap onto multiple lines.
+
 Validate the runtime environment:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ If possible, power the Pi from a separate stable power supply using the power-on
 - Bluetooth keyboard and mouse input relayed as standard USB HID
 - Auto-discovery and auto-reconnect for supported input devices
 - Optional input grabbing so the Pi does not also consume local keyboard and mouse events
+- Broad support for everyday multimedia and consumer-control keys such as
+  volume, mute, play/pause, track controls, and many common shortcut keys
 - A conservative USB HID gadget setup aimed at broad host compatibility
 - A small, well-supported diagnostics surface built around `--validate-env`, `smoke_test.sh`, and `debug.sh`
 - Optional persistent read-only operation with writable Bluetooth state on a separate ext4 filesystem
@@ -186,7 +188,7 @@ Use these runtime flags when running the CLI manually.
 | `--device_ids DEVICE_IDS, -i DEVICE_IDS` | Comma-separated identifiers for the devices to relay. Each identifier may be an event path, a Bluetooth MAC address, or a case-insensitive name fragment. The matcher accepts all three kinds in the same comma-separated list. Default: none. Examples: `-i /dev/input/event4`, `-i A1:B2:C3:D4:E5:F6`, `-i logi`, `-i '/dev/input/event4,A1:B2:C3:D4:E5:F6,MX Keys'`. |
 | `--grab_devices, -g` | Grab the selected input devices so the Pi no longer consumes their local events. |
 | `--interrupt_shortcut INTERRUPT_SHORTCUT, -s INTERRUPT_SHORTCUT` | Plus-separated key chord that toggles relaying on and off at runtime. Default: none when unset at the CLI. Example: `-s CTRL+SHIFT+F12`. |
-| `--list_devices, -l` | List readable input devices and exit without starting the relay. Useful before setting `DEVICE_IDS`. |
+| `--list_devices, -l` | List readable input devices and exit without starting the relay. Text output is shown as a formatted table with headers; `--output json` keeps the machine-readable form. Useful before setting `DEVICE_IDS`. |
 | `--log_to_file, -f` | Add file logging in addition to stdout logging. |
 | `--log_path LOG_PATH, -p LOG_PATH` | Override the path used with `--log_to_file`. Default: `/var/log/bluetooth_2_usb/bluetooth_2_usb.log`. Example: `-p /tmp/bluetooth_2_usb.log`. |
 | `--debug, -d` | Increase log verbosity for manual troubleshooting. |
@@ -201,6 +203,14 @@ List available devices:
 
 ```bash
 bluetooth_2_usb -l
+```
+
+Example text output:
+
+```text
+Status  Device                         Identity                      Path                Notes
+relay   HID 046d:c548 Consumer Control usb-0000:03:00.0-2.2/input1 /dev/input/event4
+skip    HD-Audio Generic Line          ALSA                          /dev/input/event20  missing EV_KEY/EV_REL capabilities
 ```
 
 Validate the runtime environment:

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ bluetooth_2_usb -l
 Example text output:
 
 ```text
-Status  Device                         Identity                      Path                Notes
+Status  Device                         Identity                      Path                Exclusion Reason
 relay   HID 046d:c548 Consumer Control usb-0000:03:00.0-2.2/input1 /dev/input/event4
 skip    HD-Audio Generic Line          ALSA                          /dev/input/event20  missing EV_KEY/EV_REL capabilities
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ pyftdi==0.57.1
 pyserial==3.5
 pyudev==0.24.4
 pyusb==1.3.1
+rich==14.1.0
 rpi-ws281x==5.0.0
 RPi.GPIO==0.7.1
 sysv-ipc==1.2.0

--- a/src/bluetooth_2_usb/inventory.py
+++ b/src/bluetooth_2_usb/inventory.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+import io
+import shutil
 from dataclasses import asdict, dataclass
 from types import SimpleNamespace
 from typing import Any
+
+from rich import box
+from rich.console import Console
+from rich.table import Table
 
 from .logging import get_logger
 
@@ -138,11 +144,36 @@ def describe_input_devices(
 
 
 def inventory_to_text(devices: list[InputDeviceMetadata]) -> str:
-    lines = []
+    table = Table(
+        box=box.MINIMAL_DOUBLE_HEAD,
+        expand=False,
+        header_style="bold",
+        pad_edge=False,
+        show_lines=False,
+    )
+    table.add_column("Status", no_wrap=True, width=7)
+    table.add_column("Device", min_width=18, overflow="fold")
+    table.add_column("Identity", min_width=16, overflow="fold")
+    table.add_column("Path", min_width=18, overflow="fold")
+    table.add_column("Notes", min_width=20, overflow="fold")
+
     for device in devices:
         status = "relay" if device.relay_candidate else "skip"
-        line = f"{status}\t{device.name}\t{device.identity}\t{device.path}"
-        if device.exclusion_reason:
-            line = f"{line}\t{device.exclusion_reason}"
-        lines.append(line)
-    return "\n".join(lines)
+        table.add_row(
+            status,
+            device.name or "-",
+            device.identity,
+            device.path,
+            device.exclusion_reason or "",
+        )
+
+    output = io.StringIO()
+    console = Console(
+        file=output,
+        force_terminal=False,
+        no_color=True,
+        color_system=None,
+        width=shutil.get_terminal_size(fallback=(100, 20)).columns,
+    )
+    console.print(table)
+    return output.getvalue().rstrip()

--- a/src/bluetooth_2_usb/inventory.py
+++ b/src/bluetooth_2_usb/inventory.py
@@ -155,7 +155,7 @@ def inventory_to_text(devices: list[InputDeviceMetadata]) -> str:
     table.add_column("Device", min_width=18, overflow="fold")
     table.add_column("Identity", min_width=16, overflow="fold")
     table.add_column("Path", min_width=18, overflow="fold")
-    table.add_column("Notes", min_width=20, overflow="fold")
+    table.add_column("Exclusion Reason", min_width=20, overflow="fold")
 
     for device in devices:
         status = "relay" if device.relay_candidate else "skip"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -181,5 +181,7 @@ class CliTest(unittest.TestCase):
         self.assertIn("Exclusion Reason", rendered)
         self.assertIn("Keyboard", rendered)
         self.assertIn("Audio Sink", rendered)
+        self.assertIn("relay", rendered)
+        self.assertIn("skip", rendered)
         self.assertIn("missing EV_KEY/EV_REL", rendered)
         self.assertIn("capabilities", rendered)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -178,7 +178,7 @@ class CliTest(unittest.TestCase):
         self.assertIn("Device", rendered)
         self.assertIn("Identity", rendered)
         self.assertIn("Path", rendered)
-        self.assertIn("Notes", rendered)
+        self.assertIn("Exclusion Reason", rendered)
         self.assertIn("Keyboard", rendered)
         self.assertIn("Audio Sink", rendered)
         self.assertIn("missing EV_KEY/EV_REL", rendered)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -141,3 +141,45 @@ class CliTest(unittest.TestCase):
 
         self.assertEqual(exit_code, cli.EXIT_OK)
         self.assertEqual(json.loads(stdout.getvalue())[0]["path"], "/dev/input/event1")
+
+    def test_list_devices_text_output_renders_table(self) -> None:
+        stdout = io.StringIO()
+        devices = [
+            InputDeviceMetadata(
+                path="/dev/input/event1",
+                name="Keyboard",
+                phys="phys",
+                uniq="",
+                capabilities=["EV_KEY"],
+                relay_candidate=True,
+                exclusion_reason=None,
+            ),
+            InputDeviceMetadata(
+                path="/dev/input/event2",
+                name="Audio Sink",
+                phys="alsa",
+                uniq="",
+                capabilities=[],
+                relay_candidate=False,
+                exclusion_reason="missing EV_KEY/EV_REL capabilities",
+            ),
+        ]
+
+        with patch(
+            "bluetooth_2_usb.inventory.describe_input_devices",
+            return_value=devices,
+        ):
+            with redirect_stdout(stdout):
+                exit_code = cli.run(["--list_devices"])
+
+        rendered = stdout.getvalue()
+        self.assertEqual(exit_code, cli.EXIT_OK)
+        self.assertIn("Status", rendered)
+        self.assertIn("Device", rendered)
+        self.assertIn("Identity", rendered)
+        self.assertIn("Path", rendered)
+        self.assertIn("Notes", rendered)
+        self.assertIn("Keyboard", rendered)
+        self.assertIn("Audio Sink", rendered)
+        self.assertIn("missing EV_KEY/EV_REL", rendered)
+        self.assertIn("capabilities", rendered)


### PR DESCRIPTION
## Summary
- render `bluetooth_2_usb -l` text output as a Rich table with headers
- keep `--output json` unchanged for machine-readable consumers
- rename the notes column to `Exclusion Reason`
- update the README examples and highlight broader support for everyday multimedia keys

## Testing
- `black --check src tests`
- `ruff check src tests`
- `python -m unittest discover -s tests -v`
- Pi validation on `pi4b`
- `sudo /opt/bluetooth_2_usb/scripts/install.sh`
- `sudo /opt/bluetooth_2_usb/scripts/smoke_test.sh --verbose`
- `bluetooth_2_usb -l`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Device listings now display in a formatted table with clear column headers (Status, Device, Identity, Path, Exclusion Reason) for improved readability.

* **Documentation**
  * Enhanced README documentation with expanded CLI guidance and concrete example output for the `--list_devices` command.
  * Clarified support for multimedia and consumer-control shortcuts.

* **Chores**
  * Added `rich` library as a runtime dependency for table formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->