### PR TITLE
fix: reuse bluetoothctl output in smoke test

### DIFF
--- a/scripts/lib/bluetooth.sh
+++ b/scripts/lib/bluetooth.sh
@@ -24,12 +24,23 @@ btmgmt_info() {
   btmgmt info
 }
 
+_bluetooth_controller_powered_from_stream() {
+  grep -Eq '^[[:space:]]*Powered:[[:space:]]+yes$'
+}
+
 bluetooth_rfkill_root() {
   printf '%s\n' "${B2U_RFKILL_ROOT:-/sys/class/rfkill}"
 }
 
 bluetooth_controller_powered() {
-  bluetoothctl_show 2>/dev/null | grep -Eq '^[[:space:]]*Powered:[[:space:]]+yes$'
+  bluetoothctl_show 2>/dev/null | _bluetooth_controller_powered_from_stream
+}
+
+bluetooth_controller_powered_from_file() {
+  local path="$1"
+
+  [[ -f "$path" ]] || return 1
+  _bluetooth_controller_powered_from_stream <"$path"
 }
 
 bluetooth_paired_count() {

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -206,7 +206,7 @@ else
 fi
 
 if bluetoothctl_show >"$BLUETOOTH_SHOW_LOG" 2>&1; then
-  if bluetooth_controller_powered; then
+  if bluetooth_controller_powered_from_file "$BLUETOOTH_SHOW_LOG"; then
     ok "Bluetooth controller is powered"
   else
     warn "Bluetooth controller is visible but not powered"


### PR DESCRIPTION
## Summary
- reuse the already captured `bluetoothctl show` output when evaluating controller power during `smoke_test.sh`
- avoid a second live `bluetoothctl show` call that can intermittently disagree with the logged output on `pi0w`

## Validation
- `bash -n scripts/*.sh scripts/lib/*.sh`
- `shellcheck -x scripts/*.sh scripts/lib/*.sh`
- repeated `smoke_test.sh` runs on `pi0w`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced Bluetooth controller status verification mechanisms in internal testing tools for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->