### PR TITLE
docs: add staging promotion workflow

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -17,6 +17,8 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
+    base_branches:
+      - "staging"
 
 chat:
   auto_reply: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ permissions:
 on:
   push:
     branches:
+      - staging
       - main
   pull_request:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,12 +252,30 @@ summary.
 - If CI fails, inspect the actual failing GitHub Actions step and log before
   guessing.
 - CodeRabbit comments are useful hints, not ground truth.
+- `.coderabbit.yaml` has automatic review enabled for new pushes.
+- Before manually pinging CodeRabbit, inspect both the first top-level
+  CodeRabbit PR comment and the `CodeRabbit` GitHub check on the PR head
+  commit.
+- Treat the first top-level CodeRabbit comment as the authoritative live state
+  for `review in progress`, `paused`, `rate limited`, and `no actionable
+  comments`.
+- Do not treat a successful `CodeRabbit` GitHub check alone as proof that a PR
+  has no remaining actionable feedback.
+- If the first CodeRabbit comment shows `review in progress`, `paused`, or
+  `rate limited`, do not blindly post `@coderabbitai review`; wait, resume, or
+  re-trigger only when that state makes sense.
 
 ## Git and change scope
 
 - Keep changes focused.
 - Update docs when behavior, commands, paths, defaults, or validation guidance
   change.
+- Use `staging` as the integration branch for normal repository work.
+- Open normal feature, fix, docs, refactor, test, and chore PRs against
+  `staging`, not `main`.
+- Squash-merge individual PRs into `staging`.
+- Promote validated batches from `staging` to `main` with a normal merge commit
+  so the integrated test point remains explicit.
 - Do not amend commits unless explicitly asked.
 - Do not revert user changes you did not make.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,13 +252,16 @@ summary.
 - If CI fails, inspect the actual failing GitHub Actions step and log before
   guessing.
 - CodeRabbit comments are useful hints, not ground truth.
-- `.coderabbit.yaml` has automatic review enabled for new pushes.
+- `.coderabbit.yaml` has automatic review enabled for new pushes and includes
+  `staging` in the allowed auto-review base branches.
 - Before manually pinging CodeRabbit, inspect both the first top-level
   CodeRabbit PR comment and the `CodeRabbit` GitHub check on the PR head
   commit.
 - Treat the first top-level CodeRabbit comment as the authoritative live state
   for `review in progress`, `paused`, `rate limited`, and `no actionable
   comments`.
+- Do not consider CodeRabbit complete until that first top-level comment shows
+  `no actionable comments` after the latest commit on the PR branch.
 - Do not treat a successful `CodeRabbit` GitHub check alone as proof that a PR
   has no remaining actionable feedback.
 - If the first CodeRabbit comment shows `review in progress`, `paused`, or

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,7 +210,8 @@ decision directly on the PR at the relevant thread or comment.
 
 CodeRabbit workflow:
 
-- `.coderabbit.yaml` already enables automatic review on new pushes
+- `.coderabbit.yaml` enables automatic review on new pushes and explicitly
+  includes `staging` in `reviews.auto_review.base_branches`
 - before manually triggering CodeRabbit, check the first top-level CodeRabbit
   comment on the PR and the `CodeRabbit` GitHub check on the PR head commit
 - treat the first top-level CodeRabbit comment as the authoritative live status

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ The files most contributors will touch are:
 - `bluetooth_2_usb.service`
   systemd unit template used by the installer
 - `.github/workflows/ci.yml`
-  Baseline CI checks run on pull requests
+  Baseline CI checks run on pull requests and on pushes to `staging` and `main`
 
 ## Managed deployment model
 
@@ -157,6 +157,8 @@ running.
 
 ## Pull request guidelines
 
+This repository uses `staging` as its integration branch.
+
 When you open a pull request:
 
 - keep the scope focused
@@ -166,6 +168,18 @@ When you open a pull request:
 - describe how you tested it
 - include the target host type used for validation when it matters
 - update docs when behavior, commands, paths, or defaults change
+- target `staging` for normal feature, fix, refactor, test, and documentation
+  PRs
+- do not target `main` directly for normal project work
+
+Merge policy:
+
+- merge normal PRs into `staging` with squash merge
+- validate the integrated `staging` result before promoting it
+- merge `staging` into `main` with a normal merge commit so the tested batch is
+  preserved as one promotion step
+- use direct `main` PRs only for explicit exceptions such as user-requested
+  release or hotfix flows
 
 Use branch names that describe the change and start with the change type, for
 example:
@@ -193,6 +207,21 @@ Do not assume an old resolved thread is still satisfied after later commits.
 Also check grouped nitpicks and summary comments, not just unresolved inline
 threads. If you intentionally decline a review suggestion, explain that
 decision directly on the PR at the relevant thread or comment.
+
+CodeRabbit workflow:
+
+- `.coderabbit.yaml` already enables automatic review on new pushes
+- before manually triggering CodeRabbit, check the first top-level CodeRabbit
+  comment on the PR and the `CodeRabbit` GitHub check on the PR head commit
+- treat the first top-level CodeRabbit comment as the authoritative live status
+  for `review in progress`, `paused`, `rate limited`, and `no actionable
+  comments`
+- do not treat a green `CodeRabbit` check by itself as proof that review is
+  complete; the first CodeRabbit comment must explicitly show `no actionable
+  comments` after the latest commit
+- if the first CodeRabbit comment shows `review in progress`, `paused`, or
+  `rate limited`, do not spam `@coderabbitai review`; wait, resume, or
+  re-trigger only once the state justifies it
 
 ## Reporting issues
 


### PR DESCRIPTION
## Summary
- add `staging` to push-triggered CI so integrated promotions are validated too
- document the staging->main promotion model in `AGENTS.md` and `CONTRIBUTING.md`
- document the stricter CodeRabbit completion rule based on the first top-level comment plus the CodeRabbit check

## Testing
- `venv/bin/yamllint .github/workflows/ci.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to include staging branch for automated testing.
  * Added automated review configuration for staging branch integration.

* **Documentation**
  * Updated contribution guidelines with branching strategy and code review workflow procedures.
  * Expanded development workflow documentation for staging-based integration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->