### PR TITLE
fix: fold netplan NM migration into boot optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,13 @@ If the Pi is already provisioned and no longer needs `cloud-init` on every
 boot, you can trim the boot path and optionally freeze the currently working
 DHCP IPv4 settings as a static NetworkManager profile.
 
+On systems where `NetworkManager` is being fed by generated
+`/etc/netplan/90-NM-*.yaml` files, the optimization flow also persists the
+current `netplan-*.nmconnection` profiles into
+`/etc/NetworkManager/system-connections/` and disables those generated netplan
+overrides. On a tested Pi Zero W that removed repeated `NetworkManager`
+reloads during boot and cut userspace boot time by roughly 35 seconds.
+
 Preview the changes first:
 
 ```bash
@@ -593,8 +600,10 @@ Collect a deeper redacted diagnostics bundle when `smoke_test.sh` is not enough.
 Reduce Pi boot delays that are not required for `bluetooth_2_usb`. The script
 can disable `cloud-init` on already provisioned hosts, disable
 `NetworkManager-wait-online.service`, remove `ds=nocloud...` from
-`cmdline.txt`, and optionally freeze the current DHCP IPv4 settings as a
-static NetworkManager profile. It writes rollback state to
+`cmdline.txt`, persist transient netplan-generated `NetworkManager` profiles as
+native keyfiles while disabling the generated `/etc/netplan/90-NM-*.yaml`
+overrides, and optionally freeze the current DHCP IPv4 settings as a static
+NetworkManager profile. It writes rollback state to
 `/var/lib/bluetooth_2_usb/optimize_pi_boot_state.env` so the managed host can
 be restored later.
 

--- a/docs/pi-cli-service-test-playbook.md
+++ b/docs/pi-cli-service-test-playbook.md
@@ -246,7 +246,7 @@ ssh -4 "$PI_HOST" '
   sudo -n /opt/bluetooth_2_usb/scripts/smoke_test.sh --verbose
   nmcli -g NAME,UUID,TYPE,FILENAME connection show
   nmcli -g ipv4.method,ipv4.addresses,ipv4.gateway,ipv4.dns connection show "$(nmcli --get-values GENERAL.CONNECTION device show wlan0 | head -n 1)"
-  ls -l /etc/netplan /etc/NetworkManager/system-connections
+  sudo -n ls -l /etc/netplan /etc/NetworkManager/system-connections
   systemd-analyze time
   systemd-analyze blame | head -n 20
   systemd-analyze critical-chain bluetooth_2_usb.service

--- a/docs/pi-cli-service-test-playbook.md
+++ b/docs/pi-cli-service-test-playbook.md
@@ -244,7 +244,9 @@ ssh -4 "$PI_HOST" '
   systemctl is-active bluetooth.service
   systemctl is-active bluetooth_2_usb.service
   sudo -n /opt/bluetooth_2_usb/scripts/smoke_test.sh --verbose
+  nmcli -g NAME,UUID,TYPE,FILENAME connection show
   nmcli -g ipv4.method,ipv4.addresses,ipv4.gateway,ipv4.dns connection show "$(nmcli --get-values GENERAL.CONNECTION device show wlan0 | head -n 1)"
+  ls -l /etc/netplan /etc/NetworkManager/system-connections
   systemd-analyze time
   systemd-analyze blame | head -n 20
   systemd-analyze critical-chain bluetooth_2_usb.service

--- a/scripts/lib/pi_boot_optimize.sh
+++ b/scripts/lib/pi_boot_optimize.sh
@@ -299,7 +299,7 @@ rollback_netplan_generated_nm_profiles() {
       rm -f "$connection_file"
       changed=1
     fi
-  done <<< "${B2U_CREATED_NM_KEYFILES:-}"
+  done <<<"${B2U_CREATED_NM_KEYFILES:-}"
 
   while IFS= read -r yaml_file; do
     [[ -n "$yaml_file" ]] || continue
@@ -308,7 +308,7 @@ rollback_netplan_generated_nm_profiles() {
       mv "$disabled_path" "$yaml_file"
       changed=1
     fi
-  done <<< "${B2U_DISABLED_NETPLAN_YAMLS:-}"
+  done <<<"${B2U_DISABLED_NETPLAN_YAMLS:-}"
 
   if [[ $changed -eq 1 ]]; then
     nmcli connection reload || true

--- a/scripts/lib/pi_boot_optimize.sh
+++ b/scripts/lib/pi_boot_optimize.sh
@@ -21,6 +21,7 @@ readonly B2U_CLOUD_INIT_UNITS=(
   cloud-config.service
   cloud-final.service
 )
+readonly B2U_OPTIMIZE_NETPLAN_DISABLED_DIR="${B2U_STATE_DIR}/optimize_pi_boot_netplan_disabled"
 
 managed_git() {
   git -c safe.directory="${B2U_INSTALL_DIR}" -C "${B2U_INSTALL_DIR}" "$@"
@@ -112,6 +113,47 @@ current_ipv4_dns_for_interface() {
   printf '%s\n' "${dns_csv%,}"
 }
 
+list_netplan_runtime_yaml_files() {
+  [[ -d /etc/netplan ]] || return 0
+  find /etc/netplan -maxdepth 1 -type f -name '90-NM-*.yaml' -print | sort
+}
+
+list_netplan_runtime_nm_keyfiles() {
+  [[ -d /run/NetworkManager/system-connections ]] || return 0
+  find /run/NetworkManager/system-connections -maxdepth 1 -type f -name 'netplan-*.nmconnection' -print | sort
+}
+
+capture_netplan_nm_profile_state() {
+  local source_path
+  local destination_path
+  local runtime_keyfiles=()
+  local created_keyfiles=()
+  local moved_yaml_files=()
+
+  while IFS= read -r source_path; do
+    [[ -n "$source_path" ]] || continue
+    runtime_keyfiles+=("$source_path")
+    destination_path="/etc/NetworkManager/system-connections/${source_path##*/}"
+    if [[ ! -e "$destination_path" ]]; then
+      created_keyfiles+=("$destination_path")
+    fi
+  done < <(list_netplan_runtime_nm_keyfiles)
+
+  if [[ ${#runtime_keyfiles[@]} -eq 0 ]]; then
+    printf '%s\n' "B2U_CREATED_NM_KEYFILES=''"
+    printf '%s\n' "B2U_DISABLED_NETPLAN_YAMLS=''"
+    return 0
+  fi
+
+  while IFS= read -r source_path; do
+    [[ -n "$source_path" ]] || continue
+    moved_yaml_files+=("$source_path")
+  done < <(list_netplan_runtime_yaml_files)
+
+  printf '%s\n' "B2U_CREATED_NM_KEYFILES=$(printf '%q' "$(printf '%s\n' "${created_keyfiles[@]}")")"
+  printf '%s\n' "B2U_DISABLED_NETPLAN_YAMLS=$(printf '%q' "$(printf '%s\n' "${moved_yaml_files[@]}")")"
+}
+
 capture_nm_connection_state() {
   local connection="$1"
 
@@ -146,6 +188,7 @@ write_boot_optimize_state() {
     printf '%s\n' "B2U_CMDLINE_BACKUP_PATH=$(printf '%q' "$cmdline_backup_path")"
     printf '%s\n' "B2U_STATIC_IP_MODE=$(printf '%q' "$static_ip_mode")"
     printf '%s\n' "B2U_STATIC_IP_INTERFACE=$(printf '%q' "$interface_name")"
+    capture_netplan_nm_profile_state
     for unit in "${B2U_CLOUD_INIT_UNITS[@]}"; do
       printf '%s\n' "${unit//[^A-Za-z0-9]/_}=$(printf '%q' "$(systemd_unit_enabled_state "$unit")")"
     done
@@ -181,6 +224,44 @@ disable_cloud_init() {
   done
 }
 
+persist_netplan_generated_nm_profiles() {
+  local source_path
+  local destination_path
+  local runtime_keyfiles=()
+  local migrated=0
+
+  while IFS= read -r source_path; do
+    [[ -n "$source_path" ]] || continue
+    runtime_keyfiles+=("$source_path")
+  done < <(list_netplan_runtime_nm_keyfiles)
+
+  [[ ${#runtime_keyfiles[@]} -gt 0 ]] || return 0
+
+  install -d -m 700 /etc/NetworkManager/system-connections
+
+  for source_path in "${runtime_keyfiles[@]}"; do
+    destination_path="/etc/NetworkManager/system-connections/${source_path##*/}"
+    if [[ -e "$destination_path" ]]; then
+      continue
+    fi
+    cp -a "$source_path" "$destination_path"
+    chmod 600 "$destination_path"
+    migrated=1
+  done
+
+  install -d -m 700 "$B2U_OPTIMIZE_NETPLAN_DISABLED_DIR"
+  while IFS= read -r source_path; do
+    [[ -n "$source_path" ]] || continue
+    mv "$source_path" "${B2U_OPTIMIZE_NETPLAN_DISABLED_DIR}/${source_path##*/}"
+    migrated=1
+  done < <(list_netplan_runtime_yaml_files)
+
+  if [[ $migrated -eq 1 ]]; then
+    nmcli connection reload
+    systemctl reload NetworkManager
+  fi
+}
+
 restore_cloud_init_state() {
   local marker_state="$1"
   local unit
@@ -204,6 +285,37 @@ restore_cloud_init_state() {
       systemctl disable "$unit" >/dev/null 2>&1 || true
     fi
   done
+}
+
+rollback_netplan_generated_nm_profiles() {
+  local connection_file
+  local yaml_file
+  local disabled_path
+  local changed=0
+
+  while IFS= read -r connection_file; do
+    [[ -n "$connection_file" ]] || continue
+    if [[ -e "$connection_file" ]]; then
+      rm -f "$connection_file"
+      changed=1
+    fi
+  done <<< "${B2U_CREATED_NM_KEYFILES:-}"
+
+  while IFS= read -r yaml_file; do
+    [[ -n "$yaml_file" ]] || continue
+    disabled_path="${B2U_OPTIMIZE_NETPLAN_DISABLED_DIR}/${yaml_file##*/}"
+    if [[ -e "$disabled_path" ]]; then
+      mv "$disabled_path" "$yaml_file"
+      changed=1
+    fi
+  done <<< "${B2U_DISABLED_NETPLAN_YAMLS:-}"
+
+  if [[ $changed -eq 1 ]]; then
+    nmcli connection reload || true
+    systemctl reload NetworkManager || true
+  fi
+
+  rmdir "$B2U_OPTIMIZE_NETPLAN_DISABLED_DIR" 2>/dev/null || true
 }
 
 set_wait_online_enabled_state() {
@@ -312,6 +424,7 @@ rollback_boot_optimization_state() {
     "${B2U_ORIG_IPV4_GATEWAY:-}" \
     "${B2U_ORIG_IPV4_DNS:-}" \
     "${B2U_ORIG_IPV4_IGNORE_AUTO_DNS:-no}"
+  rollback_netplan_generated_nm_profiles
 
   if [[ -n "${B2U_CMDLINE_BACKUP_PATH:-}" ]]; then
     restore_cmdline_backup "$B2U_CMDLINE_BACKUP_PATH"

--- a/scripts/optimize_pi_boot.sh
+++ b/scripts/optimize_pi_boot.sh
@@ -32,6 +32,8 @@ Reduce Pi boot delays that are not required for bluetooth_2_usb:
 - disable NetworkManager-wait-online.service
 - remove ds=nocloud... from cmdline.txt
 - optionally freeze the current DHCP IPv4 settings as a static NetworkManager configuration
+- when netplan generated transient NetworkManager profiles, persist them as native
+  NetworkManager keyfiles and disable the generated /etc/netplan/90-NM-*.yaml overrides
 
 Options:
   --dry-run                   Print the planned changes without mutating the host.
@@ -198,6 +200,8 @@ run_or_echo "Disable cloud-init for normal boots" disable_cloud_init
 MUTATED=1
 run_or_echo "Disable NetworkManager-wait-online.service" set_wait_online_enabled_state disabled
 run_or_echo "Remove ds=nocloud... from ${CMDLINE_TXT}" remove_nocloud_cmdline_tokens "$CMDLINE_TXT"
+run_or_echo "Persist generated NetworkManager profiles and disable netplan 90-NM overrides" \
+  persist_netplan_generated_nm_profiles
 
 if [[ "$STATIC_IP_MODE" == "auto" ]]; then
   ACTIVE_CONNECTION="$(active_nm_connection_for_interface "$INTERFACE_NAME")"


### PR DESCRIPTION
This PR folds the Pi Zero W network boot-time finding back into the supported `optimize_pi_boot.sh` workflow instead of leaving it as a one-off manual recovery step.

The user-visible issue behind this change is that some Pi hosts, especially on recent Raspberry Pi OS / Trixie images using NetworkManager through netplan-generated `90-NM-*.yaml` files, can spend tens of extra seconds in boot while NetworkManager repeatedly reloads before the network fully comes up. That made the optimized host still feel much slower than it should, even though `bluetooth_2_usb.service` itself was not the bottleneck.

The root cause is that the original boot-optimization flow handled cloud-init, wait-online, and optional static IPv4 settings, but it did not normalize the NetworkManager persistence layer. On the affected host, the live connections were generated into `/run/NetworkManager/system-connections/` and driven by generated `/etc/netplan/90-NM-*.yaml` files. Moving those transient profiles into native `/etc/NetworkManager/system-connections/` keyfiles and disabling the generated `90-NM-*.yaml` overrides removed the repeated reload loop that was costing roughly 35 seconds of userspace boot time on the tested Pi Zero W.

This PR updates the supported flow so `optimize_pi_boot.sh` now:

- captures the generated netplan/NM state in the rollback file
- persists transient `netplan-*.nmconnection` profiles into `/etc/NetworkManager/system-connections/`
- disables the generated `/etc/netplan/90-NM-*.yaml` overrides during optimization
- restores that state again on `--rollback`
- documents the behavior in the README and the Pi CLI service test playbook

Validation:

- `bash scripts/optimize_pi_boot.sh --help`
- `bash -n scripts/optimize_pi_boot.sh scripts/lib/pi_boot_optimize.sh`
- `venv/bin/shellcheck -x scripts/optimize_pi_boot.sh scripts/lib/pi_boot_optimize.sh`

The underlying behavioral finding was also validated earlier on `pi0w` before this PR:

- before migration: `systemd-analyze time` `4.117s + 1min 35.312s = 1min 39.430s`
- after persisting native NetworkManager keyfiles and disabling generated `90-NM-*.yaml` overrides: `4.122s + 1min 0.503s = 1min 4.625s`
- the residual single NetworkManager reload remained, but the repeated reload loop was removed
- `smoke_test.sh` continued to pass after the change

I kept the packaged `/usr/lib/netplan/00-network-manager-all.yaml` default out of the automated optimization path because removing distro-owned files is a riskier policy decision and did not yield additional meaningful boot-time gains on the tested host.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Boot optimization now preserves transient netplan-generated NetworkManager profiles as persistent connections and disables the corresponding netplan overrides; supports rollback of those changes.

* **Documentation**
  * README and script help updated to describe the new network-profile persistence behavior.
  * Test playbook expanded to emit additional NetworkManager and netplan diagnostic listings for verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->