### PR TITLE
docs: add Pi connectivity recovery playbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,10 @@ Use `smoke_test.sh` as the quick health gate and `debug.sh` as the fuller redact
 
 For a real end-to-end relay check without depending on a paired Bluetooth device, use the host/Pi loopback harness in `docs/pi-host-relay-loopback-test-playbook.md`.
 
+If the problem is workstation-to-Pi reachability itself rather than the relay
+service, start with `docs/pi-connectivity-troubleshooting.md` and then use
+`docs/pi-connectivity-recovery-playbook.md` for the full recovery flow.
+
 ### The service does not start
 
 ```bash
@@ -552,9 +556,24 @@ findmnt /mnt/b2u-persist
 grep '^B2U_' /etc/default/bluetooth_2_usb_readonly
 ```
 
+### SSH, ping, or DNS access to the Pi is flaky
+
+If `ssh pi-host` times out, `ping pi-host` is misleading, or the Pi only works
+through an IPv6 link-local address with `%interface`, do not keep debugging the
+service blindly.
+
+This has repeatedly turned out to be a workstation-to-Pi connectivity problem
+rather than a `bluetooth_2_usb` runtime bug.
+
+Start with the short classification guide in
+`docs/pi-connectivity-troubleshooting.md`, then run the full recovery flow in
+`docs/pi-connectivity-recovery-playbook.md`.
+
 ## Script reference
 
-All managed deployment scripts live in `/opt/bluetooth_2_usb/scripts/` after installation.
+Managed deployment scripts live in `/opt/bluetooth_2_usb/scripts/` after
+installation. The host-side helper `scripts/check_pi_connectivity.sh` is meant
+to be run from a workstation checkout instead.
 
 ### `install.sh`
 
@@ -661,6 +680,22 @@ Install the Linux host-side udev rule that grants `hidapi` write access to the U
 | --- | --- |
 | none | Linux only. Run once on the receiving host. Example: `sudo ./scripts/install_host_hidapi_udev_rule.sh`. |
 
+### `check_pi_connectivity.sh`
+
+Workstation-side probe for Raspberry Pi SSH, mDNS, and IPv6 link-local
+reachability. It is intended for recurring cases where the Pi is reachable but
+plain hostname SSH or IPv4 behaves inconsistently. The script does not mutate
+SSH configuration; it prints a recommended `~/.ssh/config` block when a scoped
+link-local probe succeeds.
+
+| Argument | Explanation / Example |
+| --- | --- |
+| `--host HOST` | Required Pi hostname or SSH alias to probe. Example: `./scripts/check_pi_connectivity.sh --host pi0w`. |
+| `--user USER` | SSH user. Default: current local user. |
+| `--link-local IPV6` | Known Pi link-local IPv6 address without `%scope`. |
+| `--interface IFACE` | Workstation network interface used with `--link-local`. Example: `wlp38s0`. |
+| `--timeout SEC` | Connect timeout for ping and SSH probes. Default: `5`. |
+
 ### `setup_persistent_bluetooth_state.sh`
 
 Prepare the writable ext4-backed storage for `/var/lib/bluetooth` before enabling OverlayFS.
@@ -699,6 +734,8 @@ Release tagging and versioning rules are documented in [docs/release-versioning-
 For practical validation and debugging workflows, also see:
 
 - [docs/pi-cli-service-test-playbook.md](docs/pi-cli-service-test-playbook.md)
+- [docs/pi-connectivity-troubleshooting.md](docs/pi-connectivity-troubleshooting.md)
+- [docs/pi-connectivity-recovery-playbook.md](docs/pi-connectivity-recovery-playbook.md)
 - [docs/pi-host-relay-loopback-test-playbook.md](docs/pi-host-relay-loopback-test-playbook.md)
 - [docs/pi-manual-test-plan.md](docs/pi-manual-test-plan.md)
 - [docs/doc-consistency-review-playbook.md](docs/doc-consistency-review-playbook.md)

--- a/docs/doc-consistency-review-playbook.md
+++ b/docs/doc-consistency-review-playbook.md
@@ -44,7 +44,8 @@ For each file under `docs/`, verify that:
 ### 2. Script interfaces
 
 Compare the docs against the current `--help` output of all managed scripts and
-wrapper entrypoints:
+wrapper entrypoints, plus any workstation-side helpers documented in
+`README.md`:
 
 ```bash
 for s in \
@@ -55,6 +56,7 @@ for s in \
   scripts/smoke_test.sh \
   scripts/pi_relay_test_inject.sh \
   scripts/host_relay_test_capture.sh \
+  scripts/check_pi_connectivity.sh \
   scripts/install_host_hidapi_udev_rule.sh \
   scripts/enable_readonly_overlayfs.sh \
   scripts/disable_readonly_overlayfs.sh \

--- a/docs/pi-cli-service-test-playbook.md
+++ b/docs/pi-cli-service-test-playbook.md
@@ -15,12 +15,14 @@ It is intentionally focused on:
 ## Assumptions
 
 - workstation has `git` and SSH access to the Pi
+- if plain hostname access is flaky, resolve that first with
+  `docs/pi-connectivity-recovery-playbook.md`
 - the Pi user has passwordless sudo:
 
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
 
-ssh -4 "$PI_HOST" 'sudo -n true'
+ssh "$PI_HOST" 'sudo -n true'
 ```
 
 ## Prepare the checkout on the Pi
@@ -34,7 +36,7 @@ Lite, install it first:
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
 
-ssh -4 "$PI_HOST" 'sudo -n apt update && sudo -n apt install -y git'
+ssh "$PI_HOST" 'sudo -n apt update && sudo -n apt install -y git'
 ```
 
 For a test branch:
@@ -43,7 +45,7 @@ For a test branch:
 PI_HOST="${PI_HOST:-your-pi-host}"
 BRANCH="${BRANCH:-main}"
 
-ssh -4 "$PI_HOST" "
+ssh "$PI_HOST" "
   sudo -n rm -rf /opt/bluetooth_2_usb &&
   sudo -n git clone https://github.com/quaxalber/bluetooth_2_usb.git /opt/bluetooth_2_usb &&
   sudo -n git -C /opt/bluetooth_2_usb checkout \"${BRANCH}\"
@@ -57,7 +59,7 @@ Run this before mutating the system:
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
 
-ssh -4 "$PI_HOST" '
+ssh "$PI_HOST" '
   echo SERVICE=$(systemctl is-active bluetooth_2_usb.service || true)
   echo OVERLAY=$(sudo -n raspi-config nonint get_overlay_now 2>/dev/null || echo unknown)
   echo ROOT=$(findmnt -no FSTYPE,OPTIONS /)
@@ -70,7 +72,7 @@ ssh -4 "$PI_HOST" '
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
 
-ssh -4 "$PI_HOST" '
+ssh "$PI_HOST" '
   bash /opt/bluetooth_2_usb/scripts/install.sh --help >/dev/null
   bash /opt/bluetooth_2_usb/scripts/update.sh --help >/dev/null
   bash /opt/bluetooth_2_usb/scripts/uninstall.sh --help >/dev/null
@@ -88,7 +90,7 @@ ssh -4 "$PI_HOST" '
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
 
-ssh -4 "$PI_HOST" '
+ssh "$PI_HOST" '
   sudo -n /opt/bluetooth_2_usb/scripts/install.sh
 '
 ```
@@ -98,8 +100,8 @@ Reboot and wait for SSH:
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
 
-ssh -4 "$PI_HOST" 'sudo -n reboot' || true
-until ssh -4 -o ConnectTimeout=5 "$PI_HOST" 'true' 2>/dev/null; do sleep 2; done
+ssh "$PI_HOST" 'sudo -n reboot' || true
+until ssh -o ConnectTimeout=5 "$PI_HOST" 'true' 2>/dev/null; do sleep 2; done
 ```
 
 After reboot, verify:
@@ -107,7 +109,7 @@ After reboot, verify:
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
 
-ssh -4 "$PI_HOST" '
+ssh "$PI_HOST" '
   systemctl is-active bluetooth_2_usb.service
   sudo -n /opt/bluetooth_2_usb/scripts/smoke_test.sh --verbose
   sudo -n bluetoothctl show
@@ -129,7 +131,7 @@ The supported update model is the managed update wrapper:
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
 
-ssh -4 "$PI_HOST" '
+ssh "$PI_HOST" '
   sudo -n /opt/bluetooth_2_usb/scripts/update.sh
 '
 ```
@@ -142,8 +144,8 @@ Reboot and wait for SSH so the update path is validated against the next boot:
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
 
-ssh -4 "$PI_HOST" 'sudo -n reboot' || true
-until ssh -4 -o ConnectTimeout=5 "$PI_HOST" 'true' 2>/dev/null; do sleep 2; done
+ssh "$PI_HOST" 'sudo -n reboot' || true
+until ssh -o ConnectTimeout=5 "$PI_HOST" 'true' 2>/dev/null; do sleep 2; done
 ```
 
 After reboot, verify:
@@ -151,7 +153,7 @@ After reboot, verify:
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
 
-ssh -4 "$PI_HOST" '
+ssh "$PI_HOST" '
   systemctl is-active bluetooth_2_usb.service
   sudo -n /opt/bluetooth_2_usb/scripts/smoke_test.sh --verbose
   sudo -n bluetoothctl show
@@ -173,7 +175,7 @@ Bounded run:
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
 
-ssh -4 "$PI_HOST" '
+ssh "$PI_HOST" '
   sudo -n /opt/bluetooth_2_usb/scripts/debug.sh --duration 5
 '
 ```
@@ -183,7 +185,7 @@ Manual interrupt path:
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
 
-ssh -4 -t "$PI_HOST" '
+ssh -t "$PI_HOST" '
   sudo -n /opt/bluetooth_2_usb/scripts/debug.sh
 '
 ```
@@ -203,7 +205,7 @@ Start by recording the current baseline:
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
 
-ssh -4 "$PI_HOST" '
+ssh "$PI_HOST" '
   cd /opt/bluetooth_2_usb &&
   sudo -n git -c safe.directory=/opt/bluetooth_2_usb rev-parse --abbrev-ref HEAD &&
   sudo -n git -c safe.directory=/opt/bluetooth_2_usb status --short &&
@@ -219,7 +221,7 @@ Preview the boot optimization changes:
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
 
-ssh -4 "$PI_HOST" '
+ssh "$PI_HOST" '
   sudo -n /opt/bluetooth_2_usb/scripts/optimize_pi_boot.sh --dry-run --static-ip auto
 '
 ```
@@ -229,10 +231,10 @@ Apply the changes and allow the script to reboot the Pi:
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
 
-ssh -4 "$PI_HOST" '
+ssh "$PI_HOST" '
   sudo -n /opt/bluetooth_2_usb/scripts/optimize_pi_boot.sh --static-ip auto
 ' || true
-until ssh -4 -o ConnectTimeout=5 "$PI_HOST" 'true' 2>/dev/null; do sleep 2; done
+until ssh -o ConnectTimeout=5 "$PI_HOST" 'true' 2>/dev/null; do sleep 2; done
 ```
 
 After reboot, verify:
@@ -240,7 +242,7 @@ After reboot, verify:
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
 
-ssh -4 "$PI_HOST" '
+ssh "$PI_HOST" '
   systemctl is-active bluetooth.service
   systemctl is-active bluetooth_2_usb.service
   sudo -n /opt/bluetooth_2_usb/scripts/smoke_test.sh --verbose
@@ -256,7 +258,7 @@ Explicitly test the shorter service stop timeout:
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
 
-ssh -4 "$PI_HOST" '
+ssh "$PI_HOST" '
   sudo -n systemctl restart bluetooth_2_usb.service
   sudo -n journalctl -u bluetooth_2_usb.service -n 50 --no-pager
 '
@@ -267,10 +269,10 @@ If the optimized host state regresses, rollback and reboot:
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
 
-ssh -4 "$PI_HOST" '
+ssh "$PI_HOST" '
   sudo -n /opt/bluetooth_2_usb/scripts/optimize_pi_boot.sh --rollback
 ' || true
-until ssh -4 -o ConnectTimeout=5 "$PI_HOST" 'true' 2>/dev/null; do sleep 2; done
+until ssh -o ConnectTimeout=5 "$PI_HOST" 'true' 2>/dev/null; do sleep 2; done
 ```
 
 Before ending the session, return the Pi checkout to `main` and validate again:
@@ -278,7 +280,7 @@ Before ending the session, return the Pi checkout to `main` and validate again:
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
 
-ssh -4 "$PI_HOST" '
+ssh "$PI_HOST" '
   cd /opt/bluetooth_2_usb &&
   sudo -n git -c safe.directory=/opt/bluetooth_2_usb checkout main &&
   sudo -n git -c safe.directory=/opt/bluetooth_2_usb pull --ff-only origin main &&
@@ -303,7 +305,7 @@ Prepare the writable ext4 partition:
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
 
-ssh -4 "$PI_HOST" '
+ssh "$PI_HOST" '
   sudo -n /opt/bluetooth_2_usb/scripts/setup_persistent_bluetooth_state.sh --device /dev/YOUR-PARTITION
   sudo -n /opt/bluetooth_2_usb/scripts/enable_readonly_overlayfs.sh
 '
@@ -314,8 +316,8 @@ Reboot and wait for SSH after `enable_readonly_overlayfs.sh`:
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
 
-ssh -4 "$PI_HOST" 'sudo -n reboot' || true
-until ssh -4 -o ConnectTimeout=5 "$PI_HOST" 'true' 2>/dev/null; do sleep 2; done
+ssh "$PI_HOST" 'sudo -n reboot' || true
+until ssh -o ConnectTimeout=5 "$PI_HOST" 'true' 2>/dev/null; do sleep 2; done
 ```
 
 After reboot:
@@ -323,7 +325,7 @@ After reboot:
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
 
-ssh -4 "$PI_HOST" '
+ssh "$PI_HOST" '
   sudo -n /opt/bluetooth_2_usb/scripts/smoke_test.sh --verbose
   findmnt /var/lib/bluetooth
   findmnt /mnt/b2u-persist
@@ -335,7 +337,7 @@ Disable read-only mode again:
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
 
-ssh -4 "$PI_HOST" '
+ssh "$PI_HOST" '
   sudo -n /opt/bluetooth_2_usb/scripts/disable_readonly_overlayfs.sh
 '
 ```
@@ -345,8 +347,8 @@ Reboot and wait for SSH after `disable_readonly_overlayfs.sh`:
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
 
-ssh -4 "$PI_HOST" 'sudo -n reboot' || true
-until ssh -4 -o ConnectTimeout=5 "$PI_HOST" 'true' 2>/dev/null; do sleep 2; done
+ssh "$PI_HOST" 'sudo -n reboot' || true
+until ssh -o ConnectTimeout=5 "$PI_HOST" 'true' 2>/dev/null; do sleep 2; done
 ```
 
 ## Uninstall validation
@@ -354,7 +356,7 @@ until ssh -4 -o ConnectTimeout=5 "$PI_HOST" 'true' 2>/dev/null; do sleep 2; done
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
 
-ssh -4 "$PI_HOST" '
+ssh "$PI_HOST" '
   sudo -n /opt/bluetooth_2_usb/scripts/uninstall.sh
   systemctl is-active bluetooth_2_usb.service || true
   systemctl show -P LoadState bluetooth_2_usb.service
@@ -378,7 +380,7 @@ For each run, record:
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
 
-ssh -4 "$PI_HOST" '
+ssh "$PI_HOST" '
   uname -a
   cat /etc/os-release
   echo SERVICE=$(systemctl is-active bluetooth_2_usb.service || true)

--- a/docs/pi-connectivity-recovery-playbook.md
+++ b/docs/pi-connectivity-recovery-playbook.md
@@ -1,0 +1,190 @@
+# Pi Connectivity Recovery Playbook
+
+Use this playbook when a Raspberry Pi used for `bluetooth_2_usb` is flaky or
+unreachable over SSH, especially when plain hostnames or IPv4 look broken but
+the Pi is likely still on the local network.
+
+This playbook is intentionally focused on:
+
+- SSH reachability from the workstation to the Pi
+- hostname, mDNS, and IPv6 link-local diagnosis
+- recurring Wi-Fi stability issues on Raspberry Pi OS with NetworkManager
+- minimal host-side fixes that make repeated remote validation reliable again
+
+## Assumptions
+
+- the workstation and Pi are on the same local network
+- the workstation knows which network interface reaches the Pi, for example
+  `wlp38s0`
+- the Pi user can authenticate over SSH
+- passwordless sudo is strongly recommended for repeatable agentic work and
+  remote validation:
+
+```bash
+PI_HOST="${PI_HOST:-your-pi-host}"
+
+ssh "$PI_HOST" 'sudo -n true'
+```
+
+## 1. Check the workstation view first
+
+Start on the workstation, not on the Pi.
+
+```bash
+PI_HOST="${PI_HOST:-your-pi-host}"
+
+getent hosts "$PI_HOST" || true
+getent ahosts "$PI_HOST" || true
+avahi-resolve -n "${PI_HOST}.local" 2>/dev/null || true
+ip -6 addr show dev wlp38s0
+```
+
+Interpretation:
+
+- if `getent` only shows a bare `fe80::...` address, SSH still needs an
+  interface scope such as `%wlp38s0`
+- if `PI_HOST.local` resolves but `PI_HOST` does not, mDNS is healthier than
+  the local DNS search path
+- if the workstation interface does not have its own link-local IPv6 address,
+  direct link-local reachability will not work until that interface is up
+
+## 2. Test direct reachability before trusting the hostname
+
+Probe the Pi through the paths that matter most:
+
+```bash
+ping -c 1 "${PI_HOST}.local" || true
+ping -6 -c 1 "fe80::YOUR-PI-LINK-LOCAL%wlp38s0" || true
+ssh -6 "user@fe80::YOUR-PI-LINK-LOCAL%wlp38s0" 'hostname && whoami'
+```
+
+Interpretation:
+
+- a successful link-local IPv6 ping or SSH session is a stronger signal than an
+  IPv4 ping failure on consumer Wi-Fi
+- do not treat missing IPv4 ICMP replies as proof that the Pi is down if
+  link-local SSH still works
+- if direct link-local SSH works, pin that path in `~/.ssh/config` instead of
+  repeatedly relying on ambiguous hostname resolution
+
+## 3. Pin a stable SSH alias
+
+Use a host alias that always resolves to the known-good link-local address and
+interface scope.
+
+```sshconfig
+Host pi0w pi0w.local
+    User user
+    HostName fe80::YOUR-PI-LINK-LOCAL%wlp38s0
+    AddressFamily inet6
+    HostKeyAlias pi0w
+    ConnectTimeout 5
+```
+
+Then validate:
+
+```bash
+ssh pi0w 'hostname && whoami'
+ssh pi0w.local 'hostname && whoami'
+```
+
+`HostKeyAlias` matters here because the same Pi may previously have been known
+under `pi0w`, `pi0w.local`, or a literal address.
+
+## 4. Check Pi-side network stability once SSH works
+
+After reconnecting, inspect the live NetworkManager state:
+
+```bash
+PI_HOST="${PI_HOST:-pi0w}"
+
+ssh "$PI_HOST" '
+  conn="$(nmcli --get-values GENERAL.CONNECTION device show wlan0 | head -n 1)"
+  echo "CONNECTION=${conn}"
+  nmcli device show wlan0
+  echo "---"
+  nmcli -g 802-11-wireless.powersave,ipv4.method,ipv4.gateway,ipv4.dns,ipv4.ignore-auto-dns \
+    connection show "$conn"
+  echo "---"
+  cat /etc/resolv.conf
+'
+```
+
+Look for these recurring failure patterns:
+
+- `802-11-wireless.powersave: 0 (default)` or `enable` instead of an explicit
+  disabled setting
+- only the router IP listed as DNS, for example only `192.168.2.1`
+- a healthy `wlan0` connection but flaky package installs or name resolution
+
+If `iw` is installed, you can also inspect the live Wi-Fi powersave state:
+
+```bash
+ssh "$PI_HOST" 'iw dev wlan0 get power_save'
+```
+
+## 5. Apply the stable NetworkManager profile pattern
+
+The most stable setup in this workspace has been:
+
+- `NetworkManager` managing `wlan0`
+- Wi-Fi powersave disabled
+- explicit IPv4 DNS servers, with the router resolver only as a fallback
+
+Apply that pattern to the active connection:
+
+```bash
+PI_HOST="${PI_HOST:-pi0w}"
+
+ssh "$PI_HOST" '
+  conn="$(nmcli --get-values GENERAL.CONNECTION device show wlan0 | head -n 1)"
+  sudo -n nmcli connection modify "$conn" \
+    802-11-wireless.powersave 2 \
+    ipv4.dns "1.1.1.1,9.9.9.9,192.168.2.1" \
+    ipv4.ignore-auto-dns yes
+  sudo -n nmcli connection up "$conn"
+'
+```
+
+Notes:
+
+- `802-11-wireless.powersave 2` means disabled
+- `connection up` may briefly interrupt SSH while Wi-Fi reconnects
+- reconnect through the pinned link-local SSH alias afterwards
+
+## 6. Re-validate after the profile change
+
+From the workstation:
+
+```bash
+ssh pi0w '
+  conn="$(nmcli --get-values GENERAL.CONNECTION device show wlan0 | head -n 1)"
+  nmcli -g 802-11-wireless.powersave,ipv4.dns,ipv4.ignore-auto-dns connection show "$conn"
+  cat /etc/resolv.conf
+  systemctl is-active bluetooth_2_usb.service
+'
+ping -6 -c 1 "fe80::YOUR-PI-LINK-LOCAL%wlp38s0"
+ping -c 1 pi0w.local || true
+```
+
+On the Pi:
+
+```bash
+sudo /opt/bluetooth_2_usb/scripts/smoke_test.sh --verbose
+sudo /opt/bluetooth_2_usb/scripts/debug.sh --duration 10
+```
+
+If the Pi is still reachable only through the literal link-local address, keep
+the SSH alias and treat that as the supported local-workspace path until the
+underlying LAN naming behavior changes.
+
+## Helper script
+
+For a quick workstation-side diagnosis pass, use:
+
+```bash
+./scripts/check_pi_connectivity.sh --host pi0w --user user --link-local fe80::YOUR-PI-LINK-LOCAL --interface wlp38s0
+```
+
+That helper prints resolver results, ping/SSH probe output, and a ready-to-paste
+SSH config block for the pinned link-local alias.

--- a/docs/pi-connectivity-recovery-playbook.md
+++ b/docs/pi-connectivity-recovery-playbook.md
@@ -22,7 +22,8 @@ This playbook is intentionally focused on:
 
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
-PI_HOST_LOCAL="${PI_HOST_LOCAL:-${PI_HOST}.local}"
+PI_HOST_BASE="${PI_HOST%.local}"
+PI_HOST_LOCAL="${PI_HOST_LOCAL:-${PI_HOST_BASE}.local}"
 PI_USER="${PI_USER:-user}"
 PI_IFACE="${PI_IFACE:-wlp38s0}"
 PI_LINK_LOCAL="${PI_LINK_LOCAL:-fe80::YOUR-PI-LINK-LOCAL}"
@@ -36,7 +37,8 @@ Start on the workstation, not on the Pi.
 
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
-PI_HOST_LOCAL="${PI_HOST_LOCAL:-${PI_HOST}.local}"
+PI_HOST_BASE="${PI_HOST%.local}"
+PI_HOST_LOCAL="${PI_HOST_LOCAL:-${PI_HOST_BASE}.local}"
 PI_IFACE="${PI_IFACE:-wlp38s0}"
 
 getent hosts "$PI_HOST" || true
@@ -60,7 +62,8 @@ Probe the Pi through the paths that matter most:
 
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
-PI_HOST_LOCAL="${PI_HOST_LOCAL:-${PI_HOST}.local}"
+PI_HOST_BASE="${PI_HOST%.local}"
+PI_HOST_LOCAL="${PI_HOST_LOCAL:-${PI_HOST_BASE}.local}"
 PI_USER="${PI_USER:-user}"
 PI_IFACE="${PI_IFACE:-wlp38s0}"
 PI_LINK_LOCAL="${PI_LINK_LOCAL:-fe80::YOUR-PI-LINK-LOCAL}"
@@ -170,7 +173,8 @@ From the workstation:
 
 ```bash
 PI_HOST="${PI_HOST:-pi0w}"
-PI_HOST_LOCAL="${PI_HOST_LOCAL:-${PI_HOST}.local}"
+PI_HOST_BASE="${PI_HOST%.local}"
+PI_HOST_LOCAL="${PI_HOST_LOCAL:-${PI_HOST_BASE}.local}"
 PI_IFACE="${PI_IFACE:-wlp38s0}"
 PI_LINK_LOCAL="${PI_LINK_LOCAL:-fe80::YOUR-PI-LINK-LOCAL}"
 

--- a/docs/pi-connectivity-recovery-playbook.md
+++ b/docs/pi-connectivity-recovery-playbook.md
@@ -22,6 +22,10 @@ This playbook is intentionally focused on:
 
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
+PI_HOST_LOCAL="${PI_HOST_LOCAL:-${PI_HOST}.local}"
+PI_USER="${PI_USER:-user}"
+PI_IFACE="${PI_IFACE:-wlp38s0}"
+PI_LINK_LOCAL="${PI_LINK_LOCAL:-fe80::YOUR-PI-LINK-LOCAL}"
 
 ssh "$PI_HOST" 'sudo -n true'
 ```
@@ -32,11 +36,13 @@ Start on the workstation, not on the Pi.
 
 ```bash
 PI_HOST="${PI_HOST:-your-pi-host}"
+PI_HOST_LOCAL="${PI_HOST_LOCAL:-${PI_HOST}.local}"
+PI_IFACE="${PI_IFACE:-wlp38s0}"
 
 getent hosts "$PI_HOST" || true
 getent ahosts "$PI_HOST" || true
-avahi-resolve -n "${PI_HOST}.local" 2>/dev/null || true
-ip -6 addr show dev wlp38s0
+avahi-resolve -n "${PI_HOST_LOCAL}" 2>/dev/null || true
+ip -6 addr show dev "$PI_IFACE"
 ```
 
 Interpretation:
@@ -53,9 +59,15 @@ Interpretation:
 Probe the Pi through the paths that matter most:
 
 ```bash
-ping -c 1 "${PI_HOST}.local" || true
-ping -6 -c 1 "fe80::YOUR-PI-LINK-LOCAL%wlp38s0" || true
-ssh -6 "user@fe80::YOUR-PI-LINK-LOCAL%wlp38s0" 'hostname && whoami'
+PI_HOST="${PI_HOST:-your-pi-host}"
+PI_HOST_LOCAL="${PI_HOST_LOCAL:-${PI_HOST}.local}"
+PI_USER="${PI_USER:-user}"
+PI_IFACE="${PI_IFACE:-wlp38s0}"
+PI_LINK_LOCAL="${PI_LINK_LOCAL:-fe80::YOUR-PI-LINK-LOCAL}"
+
+ping -c 1 "${PI_HOST_LOCAL}" || true
+ping -6 -c 1 "${PI_LINK_LOCAL}%${PI_IFACE}" || true
+ssh -6 "${PI_USER}@${PI_LINK_LOCAL}%${PI_IFACE}" 'hostname && whoami'
 ```
 
 Interpretation:
@@ -74,8 +86,8 @@ interface scope.
 
 ```sshconfig
 Host pi0w pi0w.local
-    User user
-    HostName fe80::YOUR-PI-LINK-LOCAL%wlp38s0
+    User YOUR-PI-USER
+    HostName fe80::YOUR-PI-LINK-LOCAL%YOUR-WORKSTATION-IFACE
     AddressFamily inet6
     HostKeyAlias pi0w
     ConnectTimeout 5
@@ -157,14 +169,19 @@ Notes:
 From the workstation:
 
 ```bash
-ssh pi0w '
+PI_HOST="${PI_HOST:-pi0w}"
+PI_HOST_LOCAL="${PI_HOST_LOCAL:-${PI_HOST}.local}"
+PI_IFACE="${PI_IFACE:-wlp38s0}"
+PI_LINK_LOCAL="${PI_LINK_LOCAL:-fe80::YOUR-PI-LINK-LOCAL}"
+
+ssh "$PI_HOST" '
   conn="$(nmcli --get-values GENERAL.CONNECTION device show wlan0 | head -n 1)"
   nmcli -g 802-11-wireless.powersave,ipv4.dns,ipv4.ignore-auto-dns connection show "$conn"
   cat /etc/resolv.conf
   systemctl is-active bluetooth_2_usb.service
 '
-ping -6 -c 1 "fe80::YOUR-PI-LINK-LOCAL%wlp38s0"
-ping -c 1 pi0w.local || true
+ping -6 -c 1 "${PI_LINK_LOCAL}%${PI_IFACE}"
+ping -c 1 "${PI_HOST_LOCAL}" || true
 ```
 
 On the Pi:
@@ -183,7 +200,16 @@ underlying LAN naming behavior changes.
 For a quick workstation-side diagnosis pass, use:
 
 ```bash
-./scripts/check_pi_connectivity.sh --host pi0w --user user --link-local fe80::YOUR-PI-LINK-LOCAL --interface wlp38s0
+PI_HOST="${PI_HOST:-pi0w}"
+PI_USER="${PI_USER:-user}"
+PI_IFACE="${PI_IFACE:-wlp38s0}"
+PI_LINK_LOCAL="${PI_LINK_LOCAL:-fe80::YOUR-PI-LINK-LOCAL}"
+
+./scripts/check_pi_connectivity.sh \
+  --host "$PI_HOST" \
+  --user "$PI_USER" \
+  --link-local "$PI_LINK_LOCAL" \
+  --interface "$PI_IFACE"
 ```
 
 That helper prints resolver results, ping/SSH probe output, and a ready-to-paste

--- a/docs/pi-connectivity-troubleshooting.md
+++ b/docs/pi-connectivity-troubleshooting.md
@@ -1,0 +1,42 @@
+# Pi Connectivity Troubleshooting
+
+This note is the short version of recurring Raspberry Pi connectivity failures
+seen during `bluetooth_2_usb` development and validation.
+
+Use it to classify the problem quickly. For the concrete commands and recovery
+sequence, go to [pi-connectivity-recovery-playbook.md](pi-connectivity-recovery-playbook.md).
+
+## Typical symptoms
+
+- `ssh pi-host` times out even though the Pi is probably still on Wi-Fi
+- `ping pi-host` fails, but `ping pi-host.local` or a direct IPv6 address works
+- `ssh` only works when you include an IPv6 link-local scope such as
+  `%wlp38s0`
+- package downloads or `pip install` fail with DNS errors even though the Pi is
+  otherwise online
+- the Pi becomes flaky again after idle time or after reconnecting to Wi-Fi
+
+## What has caused this in practice
+
+- the workstation resolved the Pi hostname to a link-local IPv6 address without
+  the required interface scope
+- SSH relied on an ambiguous hostname instead of a pinned `~/.ssh/config` alias
+- NetworkManager fell back to router-only DNS instead of explicit resolvers
+- Wi-Fi powersave remained at the default behavior instead of being explicitly
+  disabled
+
+## Fast guidance
+
+- prefer a pinned SSH alias that uses the Pi's IPv6 link-local address and the
+  workstation interface scope
+- treat successful link-local SSH as a better health signal than consumer-Wi-Fi
+  IPv4 ping behavior
+- if DNS starts failing, inspect `nmcli device show wlan0` and
+  `/etc/resolv.conf` before blaming Python packaging or the repo
+- for repeatable remote work, make sure the Pi user has passwordless sudo so
+  `sudo -n`-based playbooks and smoke checks do not fail early
+
+## Next step
+
+Run the full recovery flow in
+[pi-connectivity-recovery-playbook.md](pi-connectivity-recovery-playbook.md).

--- a/scripts/check_pi_connectivity.sh
+++ b/scripts/check_pi_connectivity.sh
@@ -91,6 +91,9 @@ require_commands getent ip ping ssh
 if [[ -n "$LINK_LOCAL" && -z "$INTERFACE" ]]; then
   fail "--interface is required when --link-local is set."
 fi
+if [[ -n "$LINK_LOCAL" && "$LINK_LOCAL" == *%* ]]; then
+  fail "--link-local must not include %scope; pass scope via --interface."
+fi
 
 HOST_BASE="${HOST%.local}"
 HOST_LOCAL="${HOST_BASE}.local"
@@ -137,7 +140,7 @@ Host ${HOST_ALIASES}
     HostName ${LINK_LOCAL}%${INTERFACE}
     AddressFamily inet6
     HostKeyAlias ${HOST_BASE}
-    ConnectTimeout 5
+    ConnectTimeout ${TIMEOUT_SEC}
 EOF
   else
     warn "Scoped link-local SSH failed"

--- a/scripts/check_pi_connectivity.sh
+++ b/scripts/check_pi_connectivity.sh
@@ -7,6 +7,9 @@ SCRIPT_DIR="$(cd -- "$(dirname "$0")" && pwd)"
 source "${SCRIPT_DIR}/lib/common.sh"
 
 HOST=""
+HOST_BASE=""
+HOST_LOCAL=""
+HOST_ALIASES=""
 PI_USER="${USER:-user}"
 LINK_LOCAL=""
 INTERFACE=""
@@ -65,6 +68,8 @@ while [[ $# -gt 0 ]]; do
       ;;
     --timeout)
       require_value "$1" "${2:-}"
+      [[ "${2:-}" =~ ^[1-9][0-9]*$ ]] \
+        || fail "--timeout must be a positive integer (seconds)."
       TIMEOUT_SEC="$2"
       shift 2
       ;;
@@ -79,20 +84,29 @@ while [[ $# -gt 0 ]]; do
 done
 
 [[ -n "$HOST" ]] || fail "--host is required."
+[[ "$TIMEOUT_SEC" =~ ^[1-9][0-9]*$ ]] \
+  || fail "--timeout must be a positive integer (seconds)."
 require_commands getent ip ping ssh
 
 if [[ -n "$LINK_LOCAL" && -z "$INTERFACE" ]]; then
   fail "--interface is required when --link-local is set."
 fi
 
-info "Resolver view for ${HOST}"
-getent hosts "$HOST" || true
-getent ahosts "$HOST" || true
+HOST_BASE="${HOST%.local}"
+HOST_LOCAL="${HOST_BASE}.local"
+HOST_ALIASES="$HOST_BASE"
+if [[ "$HOST_LOCAL" != "$HOST_BASE" ]]; then
+  HOST_ALIASES="${HOST_BASE} ${HOST_LOCAL}"
+fi
 
-info "Resolver view for ${HOST}.local"
-getent hosts "${HOST}.local" || true
+info "Resolver view for ${HOST_BASE}"
+getent hosts "$HOST_BASE" || true
+getent ahosts "$HOST_BASE" || true
+
+info "Resolver view for ${HOST_LOCAL}"
+getent hosts "$HOST_LOCAL" || true
 if command -v avahi-resolve >/dev/null 2>&1; then
-  avahi-resolve -n "${HOST}.local" || true
+  avahi-resolve -n "$HOST_LOCAL" || true
 fi
 
 if [[ -n "$INTERFACE" ]]; then
@@ -100,8 +114,8 @@ if [[ -n "$INTERFACE" ]]; then
   ip -6 addr show dev "$INTERFACE" || true
 fi
 
-probe_cmd "Ping ${HOST}" ping -c 1 -W "$TIMEOUT_SEC" "$HOST"
-probe_cmd "Ping ${HOST}.local" ping -c 1 -W "$TIMEOUT_SEC" "${HOST}.local"
+probe_cmd "Ping ${HOST_BASE}" ping -c 1 -W "$TIMEOUT_SEC" "$HOST_BASE"
+probe_cmd "Ping ${HOST_LOCAL}" ping -c 1 -W "$TIMEOUT_SEC" "$HOST_LOCAL"
 
 if [[ -n "$LINK_LOCAL" ]]; then
   SCOPED_LINK_LOCAL="${LINK_LOCAL}%${INTERFACE}"
@@ -111,18 +125,18 @@ if [[ -n "$LINK_LOCAL" ]]; then
   if ssh -6 \
     -o BatchMode=yes \
     -o ConnectTimeout="$TIMEOUT_SEC" \
-    -o HostKeyAlias="$HOST" \
+    -o HostKeyAlias="$HOST_BASE" \
     "${PI_USER}@${SCOPED_LINK_LOCAL}" \
     'hostname && whoami'; then
     ok "Scoped link-local SSH succeeded"
     cat <<EOF
 
 Recommended SSH config:
-Host ${HOST} ${HOST}.local
+Host ${HOST_ALIASES}
     User ${PI_USER}
     HostName ${LINK_LOCAL}%${INTERFACE}
     AddressFamily inet6
-    HostKeyAlias ${HOST}
+    HostKeyAlias ${HOST_BASE}
     ConnectTimeout 5
 EOF
   else
@@ -130,5 +144,5 @@ EOF
   fi
 fi
 
-info "Rendered SSH configuration for ${HOST}"
-ssh -G "$HOST" | sed -n '1,20p' || true
+info "Rendered SSH configuration for ${HOST_BASE}"
+ssh -G "$HOST_BASE" | sed -n '1,20p' || true

--- a/scripts/check_pi_connectivity.sh
+++ b/scripts/check_pi_connectivity.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd -- "$(dirname "$0")" && pwd)"
+# shellcheck source=./lib/common.sh
+source "${SCRIPT_DIR}/lib/common.sh"
+
+HOST=""
+PI_USER="${USER:-user}"
+LINK_LOCAL=""
+INTERFACE=""
+TIMEOUT_SEC=5
+
+usage() {
+  cat <<EOF
+Usage: ./scripts/check_pi_connectivity.sh --host HOST [options]
+
+Workstation-side Raspberry Pi connectivity probe for recurring SSH, mDNS,
+link-local IPv6, and NetworkManager-related reachability issues.
+
+Options:
+  --host HOST               Pi hostname or SSH alias to probe.
+  --user USER               SSH user. Default: current local user.
+  --link-local IPV6         Known Pi link-local IPv6 address without %scope.
+  --interface IFACE         Workstation network interface for link-local probes.
+  --timeout SEC             Connect timeout for ping and SSH probes. Default: 5.
+  -h, --help                Show this help and exit.
+EOF
+}
+
+probe_cmd() {
+  local description="$1"
+  shift
+
+  info "$description"
+  if "$@"; then
+    ok "$description succeeded"
+  else
+    warn "$description failed"
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --host)
+      require_value "$1" "${2:-}"
+      HOST="$2"
+      shift 2
+      ;;
+    --user)
+      require_value "$1" "${2:-}"
+      PI_USER="$2"
+      shift 2
+      ;;
+    --link-local)
+      require_value "$1" "${2:-}"
+      LINK_LOCAL="$2"
+      shift 2
+      ;;
+    --interface)
+      require_value "$1" "${2:-}"
+      INTERFACE="$2"
+      shift 2
+      ;;
+    --timeout)
+      require_value "$1" "${2:-}"
+      TIMEOUT_SEC="$2"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "Unknown option: $1"
+      ;;
+  esac
+done
+
+[[ -n "$HOST" ]] || fail "--host is required."
+require_commands getent ip ping ssh
+
+if [[ -n "$LINK_LOCAL" && -z "$INTERFACE" ]]; then
+  fail "--interface is required when --link-local is set."
+fi
+
+info "Resolver view for ${HOST}"
+getent hosts "$HOST" || true
+getent ahosts "$HOST" || true
+
+info "Resolver view for ${HOST}.local"
+getent hosts "${HOST}.local" || true
+if command -v avahi-resolve >/dev/null 2>&1; then
+  avahi-resolve -n "${HOST}.local" || true
+fi
+
+if [[ -n "$INTERFACE" ]]; then
+  info "Local IPv6 addresses on ${INTERFACE}"
+  ip -6 addr show dev "$INTERFACE" || true
+fi
+
+probe_cmd "Ping ${HOST}" ping -c 1 -W "$TIMEOUT_SEC" "$HOST"
+probe_cmd "Ping ${HOST}.local" ping -c 1 -W "$TIMEOUT_SEC" "${HOST}.local"
+
+if [[ -n "$LINK_LOCAL" ]]; then
+  SCOPED_LINK_LOCAL="${LINK_LOCAL}%${INTERFACE}"
+  probe_cmd "Ping ${SCOPED_LINK_LOCAL}" ping -6 -c 1 -W "$TIMEOUT_SEC" "$SCOPED_LINK_LOCAL"
+
+  info "SSH probe through scoped link-local"
+  if ssh -6 \
+    -o BatchMode=yes \
+    -o ConnectTimeout="$TIMEOUT_SEC" \
+    -o HostKeyAlias="$HOST" \
+    "${PI_USER}@${SCOPED_LINK_LOCAL}" \
+    'hostname && whoami'; then
+    ok "Scoped link-local SSH succeeded"
+    cat <<EOF
+
+Recommended SSH config:
+Host ${HOST} ${HOST}.local
+    User ${PI_USER}
+    HostName ${LINK_LOCAL}%${INTERFACE}
+    AddressFamily inet6
+    HostKeyAlias ${HOST}
+    ConnectTimeout 5
+EOF
+  else
+    warn "Scoped link-local SSH failed"
+  fi
+fi
+
+info "Rendered SSH configuration for ${HOST}"
+ssh -G "$HOST" | sed -n '1,20p' || true


### PR DESCRIPTION
This PR adds a dedicated Raspberry Pi connectivity recovery workflow for cases where workstation-to-Pi access is the real problem rather than the `bluetooth_2_usb` runtime.

The user-visible issue behind this change is recurring validation friction when `ssh pi-host` fails, `ping` is misleading, or the Pi only works reliably through a scoped IPv6 link-local address. In those cases the existing docs jumped too quickly into service-level debugging, which wastes time and makes healthy Pi deployments look broken.

The root cause is that these failures are usually a combination of host-side name resolution, missing link-local interface scope, Wi-Fi powersave defaults, and weak DNS settings on Raspberry Pi OS with NetworkManager. None of that was documented in one focused path, and there was no host-side helper to classify the problem quickly.

This change adds:

- a short troubleshooting note to classify the connectivity failure mode
- a full recovery playbook with the tested host-side and Pi-side recovery sequence
- a workstation helper script, `scripts/check_pi_connectivity.sh`, that prints resolver state, reachability probes, and a recommended `~/.ssh/config` block
- README and Pi CLI playbook updates so operators start with the connectivity docs when SSH itself is flaky
- doc-consistency playbook coverage for the new helper script

Validation for this PR was intentionally scoped to the new shell helper and doc-linked interface surface:

- `bash scripts/check_pi_connectivity.sh --help`
- `bash -n scripts/check_pi_connectivity.sh scripts/lib/common.sh`
- `venv/bin/shellcheck -x scripts/check_pi_connectivity.sh`

No Pi mutation was performed as part of this PR creation flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a workstation connectivity diagnostic tool with CLI options (host, user, interface, link-local probing, timeout); runs SSH, mDNS and IPv6 link-local probes and prints recommended SSH config snippets.

* **Documentation**
  * Added a short troubleshooting guide for Pi connectivity symptoms and quick fixes.
  * Added a stepwise recovery playbook with full diagnostics and remediation steps.
  * Updated playbooks and script-interface checks, and adjusted example SSH invocations to allow IPv6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->