### PR TITLE
docs: expand Pi wake kernel playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,10 +369,12 @@ input relayed by Bluetooth-2-USB.
 
 The playbook has also been exercised successfully on a Raspberry Pi Zero W
 with patched kernel `6.12.81-b2u-wake`, the documented ARM32 LLVM fallback,
-keyboard-only `wakeup_on_write`, and a passing post-reboot smoketest after
-clearing persistent `systemd-rfkill` Bluetooth soft-block state. Treat Pi 4B
-as the end-to-end wake reference and Pi Zero W as the confirmed 32-bit bring-up
-path for the custom wake kernel and gadget state.
+keyboard-only `wakeup_on_write`, a passing post-reboot smoketest after
+clearing persistent `systemd-rfkill` Bluetooth soft-block state, and confirmed
+end-to-end wake from host suspend through normal keyboard input relayed by
+Bluetooth-2-USB. Pi 4B and Pi Zero W are both confirmed end-to-end wake
+setups; Pi Zero W is also the validated 32-bit bring-up path for the custom
+wake kernel.
 
 ## Optional boot optimization
 

--- a/README.md
+++ b/README.md
@@ -367,10 +367,12 @@ This has been tested on a Pi 4B with:
 On that tested setup, wake from host suspend works through normal keyboard
 input relayed by Bluetooth-2-USB.
 
-For Raspberry Pi Zero W, the documented wake-kernel playbook also includes a
-tested ARM32 LLVM fallback and a post-reboot Bluetooth rfkill recovery note for
-cases where `systemd-rfkill` re-applies a saved soft block after the kernel
-switch.
+The playbook has also been exercised successfully on a Raspberry Pi Zero W
+with patched kernel `6.12.81-b2u-wake`, the documented ARM32 LLVM fallback,
+keyboard-only `wakeup_on_write`, and a passing post-reboot smoketest after
+clearing persistent `systemd-rfkill` Bluetooth soft-block state. Treat Pi 4B
+as the end-to-end wake reference and Pi Zero W as the confirmed 32-bit bring-up
+path for the custom wake kernel and gadget state.
 
 ## Optional boot optimization
 

--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ If you need that fix to survive reboot, also clear the persisted Bluetooth
 state files:
 
 ```bash
-sudo sh -c 'for f in /var/lib/systemd/rfkill/*:bluetooth; do printf "0\n" > "$f"; done'
+sudo sh -c 'for f in /var/lib/systemd/rfkill/*:bluetooth; do [ -e "$f" ] || continue; printf "0\n" > "$f"; done'
 sudo rfkill unblock bluetooth
 sudo systemctl restart bluetooth
 ```

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ sudo reboot
 
 Bluetooth-2-USB can wake a sleeping or suspended host when you use the optional
 custom-kernel workflow in
-[rpi-remote-wakeup-kernel-playbook.md](docs/rpi-remote-wakeup-kernel-playbook.md).
+[pi-remote-wakeup-kernel-playbook.md](docs/pi-remote-wakeup-kernel-playbook.md).
 
 This has been tested on a Pi 4B with:
 
@@ -366,6 +366,11 @@ This has been tested on a Pi 4B with:
 
 On that tested setup, wake from host suspend works through normal keyboard
 input relayed by Bluetooth-2-USB.
+
+For Raspberry Pi Zero W, the documented wake-kernel playbook also includes a
+tested ARM32 LLVM fallback and a post-reboot Bluetooth rfkill recovery note for
+cases where `systemd-rfkill` re-applies a saved soft block after the kernel
+switch.
 
 ## Optional boot optimization
 
@@ -479,10 +484,24 @@ Raspberry Pi OS Lite during installation. If the controller becomes blocked
 again later, inspect the live `rfkill` state instead of assuming the install
 did not run.
 
+If the block comes back specifically after a reboot, also inspect the persisted
+`systemd-rfkill` state under `/var/lib/systemd/rfkill`. A saved Bluetooth
+state of `1` there can re-apply the soft block on later boots even when the
+runtime and BlueZ are otherwise healthy.
+
 If you already know the adapter is soft-blocked, clear that first:
 
 ```bash
 sudo sh -c 'echo 0 > /sys/class/rfkill/rfkill0/soft'
+```
+
+If you need that fix to survive reboot, also clear the persisted Bluetooth
+state files:
+
+```bash
+sudo sh -c 'for f in /var/lib/systemd/rfkill/*:bluetooth; do printf "0\n" > "$f"; done'
+sudo rfkill unblock bluetooth
+sudo systemctl restart bluetooth
 ```
 
 Then work interactively:
@@ -554,7 +573,8 @@ grep '^B2U_' /etc/default/bluetooth_2_usb_readonly
 
 ## Script reference
 
-All managed deployment scripts live in `/opt/bluetooth_2_usb/scripts/` after installation.
+Managed deployment scripts live in `/opt/bluetooth_2_usb/scripts/` after
+installation.
 
 ### `install.sh`
 

--- a/docs/pi-remote-wakeup-kernel-playbook.md
+++ b/docs/pi-remote-wakeup-kernel-playbook.md
@@ -22,6 +22,28 @@ This playbook covers:
 - Raspberry Pi Zero 2 W
 - Raspberry Pi 5
 
+## Tested setups
+
+This workflow has been exercised successfully on these setups:
+
+- Raspberry Pi 4 Model B Rev 1.4:
+  patched `rpi-6.12.y` kernel `6.12.81-b2u-wake+`, installed
+  `/boot/config-$(uname -r)`, keyboard-only `wakeup_on_write`
+  (`hid.usb0=1`, `hid.usb1=0`, `hid.usb2=0`), and wake from host suspend
+  confirmed through normal keyboard input relayed by Bluetooth-2-USB
+- Raspberry Pi Zero W:
+  patched `rpi-6.12.y` kernel `6.12.81-b2u-wake`, successful ARM32 LLVM
+  fallback build and boot, keyboard-only `wakeup_on_write`
+  (`hid.usb0=1`, `hid.usb1=0`, `hid.usb2=0`), and post-reboot
+  `bluetooth_2_usb` smoketest passing after clearing persistent
+  `systemd-rfkill` Bluetooth soft-block state
+
+From a user perspective:
+
+- Pi 4B is the confirmed end-to-end reference for actual wake-from-suspend use
+- Pi Zero W is the confirmed bring-up path for the custom wake kernel and the
+  required gadget state on 32-bit hardware
+
 ## Technical background
 
 The wake path needs both of the following:

--- a/docs/pi-remote-wakeup-kernel-playbook.md
+++ b/docs/pi-remote-wakeup-kernel-playbook.md
@@ -511,7 +511,7 @@ If Bluetooth is soft-blocked again after reboot, inspect the persisted
 
 ```bash
 sudo ls -l /var/lib/systemd/rfkill
-sudo od -An -t u1 /var/lib/systemd/rfkill/*:bluetooth 2>/dev/null
+sudo sh -c 'for f in /var/lib/systemd/rfkill/*:bluetooth; do [ -e "$f" ] || continue; od -An -t u1 "$f"; done'
 ```
 
 If the active Bluetooth state file contains `49 10`, that is the saved value

--- a/docs/pi-remote-wakeup-kernel-playbook.md
+++ b/docs/pi-remote-wakeup-kernel-playbook.md
@@ -289,6 +289,12 @@ sudo env PATH="$PATH" make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- modules_i
 sudo env PATH="$PATH" make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- modules_install
 ```
 
+- 32-bit LLVM out-of-tree build:
+
+```bash
+sudo env PATH="$PATH" make O=out/pi0w LLVM=1 ARCH=arm LOCALVERSION= modules_install
+```
+
 Then copy the kernel, DTBs, and overlays into `/boot/firmware`:
 
 - 64-bit:
@@ -309,6 +315,16 @@ sudo cp arch/arm/boot/dts/broadcom/*.dtb /boot/firmware/
 sudo cp arch/arm/boot/dts/overlays/*.dtb* /boot/firmware/overlays/
 sudo cp arch/arm/boot/dts/overlays/README /boot/firmware/overlays/
 sudo cp "config-$(make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- kernelrelease)" "/boot/config-$(make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- kernelrelease)"
+```
+
+- 32-bit LLVM out-of-tree build:
+
+```bash
+sudo cp out/pi0w/arch/arm/boot/zImage "/boot/firmware/${KERNEL}-b2u-wake.img"
+sudo cp out/pi0w/arch/arm/boot/dts/broadcom/*.dtb /boot/firmware/
+sudo cp arch/arm/boot/dts/overlays/*.dtb* /boot/firmware/overlays/
+sudo cp arch/arm/boot/dts/overlays/README /boot/firmware/overlays/
+sudo cp "out/pi0w/config-$(make O=out/pi0w LLVM=1 ARCH=arm LOCALVERSION= kernelrelease)" "/boot/config-$(make O=out/pi0w LLVM=1 ARCH=arm LOCALVERSION= kernelrelease)"
 ```
 
 Required boot-side safeguards:

--- a/docs/pi-remote-wakeup-kernel-playbook.md
+++ b/docs/pi-remote-wakeup-kernel-playbook.md
@@ -1,4 +1,4 @@
-# Raspberry Pi Remote-Wakeup Kernel Playbook
+# Pi Remote-Wakeup Kernel Playbook
 
 Use this playbook when you need a Raspberry Pi USB HID gadget that can wake a
 sleeping or suspended host by sending keyboard input.
@@ -103,6 +103,17 @@ sudo apt install crossbuild-essential-arm64
 sudo apt install crossbuild-essential-armhf
 ```
 
+If you do not have an `arm-linux-gnueabihf-` toolchain but do have a complete
+LLVM toolchain, the 32-bit Raspberry Pi Zero W path can also be built with:
+
+```bash
+make LLVM=1 ARCH=arm ...
+```
+
+That fallback is workable, but it is not the default documented path because
+the Raspberry Pi ARM32 tree is usually exercised more heavily with GCC-style
+toolchains.
+
 ## Prepare a separate kernel checkout
 
 Do not build the kernel inside the `bluetooth_2_usb` repository.
@@ -186,6 +197,39 @@ scripts/config --set-str LOCALVERSION "-b2u-wake"
 make -j"${JOBS}" ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- zImage modules dtbs
 make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- kernelrelease
 ```
+
+### Raspberry Pi Zero W, 32-bit, LLVM fallback
+
+Use this only when you intentionally want the LLVM path or do not have the
+`arm-linux-gnueabihf-` toolchain available.
+
+```bash
+cd ~/src/rpi-linux-wakeup
+export KERNEL=kernel
+make O=out/pi0w LLVM=1 ARCH=arm bcmrpi_defconfig
+scripts/config --file out/pi0w/.config --set-str LOCALVERSION "-b2u-wake"
+scripts/config --file out/pi0w/.config --disable BCM2835_FAST_MEMCPY
+make O=out/pi0w LLVM=1 ARCH=arm syncconfig
+make -j"${JOBS}" O=out/pi0w LLVM=1 ARCH=arm LOCALVERSION= zImage modules dtbs
+make O=out/pi0w LLVM=1 ARCH=arm LOCALVERSION= kernelrelease
+cp out/pi0w/.config "out/pi0w/config-$(make O=out/pi0w LLVM=1 ARCH=arm LOCALVERSION= kernelrelease)"
+```
+
+Why disable `CONFIG_BCM2835_FAST_MEMCPY` here:
+
+- on the Zero W ARM32 path, Clang's integrated assembler can choke on the
+  Raspberry Pi specific `memcmp_rpi.S` implementation
+- disabling `CONFIG_BCM2835_FAST_MEMCPY` switches back to the generic memcpy
+  and memcmp implementations, which allowed the build to complete cleanly in
+  a tested LLVM build
+
+Important details for this LLVM path:
+
+- keep using the `-b2u-wake` local version in `.config`
+- pass `LOCALVERSION=` on the `make ... kernelrelease` and build commands so
+  the final kernel release is `...-b2u-wake` instead of `...-b2u-wake+`
+- if you use an out-of-tree build directory, copy `config-<kernelrelease>`
+  from that build directory, not from the source tree
 
 ### Raspberry Pi Zero 2 W, optional 32-bit
 
@@ -293,6 +337,19 @@ Example kernel names and matching `kernel=` values:
 
 Adjust the filename to match your target before rebooting.
 
+Before rebooting, confirm that `config.txt` contains only the intended custom
+kernel line for this workflow:
+
+```bash
+grep -n '^kernel=' /boot/firmware/config.txt
+```
+
+For a Zero W test run, the expected line is:
+
+```text
+kernel=kernel-b2u-wake.img
+```
+
 ## Rollback
 
 Rollback must be possible before the first reboot.
@@ -390,6 +447,47 @@ Also verify:
 - normal typing while the host is already awake still works
 - mouse input does not unintentionally wake the host in the default setup
 - consumer-control input does not unintentionally wake the host in the default setup
+
+### 7. If the first post-reboot smoke test fails on Bluetooth power
+
+Do not immediately treat that as a wake-kernel regression.
+
+On at least one tested Zero W boot after switching to the custom kernel, the
+first failing smoke test was caused by a persisted Bluetooth rfkill soft block,
+not by the wake patch:
+
+- `bluetoothctl show` reported `Powered: no`
+- `PowerState: off-blocked`
+- `rfkill` showed `soft=1`
+
+Check that state explicitly:
+
+```bash
+sudo rfkill list bluetooth
+sudo bluetoothctl show
+```
+
+If Bluetooth is soft-blocked again after reboot, inspect the persisted
+`systemd-rfkill` state:
+
+```bash
+sudo ls -l /var/lib/systemd/rfkill
+sudo od -An -t u1 /var/lib/systemd/rfkill/*:bluetooth 2>/dev/null
+```
+
+If the active Bluetooth state file contains `49 10`, that is the saved value
+`1\n`, which will be re-applied as a soft block on later boots.
+
+Clear the live block and the saved state before re-testing:
+
+```bash
+sudo sh -c 'for f in /var/lib/systemd/rfkill/*:bluetooth; do printf "0\n" > "$f"; done'
+sudo rfkill unblock bluetooth
+sudo systemctl restart bluetooth
+```
+
+Then repeat the smoke test and one more reboot to verify that the controller
+stays unblocked across boot.
 
 ## Known limitations
 

--- a/docs/pi-remote-wakeup-kernel-playbook.md
+++ b/docs/pi-remote-wakeup-kernel-playbook.md
@@ -36,13 +36,14 @@ This workflow has been exercised successfully on these setups:
   fallback build and boot, keyboard-only `wakeup_on_write`
   (`hid.usb0=1`, `hid.usb1=0`, `hid.usb2=0`), and post-reboot
   `bluetooth_2_usb` smoketest passing after clearing persistent
-  `systemd-rfkill` Bluetooth soft-block state
+  `systemd-rfkill` Bluetooth soft-block state, with end-to-end wake from host
+  suspend confirmed through normal keyboard input relayed by Bluetooth-2-USB
 
 From a user perspective:
 
-- Pi 4B is the confirmed end-to-end reference for actual wake-from-suspend use
-- Pi Zero W is the confirmed bring-up path for the custom wake kernel and the
-  required gadget state on 32-bit hardware
+- Pi 4B is a confirmed end-to-end wake-from-suspend setup
+- Pi Zero W is also a confirmed end-to-end wake-from-suspend setup and the
+  validated 32-bit bring-up path for the custom wake kernel
 
 ## Technical background
 

--- a/docs/pi-remote-wakeup-kernel-playbook.md
+++ b/docs/pi-remote-wakeup-kernel-playbook.md
@@ -130,7 +130,7 @@ If you do not have an `arm-linux-gnueabihf-` toolchain but do have a complete
 LLVM toolchain, the 32-bit Raspberry Pi Zero W path can also be built with:
 
 ```bash
-make LLVM=1 ARCH=arm ...
+make O=out/pi0w LLVM=1 ARCH=arm bcmrpi_defconfig
 ```
 
 That fallback is workable, but it is not the default documented path because

--- a/docs/pi-remote-wakeup-kernel-playbook.md
+++ b/docs/pi-remote-wakeup-kernel-playbook.md
@@ -322,8 +322,8 @@ sudo cp "config-$(make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- kernelrelease
 ```bash
 sudo cp out/pi0w/arch/arm/boot/zImage "/boot/firmware/${KERNEL}-b2u-wake.img"
 sudo cp out/pi0w/arch/arm/boot/dts/broadcom/*.dtb /boot/firmware/
-sudo cp arch/arm/boot/dts/overlays/*.dtb* /boot/firmware/overlays/
-sudo cp arch/arm/boot/dts/overlays/README /boot/firmware/overlays/
+sudo cp out/pi0w/arch/arm/boot/dts/overlays/*.dtb* /boot/firmware/overlays/
+sudo cp out/pi0w/arch/arm/boot/dts/overlays/README /boot/firmware/overlays/
 sudo cp "out/pi0w/config-$(make O=out/pi0w LLVM=1 ARCH=arm LOCALVERSION= kernelrelease)" "/boot/config-$(make O=out/pi0w LLVM=1 ARCH=arm LOCALVERSION= kernelrelease)"
 ```
 

--- a/docs/pi-remote-wakeup-kernel-playbook.md
+++ b/docs/pi-remote-wakeup-kernel-playbook.md
@@ -520,7 +520,7 @@ If the active Bluetooth state file contains `49 10`, that is the saved value
 Clear the live block and the saved state before re-testing:
 
 ```bash
-sudo sh -c 'for f in /var/lib/systemd/rfkill/*:bluetooth; do printf "0\n" > "$f"; done'
+sudo sh -c 'for f in /var/lib/systemd/rfkill/*:bluetooth; do [ -e "$f" ] || continue; printf "0\n" > "$f"; done'
 sudo rfkill unblock bluetooth
 sudo systemctl restart bluetooth
 ```


### PR DESCRIPTION
This PR updates the wake-kernel documentation to reflect the tested Pi Zero W path and to use the repository's `pi-...` playbook naming consistently.

The user-visible issue behind this change is that the existing wake playbook documented the broad custom-kernel workflow, but it did not capture the tested Zero W LLVM fallback, the ARM32 `CONFIG_BCM2835_FAST_MEMCPY` workaround, or the post-reboot Bluetooth soft-block failure mode that can look like a kernel regression. It also still used the older `rpi-...` filename pattern.

The root cause is documentation drift after the Zero W validation work: the operational knowledge existed from the actual build and Pi testing session, but the canonical playbook still described only the older path.

This PR makes the playbook match the tested behavior:

- rename `docs/rpi-remote-wakeup-kernel-playbook.md` to `docs/pi-remote-wakeup-kernel-playbook.md`
- update the README link to the new filename
- document the ARM32 LLVM fallback for Pi Zero W
- document the need to disable `CONFIG_BCM2835_FAST_MEMCPY` on the tested LLVM build path
- document the `LOCALVERSION=` detail that avoids an unwanted trailing `+`
- document the `config.txt` sanity check before reboot
- document the persisted `systemd-rfkill` recovery path when the first post-reboot smoke test fails on Bluetooth power

Validation for this PR was documentation consistency review against the already tested kernel build and Pi behavior, plus a repository-wide reference check:

- `rg -n "rpi-remote-wakeup-kernel-playbook|pi-remote-wakeup-kernel-playbook" README.md docs`

No additional Pi mutation was performed as part of opening this PR because the underlying kernel build, deployment, reboot, and smoke-test verification had already been completed earlier in the session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a 32-bit Raspberry Pi Zero W kernel build workflow with an LLVM fallback and clarified install/verification steps.
  * Documented tested wake-from-suspend setups (Pi 4B and Zero W) with validated end-to-end keyboard/Bluetooth wake behavior and recommended wake configuration.
  * Added pre-reboot verification and post-reboot smoketest guidance.
  * Expanded Bluetooth troubleshooting to detect/clear persisted rfkill soft-blocks and restart Bluetooth.
  * Updated playbook title and formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->