### PR TITLE
fix: clear bluetooth rfkill soft blocks during install

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ sudo git clone https://github.com/quaxalber/bluetooth_2_usb.git /opt/bluetooth_2
 sudo /opt/bluetooth_2_usb/scripts/install.sh
 ```
 
+On current Raspberry Pi OS 64-bit Lite images, the installer also clears a
+common Bluetooth soft-blocked `rfkill` default so pairing can start from a
+known-good controller state.
+
 ### 3. Reboot
 
 ```bash
@@ -411,6 +415,11 @@ grep -H . /sys/class/rfkill/rfkill*/{soft,hard,state} 2>/dev/null
 ```
 
 If `smoke_test.sh` or `debug.sh` already show the adapter as healthy, switch to an interactive `bluetoothctl` session and complete the actual bonding flow there. The common failure mode is not missing BlueZ, but an unanswered pairing prompt or a bonding handshake that never completes.
+
+The managed installer already clears common Bluetooth `rfkill` soft blocks on
+Raspberry Pi OS Lite during installation. If the controller becomes blocked
+again later, inspect the live `rfkill` state instead of assuming the install
+did not run.
 
 If you already know the adapter is soft-blocked, clear that first:
 

--- a/docs/pi-cli-service-test-playbook.md
+++ b/docs/pi-cli-service-test-playbook.md
@@ -92,6 +92,11 @@ ssh -4 "$PI_HOST" '
 '
 ```
 
+The installer now clears common Bluetooth `rfkill` soft blocks on Raspberry Pi
+OS Lite before you move on to pairing and validation. Treat a later blocked
+controller as current runtime state to debug, not as proof that install
+skipped the Bluetooth setup.
+
 Reboot and wait for SSH:
 
 ```bash
@@ -111,6 +116,7 @@ ssh -4 "$PI_HOST" '
   sudo -n /opt/bluetooth_2_usb/scripts/smoke_test.sh --verbose
   sudo -n bluetoothctl show
   sudo -n btmgmt info
+  grep -H . /sys/class/rfkill/rfkill*/{soft,hard,state} 2>/dev/null || true
 '
 ```
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,6 +9,8 @@ source "${SCRIPT_DIR}/lib/paths.sh"
 source "${SCRIPT_DIR}/lib/common.sh"
 # shellcheck source=./lib/boot.sh
 source "${SCRIPT_DIR}/lib/boot.sh"
+# shellcheck source=./lib/bluetooth.sh
+source "${SCRIPT_DIR}/lib/bluetooth.sh"
 # shellcheck source=./lib/install.sh
 source "${SCRIPT_DIR}/lib/install.sh"
 
@@ -57,6 +59,7 @@ info "Detected dwc2 mode: ${DWC2_MODE}"
 
 apt-get update -y
 apt-get install -y --no-install-recommends git python3 python3-pip python3-venv python3-dev
+clear_bluetooth_rfkill_soft_blocks
 
 normalize_dwc2_overlay "$CONFIG_TXT" "$OVERLAY_LINE"
 normalize_modules_load "$CMDLINE_TXT" "$MODULES"

--- a/scripts/lib/bluetooth.sh
+++ b/scripts/lib/bluetooth.sh
@@ -36,13 +36,13 @@ bluetooth_paired_count() {
   bluetoothctl_paired_devices 2>/dev/null | grep -c '^Device ' || true
 }
 
-bluetooth_rfkill_entries() {
+_bluetooth_rfkill_records() {
   local type_file=""
   local rfkill_dir=""
+  local name=""
   local soft=""
   local hard=""
   local state=""
-  local name=""
   local found=1
 
   for type_file in "$(bluetooth_rfkill_root)"/rfkill*/type; do
@@ -57,61 +57,63 @@ bluetooth_rfkill_entries() {
     soft="$(cat "${rfkill_dir}/soft" 2>/dev/null || printf '%s' '?')"
     hard="$(cat "${rfkill_dir}/hard" 2>/dev/null || printf '%s' '?')"
     state="$(cat "${rfkill_dir}/state" 2>/dev/null || printf '%s' '?')"
-    printf '%s type=bluetooth soft=%s hard=%s state=%s\n' "$name" "$soft" "$hard" "$state"
+    printf '%s|%s|%s|%s\n' "$name" "$soft" "$hard" "$state"
   done
 
   return "$found"
 }
 
-bluetooth_rfkill_blocked() {
-  local type_file=""
-  local rfkill_dir=""
-  local found=1
+bluetooth_rfkill_entries() {
+  local record=""
+  local name=""
   local soft=""
   local hard=""
   local state=""
+  local found=1
 
-  for type_file in "$(bluetooth_rfkill_root)"/rfkill*/type; do
-    [[ -f "$type_file" ]] || continue
-    if [[ "$(cat "$type_file" 2>/dev/null || true)" != "bluetooth" ]]; then
-      continue
-    fi
-
+  while IFS= read -r record; do
+    [[ -n "$record" ]] || continue
     found=0
-    rfkill_dir="$(dirname "$type_file")"
-    soft="$(cat "${rfkill_dir}/soft" 2>/dev/null || printf '%s' '?')"
-    hard="$(cat "${rfkill_dir}/hard" 2>/dev/null || printf '%s' '?')"
-    state="$(cat "${rfkill_dir}/state" 2>/dev/null || printf '%s' '?')"
+    IFS='|' read -r name soft hard state <<<"$record"
+    printf '%s type=bluetooth soft=%s hard=%s state=%s\n' "$name" "$soft" "$hard" "$state"
+  done < <(_bluetooth_rfkill_records)
+
+  return "$found"
+}
+
+bluetooth_rfkill_blocked() {
+  local record=""
+  local name=""
+  local soft=""
+  local hard=""
+  local state=""
+  local found=1
+
+  while IFS= read -r record; do
+    [[ -n "$record" ]] || continue
+    found=0
+    IFS='|' read -r name soft hard state <<<"$record"
     if [[ "$soft" == "1" || "$hard" == "1" || "$state" == "0" ]]; then
       return 0
     fi
-  done
+  done < <(_bluetooth_rfkill_records)
 
   [[ $found -eq 0 ]] || return 1
   return 1
 }
 
 clear_bluetooth_rfkill_soft_blocks() {
-  local type_file=""
-  local rfkill_dir=""
+  local record=""
   local name=""
   local soft=""
   local hard=""
   local state=""
   local found=1
 
-  for type_file in "$(bluetooth_rfkill_root)"/rfkill*/type; do
-    [[ -f "$type_file" ]] || continue
-    if [[ "$(cat "$type_file" 2>/dev/null || true)" != "bluetooth" ]]; then
-      continue
-    fi
-
+  while IFS= read -r record; do
+    [[ -n "$record" ]] || continue
     found=0
-    rfkill_dir="$(dirname "$type_file")"
-    name="$(basename "$rfkill_dir")"
-    soft="$(cat "${rfkill_dir}/soft" 2>/dev/null || printf '%s' '?')"
-    hard="$(cat "${rfkill_dir}/hard" 2>/dev/null || printf '%s' '?')"
-    state="$(cat "${rfkill_dir}/state" 2>/dev/null || printf '%s' '?')"
+    IFS='|' read -r name soft hard state <<<"$record"
 
     if [[ "$hard" == "1" ]]; then
       warn "Bluetooth rfkill ${name} is hard-blocked; leaving it unchanged."
@@ -123,9 +125,9 @@ clear_bluetooth_rfkill_soft_blocks() {
       continue
     fi
 
-    if printf '%s\n' 0 >"${rfkill_dir}/soft" 2>/dev/null; then
-      soft="$(cat "${rfkill_dir}/soft" 2>/dev/null || printf '%s' '?')"
-      state="$(cat "${rfkill_dir}/state" 2>/dev/null || printf '%s' '?')"
+    if printf '%s\n' 0 >"$(bluetooth_rfkill_root)/${name}/soft" 2>/dev/null; then
+      soft="$(cat "$(bluetooth_rfkill_root)/${name}/soft" 2>/dev/null || printf '%s' '?')"
+      state="$(cat "$(bluetooth_rfkill_root)/${name}/state" 2>/dev/null || printf '%s' '?')"
       if [[ "$soft" == "0" ]]; then
         ok "Cleared Bluetooth rfkill soft block for ${name} (state=${state})."
       else
@@ -135,7 +137,7 @@ clear_bluetooth_rfkill_soft_blocks() {
     fi
 
     warn "Failed to clear Bluetooth rfkill soft block for ${name}."
-  done
+  done < <(_bluetooth_rfkill_records)
 
   if [[ $found -eq 1 ]]; then
     info "No bluetooth rfkill entries found; skipping soft-block cleanup."

--- a/scripts/lib/bluetooth.sh
+++ b/scripts/lib/bluetooth.sh
@@ -24,6 +24,10 @@ btmgmt_info() {
   btmgmt info
 }
 
+bluetooth_rfkill_root() {
+  printf '%s\n' "${B2U_RFKILL_ROOT:-/sys/class/rfkill}"
+}
+
 bluetooth_controller_powered() {
   bluetoothctl_show 2>/dev/null | grep -Eq '^[[:space:]]*Powered:[[:space:]]+yes$'
 }
@@ -41,7 +45,7 @@ bluetooth_rfkill_entries() {
   local name=""
   local found=1
 
-  for type_file in /sys/class/rfkill/rfkill*/type; do
+  for type_file in "$(bluetooth_rfkill_root)"/rfkill*/type; do
     [[ -f "$type_file" ]] || continue
     if [[ "$(cat "$type_file" 2>/dev/null || true)" != "bluetooth" ]]; then
       continue
@@ -67,7 +71,7 @@ bluetooth_rfkill_blocked() {
   local hard=""
   local state=""
 
-  for type_file in /sys/class/rfkill/rfkill*/type; do
+  for type_file in "$(bluetooth_rfkill_root)"/rfkill*/type; do
     [[ -f "$type_file" ]] || continue
     if [[ "$(cat "$type_file" 2>/dev/null || true)" != "bluetooth" ]]; then
       continue
@@ -85,4 +89,56 @@ bluetooth_rfkill_blocked() {
 
   [[ $found -eq 0 ]] || return 1
   return 1
+}
+
+clear_bluetooth_rfkill_soft_blocks() {
+  local type_file=""
+  local rfkill_dir=""
+  local name=""
+  local soft=""
+  local hard=""
+  local state=""
+  local found=1
+
+  for type_file in "$(bluetooth_rfkill_root)"/rfkill*/type; do
+    [[ -f "$type_file" ]] || continue
+    if [[ "$(cat "$type_file" 2>/dev/null || true)" != "bluetooth" ]]; then
+      continue
+    fi
+
+    found=0
+    rfkill_dir="$(dirname "$type_file")"
+    name="$(basename "$rfkill_dir")"
+    soft="$(cat "${rfkill_dir}/soft" 2>/dev/null || printf '%s' '?')"
+    hard="$(cat "${rfkill_dir}/hard" 2>/dev/null || printf '%s' '?')"
+    state="$(cat "${rfkill_dir}/state" 2>/dev/null || printf '%s' '?')"
+
+    if [[ "$hard" == "1" ]]; then
+      warn "Bluetooth rfkill ${name} is hard-blocked; leaving it unchanged."
+      continue
+    fi
+
+    if [[ "$soft" != "1" ]]; then
+      info "Bluetooth rfkill ${name} is already unblocked (soft=${soft} state=${state})."
+      continue
+    fi
+
+    if printf '%s\n' 0 >"${rfkill_dir}/soft" 2>/dev/null; then
+      soft="$(cat "${rfkill_dir}/soft" 2>/dev/null || printf '%s' '?')"
+      state="$(cat "${rfkill_dir}/state" 2>/dev/null || printf '%s' '?')"
+      if [[ "$soft" == "0" ]]; then
+        ok "Cleared Bluetooth rfkill soft block for ${name} (state=${state})."
+      else
+        warn "Attempted to clear Bluetooth rfkill ${name}, but soft=${soft} afterwards."
+      fi
+      continue
+    fi
+
+    warn "Failed to clear Bluetooth rfkill soft block for ${name}."
+  done
+
+  if [[ $found -eq 1 ]]; then
+    info "No bluetooth rfkill entries found; skipping soft-block cleanup."
+  fi
+  return 0
 }

--- a/tests/test_bluetooth_rfkill_lib.py
+++ b/tests/test_bluetooth_rfkill_lib.py
@@ -1,0 +1,67 @@
+import os
+import shlex
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BLUETOOTH_LIB = REPO_ROOT / "scripts/lib/bluetooth.sh"
+
+
+def _write_rfkill_entry(
+    root: Path,
+    index: int,
+    *,
+    type_name: str = "bluetooth",
+    soft: str = "0",
+    hard: str = "0",
+    state: str = "1",
+) -> Path:
+    rfkill_dir = root / f"rfkill{index}"
+    rfkill_dir.mkdir(parents=True, exist_ok=True)
+    (rfkill_dir / "type").write_text(f"{type_name}\n", encoding="utf-8")
+    (rfkill_dir / "soft").write_text(f"{soft}\n", encoding="utf-8")
+    (rfkill_dir / "hard").write_text(f"{hard}\n", encoding="utf-8")
+    (rfkill_dir / "state").write_text(f"{state}\n", encoding="utf-8")
+    return rfkill_dir
+
+
+class BluetoothRfkillLibTest(unittest.TestCase):
+    def _run_helper(self, rfkill_root: Path) -> subprocess.CompletedProcess[str]:
+        command = (
+            f"source {shlex.quote(str(BLUETOOTH_LIB))}; "
+            "clear_bluetooth_rfkill_soft_blocks"
+        )
+        env = os.environ.copy()
+        env["B2U_RFKILL_ROOT"] = str(rfkill_root)
+        return subprocess.run(
+            ["bash", "-lc", command],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_clear_bluetooth_rfkill_soft_blocks_clears_soft_block(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rfkill_root = Path(tmpdir)
+            entry = _write_rfkill_entry(rfkill_root, 0, soft="1", hard="0", state="0")
+
+            completed = self._run_helper(rfkill_root)
+
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertEqual((entry / "soft").read_text(encoding="utf-8").strip(), "0")
+            self.assertIn("Cleared Bluetooth rfkill soft block", completed.stdout)
+
+    def test_clear_bluetooth_rfkill_soft_blocks_keeps_hard_block(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rfkill_root = Path(tmpdir)
+            entry = _write_rfkill_entry(rfkill_root, 0, soft="1", hard="1", state="0")
+
+            completed = self._run_helper(rfkill_root)
+
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertEqual((entry / "soft").read_text(encoding="utf-8").strip(), "1")
+            self.assertIn("hard-blocked", completed.stdout)

--- a/tests/test_bluetooth_rfkill_lib.py
+++ b/tests/test_bluetooth_rfkill_lib.py
@@ -65,3 +65,12 @@ class BluetoothRfkillLibTest(unittest.TestCase):
             self.assertEqual(completed.returncode, 0, completed.stderr)
             self.assertEqual((entry / "soft").read_text(encoding="utf-8").strip(), "1")
             self.assertIn("hard-blocked", completed.stdout)
+
+    def test_clear_bluetooth_rfkill_soft_blocks_with_no_entries(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rfkill_root = Path(tmpdir)
+
+            completed = self._run_helper(rfkill_root)
+
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertIn("No bluetooth rfkill entries found", completed.stdout)


### PR DESCRIPTION
## Summary
- detect Bluetooth rfkill entries via sysfs during install
- clear Bluetooth soft blocks conservatively during install
- warn on hard blocks instead of trying to override them
- document the Raspberry Pi OS Lite default and the new installer behavior

## Testing
- `black --check src tests`
- `ruff check src tests`
- `python -m unittest discover -s tests -v`
- `shfmt -d -i 2 -ci -bn scripts/*.sh scripts/lib/*.sh`
- `shellcheck -x scripts/*.sh scripts/lib/*.sh`
- `bash -n scripts/*.sh scripts/lib/*.sh`
- Pi validation on `pi4b`
- force Bluetooth rfkill soft block
- `sudo /opt/bluetooth_2_usb/scripts/install.sh`
- `sudo /opt/bluetooth_2_usb/scripts/smoke_test.sh --verbose`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer now automatically clears Bluetooth rfkill soft blocks on Raspberry Pi OS 64-bit Lite during setup to ensure a known-good controller state for pairing.

* **Documentation**
  * README and install/playbook docs updated to note the installer clears rfkill soft blocks and to advise inspecting live rfkill state if blocking recurs.

* **Tests**
  * Added unit tests covering rfkill soft-block clearing behavior and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->