### PR TITLE
fix: canonicalize runtime env booleans as true and false

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,25 +146,25 @@ The service reads structured runtime settings from:
 Default content:
 
 ```bash
-B2U_AUTO_DISCOVER=1
+B2U_AUTO_DISCOVER=true
 B2U_DEVICE_IDS=
-B2U_GRAB_DEVICES=1
+B2U_GRAB_DEVICES=true
 B2U_INTERRUPT_SHORTCUT=CTRL+SHIFT+F12
-B2U_LOG_TO_FILE=0
+B2U_LOG_TO_FILE=false
 B2U_LOG_PATH=/var/log/bluetooth_2_usb/bluetooth_2_usb.log
-B2U_DEBUG=0
+B2U_DEBUG=false
 B2U_UDC_PATH=
 ```
 
 Meaning:
 
-- `B2U_AUTO_DISCOVER=1` relays all suitable readable input devices except known excluded platform devices.
+- `B2U_AUTO_DISCOVER=true` relays all suitable readable input devices except known excluded platform devices.
 - `B2U_DEVICE_IDS` is the precise alternative when you want to pin the runtime to specific event paths, Bluetooth MACs, or case-insensitive device-name fragments.
-- `B2U_GRAB_DEVICES=1` grabs the selected input devices so the Pi stops consuming their local events.
+- `B2U_GRAB_DEVICES=true` grabs the selected input devices so the Pi stops consuming their local events.
 - `B2U_INTERRUPT_SHORTCUT=CTRL+SHIFT+F12` defines a plus-separated key chord that toggles relaying on and off at runtime.
-- `B2U_LOG_TO_FILE=0` disables file logging by default.
+- `B2U_LOG_TO_FILE=false` disables file logging by default.
 - `B2U_LOG_PATH=...` controls the file path used when file logging is enabled.
-- `B2U_DEBUG=0` keeps normal log verbosity.
+- `B2U_DEBUG=false` keeps normal log verbosity.
 - `B2U_UDC_PATH` is optional and only needed if you must pin UDC detection on a system with multiple gadget-capable controllers.
 
 After editing that file, restart the service:

--- a/docs/pi-host-relay-loopback-test-playbook.md
+++ b/docs/pi-host-relay-loopback-test-playbook.md
@@ -18,7 +18,7 @@ This validates the path:
 
 - the Pi is connected to the host through the OTG-capable data path
 - `bluetooth_2_usb.service` is active on the Pi
-- `B2U_AUTO_DISCOVER=1` is enabled in `/etc/default/bluetooth_2_usb`
+- `B2U_AUTO_DISCOVER=true` is enabled in `/etc/default/bluetooth_2_usb`
 - `/dev/uinput` exists on the Pi
 - the host Python environment has `hidapi` installed for gadget discovery
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -79,6 +79,9 @@ ok "Virtual environment updated at ${VENV_DIR}"
 install_service_unit
 write_default_env_file
 normalize_runtime_env_file
+if ! "${VENV_DIR}/bin/python" -m bluetooth_2_usb.service_config --canonicalize-bools >/dev/null; then
+  fail "Runtime config boolean canonicalization failed for ${B2U_ENV_FILE}."
+fi
 if ! "${VENV_DIR}/bin/python" -m bluetooth_2_usb.service_config --check >/dev/null; then
   fail "Runtime config validation failed for ${B2U_ENV_FILE}. Expected the structured B2U_* format."
 fi

--- a/scripts/lib/install.sh
+++ b/scripts/lib/install.sh
@@ -35,13 +35,13 @@ write_default_env_file() {
   if [[ ! -f "$B2U_ENV_FILE" ]]; then
     cat >"$B2U_ENV_FILE" <<'EOF'
 # Structured runtime configuration for bluetooth_2_usb.service.
-B2U_AUTO_DISCOVER=1
+B2U_AUTO_DISCOVER=true
 B2U_DEVICE_IDS=
-B2U_GRAB_DEVICES=1
+B2U_GRAB_DEVICES=true
 B2U_INTERRUPT_SHORTCUT=CTRL+SHIFT+F12
-B2U_LOG_TO_FILE=0
+B2U_LOG_TO_FILE=false
 B2U_LOG_PATH=/var/log/bluetooth_2_usb/bluetooth_2_usb.log
-B2U_DEBUG=0
+B2U_DEBUG=false
 B2U_UDC_PATH=
 EOF
     chmod 0644 "$B2U_ENV_FILE"

--- a/src/bluetooth_2_usb/service_config.py
+++ b/src/bluetooth_2_usb/service_config.py
@@ -9,6 +9,18 @@ from pathlib import Path
 
 DEFAULT_ENV_FILE = Path("/etc/default/bluetooth_2_usb")
 DEFAULT_LOG_PATH = "/var/log/bluetooth_2_usb/bluetooth_2_usb.log"
+BOOL_KEYS = {
+    "B2U_AUTO_DISCOVER",
+    "B2U_GRAB_DEVICES",
+    "B2U_LOG_TO_FILE",
+    "B2U_DEBUG",
+}
+ALLOWED_KEYS = BOOL_KEYS | {
+    "B2U_INTERRUPT_SHORTCUT",
+    "B2U_LOG_PATH",
+    "B2U_DEVICE_IDS",
+    "B2U_UDC_PATH",
+}
 
 
 class ServiceConfigError(ValueError):
@@ -60,21 +72,14 @@ def _parse_device_ids(raw_value: str) -> list[str]:
     ]
 
 
+def _canonical_bool(value: bool) -> str:
+    return "true" if value else "false"
+
+
 def load_service_config(env_file: Path = DEFAULT_ENV_FILE) -> ServiceConfig:
     config = ServiceConfig()
     if not env_file.exists():
         return config
-
-    allowed_keys = {
-        "B2U_AUTO_DISCOVER",
-        "B2U_GRAB_DEVICES",
-        "B2U_INTERRUPT_SHORTCUT",
-        "B2U_LOG_TO_FILE",
-        "B2U_LOG_PATH",
-        "B2U_DEBUG",
-        "B2U_DEVICE_IDS",
-        "B2U_UDC_PATH",
-    }
 
     for line_number, raw_line in enumerate(
         env_file.read_text(encoding="utf-8").splitlines(), start=1
@@ -90,7 +95,7 @@ def load_service_config(env_file: Path = DEFAULT_ENV_FILE) -> ServiceConfig:
 
         key, raw_value = raw_line.split("=", 1)
         key = key.strip()
-        if key not in allowed_keys:
+        if key not in ALLOWED_KEYS:
             raise ServiceConfigError(
                 f"{env_file}:{line_number}: unexpected key {key!r} in runtime config"
             )
@@ -114,6 +119,53 @@ def load_service_config(env_file: Path = DEFAULT_ENV_FILE) -> ServiceConfig:
             config.udc_path = value
 
     return config
+
+
+def canonicalize_service_config_bools(env_file: Path = DEFAULT_ENV_FILE) -> bool:
+    if not env_file.exists():
+        return False
+
+    original_text = env_file.read_text(encoding="utf-8")
+    updated_lines: list[str] = []
+    changed = False
+
+    for line_number, raw_line in enumerate(original_text.splitlines(), start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            updated_lines.append(raw_line)
+            continue
+
+        if "=" not in raw_line:
+            raise ServiceConfigError(
+                f"{env_file}:{line_number}: expected KEY=value, got {raw_line!r}"
+            )
+
+        key, raw_value = raw_line.split("=", 1)
+        key = key.strip()
+        if key not in ALLOWED_KEYS:
+            raise ServiceConfigError(
+                f"{env_file}:{line_number}: unexpected key {key!r} in runtime config"
+            )
+
+        if key not in BOOL_KEYS:
+            updated_lines.append(raw_line)
+            continue
+
+        canonical_line = (
+            f"{key}={_canonical_bool(_parse_bool(_parse_value(raw_value), key))}"
+        )
+        updated_lines.append(canonical_line)
+        if canonical_line != raw_line:
+            changed = True
+
+    if not changed:
+        return False
+
+    updated_text = "\n".join(updated_lines)
+    if original_text.endswith("\n"):
+        updated_text += "\n"
+    env_file.write_text(updated_text, encoding="utf-8")
+    return True
 
 
 def build_cli_argv(config: ServiceConfig, *, append_debug: bool = False) -> list[str]:
@@ -165,6 +217,11 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Print the parsed config as JSON.",
     )
+    group.add_argument(
+        "--canonicalize-bools",
+        action="store_true",
+        help="Rewrite boolean values in place using canonical true/false values.",
+    )
     parser.add_argument(
         "--executable",
         default=f"{sys.executable} -m bluetooth_2_usb",
@@ -197,6 +254,9 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     if args.print_summary_json:
         print(json.dumps(config.to_dict(), sort_keys=True))
+        return 0
+    if args.canonicalize_bools:
+        canonicalize_service_config_bools()
         return 0
 
     return 1

--- a/src/bluetooth_2_usb/service_config.py
+++ b/src/bluetooth_2_usb/service_config.py
@@ -15,6 +15,16 @@ BOOL_KEYS = {
     "B2U_LOG_TO_FILE",
     "B2U_DEBUG",
 }
+RUNTIME_ENV_KEY_ORDER = (
+    "B2U_AUTO_DISCOVER",
+    "B2U_DEVICE_IDS",
+    "B2U_GRAB_DEVICES",
+    "B2U_INTERRUPT_SHORTCUT",
+    "B2U_LOG_TO_FILE",
+    "B2U_LOG_PATH",
+    "B2U_DEBUG",
+    "B2U_UDC_PATH",
+)
 ALLOWED_KEYS = BOOL_KEYS | {
     "B2U_INTERRUPT_SHORTCUT",
     "B2U_LOG_PATH",
@@ -76,6 +86,30 @@ def _canonical_bool(value: bool) -> str:
     return "true" if value else "false"
 
 
+def _quote_if_needed(value: str) -> str:
+    return shlex.join([value]) if value else ""
+
+
+def _canonical_value_for_key(key: str, config: ServiceConfig) -> str:
+    if key == "B2U_AUTO_DISCOVER":
+        return _canonical_bool(config.auto_discover)
+    if key == "B2U_DEVICE_IDS":
+        return _quote_if_needed(", ".join(config.device_ids))
+    if key == "B2U_GRAB_DEVICES":
+        return _canonical_bool(config.grab_devices)
+    if key == "B2U_INTERRUPT_SHORTCUT":
+        return config.interrupt_shortcut
+    if key == "B2U_LOG_TO_FILE":
+        return _canonical_bool(config.log_to_file)
+    if key == "B2U_LOG_PATH":
+        return _quote_if_needed(config.log_path)
+    if key == "B2U_DEBUG":
+        return _canonical_bool(config.debug)
+    if key == "B2U_UDC_PATH":
+        return _quote_if_needed(config.udc_path)
+    raise ServiceConfigError(f"Unexpected runtime config key: {key!r}")
+
+
 def load_service_config(env_file: Path = DEFAULT_ENV_FILE) -> ServiceConfig:
     config = ServiceConfig()
     if not env_file.exists():
@@ -126,13 +160,23 @@ def canonicalize_service_config_bools(env_file: Path = DEFAULT_ENV_FILE) -> bool
         return False
 
     original_text = env_file.read_text(encoding="utf-8")
-    updated_lines: list[str] = []
-    changed = False
+    config = load_service_config(env_file)
+    leading_lines: list[str] = []
+    trailing_lines: list[str] = []
+    seen_key = False
 
     for line_number, raw_line in enumerate(original_text.splitlines(), start=1):
         line = raw_line.strip()
-        if not line or line.startswith("#"):
-            updated_lines.append(raw_line)
+        if not line:
+            if not seen_key:
+                leading_lines.append(raw_line)
+            continue
+
+        if line.startswith("#"):
+            if seen_key:
+                trailing_lines.append(raw_line)
+            else:
+                leading_lines.append(raw_line)
             continue
 
         if "=" not in raw_line:
@@ -146,24 +190,23 @@ def canonicalize_service_config_bools(env_file: Path = DEFAULT_ENV_FILE) -> bool
             raise ServiceConfigError(
                 f"{env_file}:{line_number}: unexpected key {key!r} in runtime config"
             )
+        seen_key = True
 
-        if key not in BOOL_KEYS:
-            updated_lines.append(raw_line)
-            continue
-
-        canonical_line = (
-            f"{key}={_canonical_bool(_parse_bool(_parse_value(raw_value), key))}"
-        )
-        updated_lines.append(canonical_line)
-        if canonical_line != raw_line:
-            changed = True
-
-    if not changed:
-        return False
-
+    updated_lines = [
+        *leading_lines,
+        *[
+            f"{key}={_canonical_value_for_key(key, config)}"
+            for key in RUNTIME_ENV_KEY_ORDER
+        ],
+        *trailing_lines,
+    ]
     updated_text = "\n".join(updated_lines)
     if original_text.endswith("\n"):
         updated_text += "\n"
+
+    if updated_text == original_text:
+        return False
+
     env_file.write_text(updated_text, encoding="utf-8")
     return True
 

--- a/tests/test_service_config.py
+++ b/tests/test_service_config.py
@@ -6,6 +6,7 @@ from bluetooth_2_usb.service_config import (
     ServiceConfigError,
     build_cli_argv,
     build_shell_command,
+    canonicalize_service_config_bools,
     load_service_config,
 )
 
@@ -40,6 +41,33 @@ class ServiceConfigTest(unittest.TestCase):
         self.assertTrue(config.debug)
         self.assertEqual(config.device_ids, ["mouse", "keyboard"])
         self.assertEqual(config.udc_path, "/tmp/udc")
+
+    def test_loads_multiple_boolean_spellings(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env_file = Path(tmpdir) / "bluetooth_2_usb"
+            env_file.write_text(
+                "\n".join(
+                    [
+                        "B2U_AUTO_DISCOVER=false",
+                        "B2U_GRAB_DEVICES=yes",
+                        "B2U_INTERRUPT_SHORTCUT=CTRL+SHIFT+F12",
+                        "B2U_LOG_TO_FILE=on",
+                        "B2U_LOG_PATH=/tmp/debug.log",
+                        "B2U_DEBUG=no",
+                        "B2U_DEVICE_IDS=",
+                        "B2U_UDC_PATH=",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            config = load_service_config(env_file)
+
+        self.assertFalse(config.auto_discover)
+        self.assertTrue(config.grab_devices)
+        self.assertTrue(config.log_to_file)
+        self.assertFalse(config.debug)
 
     def test_unknown_key_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -100,3 +128,53 @@ class ServiceConfigTest(unittest.TestCase):
             argv = build_cli_argv(config)
 
         self.assertNotIn("--hid-profile", argv)
+
+    def test_canonicalize_service_config_bools_rewrites_bool_values(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env_file = Path(tmpdir) / "bluetooth_2_usb"
+            env_file.write_text(
+                "\n".join(
+                    [
+                        "# Managed runtime config",
+                        "B2U_AUTO_DISCOVER=1",
+                        "",
+                        "B2U_DEVICE_IDS='MX Keys'",
+                        "B2U_GRAB_DEVICES=yes",
+                        "B2U_LOG_TO_FILE=off",
+                        "B2U_DEBUG=0",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            changed = canonicalize_service_config_bools(env_file)
+
+            self.assertTrue(changed)
+            self.assertEqual(
+                env_file.read_text(encoding="utf-8"),
+                "\n".join(
+                    [
+                        "# Managed runtime config",
+                        "B2U_AUTO_DISCOVER=true",
+                        "",
+                        "B2U_DEVICE_IDS='MX Keys'",
+                        "B2U_GRAB_DEVICES=true",
+                        "B2U_LOG_TO_FILE=false",
+                        "B2U_DEBUG=false",
+                    ]
+                )
+                + "\n",
+            )
+
+    def test_canonicalize_service_config_bools_preserves_canonical_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env_file = Path(tmpdir) / "bluetooth_2_usb"
+            env_file.write_text(
+                "B2U_AUTO_DISCOVER=true\nB2U_GRAB_DEVICES=true\n",
+                encoding="utf-8",
+            )
+
+            changed = canonicalize_service_config_bools(env_file)
+
+        self.assertFalse(changed)

--- a/tests/test_service_config.py
+++ b/tests/test_service_config.py
@@ -138,10 +138,10 @@ class ServiceConfigTest(unittest.TestCase):
                         "# Managed runtime config",
                         "B2U_AUTO_DISCOVER=1",
                         "",
-                        "B2U_DEVICE_IDS='MX Keys'",
                         "B2U_GRAB_DEVICES=yes",
                         "B2U_LOG_TO_FILE=off",
                         "B2U_DEBUG=0",
+                        "B2U_DEVICE_IDS='MX Keys'",
                     ]
                 )
                 + "\n",
@@ -157,11 +157,13 @@ class ServiceConfigTest(unittest.TestCase):
                     [
                         "# Managed runtime config",
                         "B2U_AUTO_DISCOVER=true",
-                        "",
                         "B2U_DEVICE_IDS='MX Keys'",
                         "B2U_GRAB_DEVICES=true",
+                        "B2U_INTERRUPT_SHORTCUT=CTRL+SHIFT+F12",
                         "B2U_LOG_TO_FILE=false",
+                        "B2U_LOG_PATH=/var/log/bluetooth_2_usb/bluetooth_2_usb.log",
                         "B2U_DEBUG=false",
+                        "B2U_UDC_PATH=",
                     ]
                 )
                 + "\n",
@@ -171,7 +173,19 @@ class ServiceConfigTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             env_file = Path(tmpdir) / "bluetooth_2_usb"
             env_file.write_text(
-                "B2U_AUTO_DISCOVER=true\nB2U_GRAB_DEVICES=true\n",
+                "\n".join(
+                    [
+                        "B2U_AUTO_DISCOVER=true",
+                        "B2U_DEVICE_IDS=",
+                        "B2U_GRAB_DEVICES=true",
+                        "B2U_INTERRUPT_SHORTCUT=CTRL+SHIFT+F12",
+                        "B2U_LOG_TO_FILE=false",
+                        "B2U_LOG_PATH=/var/log/bluetooth_2_usb/bluetooth_2_usb.log",
+                        "B2U_DEBUG=false",
+                        "B2U_UDC_PATH=",
+                    ]
+                )
+                + "\n",
                 encoding="utf-8",
             )
 


### PR DESCRIPTION
## Summary
- write managed runtime booleans as lowercase `true` and `false`
- keep parser compatibility with legacy boolean spellings
- canonicalize managed env output while preserving comments
- normalize managed env key order so `B2U_DEVICE_IDS` follows `B2U_AUTO_DISCOVER`
- update docs and examples to the canonical boolean style

## Testing
- `black --check src tests`
- `ruff check src tests`
- `python -m unittest discover -s tests -v`
- `shfmt -d -i 2 -ci -bn scripts/*.sh scripts/lib/*.sh`
- `shellcheck -x scripts/*.sh scripts/lib/*.sh`
- `bash -n scripts/*.sh scripts/lib/*.sh`
- Pi validation on `pi4b`
- `sudo /opt/bluetooth_2_usb/scripts/install.sh`
- `sudo /opt/bluetooth_2_usb/scripts/smoke_test.sh --verbose`
- inspect `/etc/default/bluetooth_2_usb` and CLI help ordering