### PR TITLE
docs: clarify contributor workflow rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Before making changes, read:
 Use these repo-specific playbooks when they match the task:
 
 - `docs/pi-cli-service-test-playbook.md`
+- `docs/pi-connectivity-recovery-playbook.md`
 - `docs/pi-host-relay-loopback-test-playbook.md`
 - `docs/pi-manual-test-plan.md`
 - `docs/doc-consistency-review-playbook.md`
@@ -55,6 +56,8 @@ Important:
 - If a fresh shell cannot find `shfmt` or `shellcheck`, activate the venv first.
 - For one-off commands in automation, prefer `source venv/bin/activate && ...`
   or `venv/bin/<tool>`.
+- For remote Pi work, passwordless sudo is strongly recommended so SSH-driven
+  validation and agentic workflows can use `sudo -n ...` safely.
 
 ## Repository layout
 
@@ -258,6 +261,8 @@ summary.
 - Keep changes focused.
 - Update docs when behavior, commands, paths, defaults, or validation guidance
   change.
+- Do not push directly to `main`; do the work on a branch and merge through a
+  pull request.
 - Do not amend commits unless explicitly asked.
 - Do not revert user changes you did not make.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,6 +249,16 @@ summary.
   notes against the current code before deciding they are irrelevant.
 - If you intentionally disagree with review feedback, document the technical
   reason directly on the PR at the relevant thread or comment location.
+- For CodeRabbit specifically, treat the first top-level CodeRabbit comment on
+  the PR as the live review-status source of truth. That comment is updated in
+  place and may show states such as review in progress, paused, or rate limit
+  exceeded.
+- Do not treat a CodeRabbit review as complete after the latest commit until
+  that first top-level CodeRabbit comment explicitly says no actionable comments
+  were generated for the recent review.
+- If that first CodeRabbit comment shows a rate-limit state, wait for the
+  window to expire before retriggering review, and avoid claiming the PR is
+  fully reviewed in the meantime.
 - Findings should focus on behavioral regressions, release risk, shell/runtime
   contract drift, and maintainability with operational impact.
 - If CI fails, inspect the actual failing GitHub Actions step and log before

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,6 @@ Before making changes, read:
 Use these repo-specific playbooks when they match the task:
 
 - `docs/pi-cli-service-test-playbook.md`
-- `docs/pi-connectivity-recovery-playbook.md`
 - `docs/pi-host-relay-loopback-test-playbook.md`
 - `docs/pi-manual-test-plan.md`
 - `docs/doc-consistency-review-playbook.md`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,6 +143,7 @@ For Pi-side validation, use a reachable Raspberry Pi over SSH when feasible.
 Use these repo-specific playbooks when they match the task:
 
 - `docs/pi-cli-service-test-playbook.md`
+- `docs/pi-connectivity-recovery-playbook.md`
 - `docs/pi-host-relay-loopback-test-playbook.md`
 - `docs/pi-manual-test-plan.md`
 - `docs/doc-consistency-review-playbook.md`
@@ -176,6 +177,9 @@ example:
 - `refactor/...`
 - `test/...`
 - `chore/...`
+
+Do not push directly to `main`. Create a branch for the change and merge it
+through a pull request.
 
 Do not use `codex/...` branch prefixes for normal project work.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,6 +196,12 @@ Do not assume an old resolved thread is still satisfied after later commits.
 Also check grouped nitpicks and summary comments, not just unresolved inline
 threads. If you intentionally decline a review suggestion, explain that
 decision directly on the PR at the relevant thread or comment.
+For CodeRabbit, use the first top-level CodeRabbit comment on the PR as the
+live status indicator because CodeRabbit edits that comment in place. States
+such as review in progress, paused, and rate limit exceeded mean the latest
+review cycle is not finished yet. Only treat the latest CodeRabbit pass as
+complete when that first comment says no actionable comments were generated for
+the recent review.
 
 ## Reporting issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,7 +143,6 @@ For Pi-side validation, use a reachable Raspberry Pi over SSH when feasible.
 Use these repo-specific playbooks when they match the task:
 
 - `docs/pi-cli-service-test-playbook.md`
-- `docs/pi-connectivity-recovery-playbook.md`
 - `docs/pi-host-relay-loopback-test-playbook.md`
 - `docs/pi-manual-test-plan.md`
 - `docs/doc-consistency-review-playbook.md`


### PR DESCRIPTION
This PR tightens the repository's contributor workflow guidance so everyday project work follows the same rules that have already been used operationally.

The user-facing problem behind this change is process drift: contributors and agents could infer the right habits from prior conversations, but the repository docs did not state them clearly enough in the canonical places. That makes it easier to push straight to `main`, forget the branch-only flow, or run remote Pi validation without `sudo -n` support.

The root issue is missing workflow policy in the repo's own fast-start and contributor docs, not a code bug. `AGENTS.md` and `CONTRIBUTING.md` are the right files to make those rules explicit.

This PR documents three things:

- the connectivity recovery playbook is part of the standard playbook set
- passwordless sudo is strongly recommended for SSH-driven Pi validation and agentic work
- normal project work should go through branches and pull requests rather than direct pushes to `main`

Validation for this PR was limited to reviewing the rendered diffs because the change is documentation-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enforced branch-based workflow: forbid direct pushes to main; require changes via branch and pull request.
  * Recommend passwordless sudo for remote/SSH automation to support headless/agentic workflows on devices like Raspberry Pi.
  * Clarified automated-review handling: the first top-level automated comment is the authoritative live review status; reviews remain open after new commits until that comment reports no actionable issues, and rate-limit windows must expire before retriggering review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->