### PR TITLE
Fix read-only initramfs and live validation

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -15,7 +15,7 @@ reviews:
   review_details: false
   collapse_walkthrough: false
   auto_review:
-    enabled: true
+    enabled: false
     drafts: false
     base_branches:
       - "staging"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,14 +80,8 @@ summary.
 
 CodeRabbit:
 
-- Treat the first top-level CodeRabbit PR comment as the authoritative live
-  state.
-- Do not consider CodeRabbit complete until that comment says
-  `no actionable comments` after the latest commit.
-- Before manually pinging CodeRabbit, inspect both that first comment and the
-  `CodeRabbit` GitHub check on the PR head commit.
-- If the first comment shows `review in progress`, `paused`, or `rate limited`,
-  wait, resume, or re-trigger only when that state justifies it.
+- Follow the canonical CodeRabbit review policy in `CONTRIBUTING.md`.
+- Do not duplicate or override that policy here.
 
 ## Final response expectations
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,8 +161,10 @@ CodeRabbit policy:
 - treat that prompt section as the source of truth for actionable review
   findings, including nitpicks, outside-diff-range comments, summary comments,
   and other grouped review items
-- if the first CodeRabbit comment says `review in progress`, `paused`, or
-  `rate limited`, wait or resume before posting `@coderabbitai full review`
+- if the first CodeRabbit comment says `review in progress`, wait for completion
+- if it says `paused`, resume the review first (for example, click Resume or
+  post `@coderabbitai resume`) before posting `@coderabbitai full review`
+- if it says `rate limited`, wait and retry `@coderabbitai full review`
 
 ## Reporting issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,15 +149,20 @@ Branch and commit naming:
 
 CodeRabbit policy:
 
-- `.coderabbit.yaml` enables automatic review on new pushes and includes
-  `staging`
+- `.coderabbit.yaml` disables automatic review; request CodeRabbit manually when
+  needed, using `@coderabbitai full review` by default
 - treat the first top-level CodeRabbit PR comment as the live status source of
   truth
 - do not consider review complete until that comment says
   `no actionable comments` after the latest commit
 - do not use a green `CodeRabbit` check alone as proof that review is finished
+- for the actual findings, inspect the newest review comments and read the
+  section `Prompt for all review comments with AI agents`
+- treat that prompt section as the source of truth for actionable review
+  findings, including nitpicks, outside-diff-range comments, summary comments,
+  and other grouped review items
 - if the first CodeRabbit comment says `review in progress`, `paused`, or
-  `rate limited`, wait or resume before posting `@coderabbitai review`
+  `rate limited`, wait or resume before posting `@coderabbitai full review`
 
 ## Reporting issues
 

--- a/docs/cli-service-test.md
+++ b/docs/cli-service-test.md
@@ -289,6 +289,9 @@ until ssh -o ConnectTimeout=5 <pi-host> 'true' 2>/dev/null; do
 done
 ```
 
+Only run destructive read-only rollback checks after `findmnt -no FSTYPE,SOURCE /`
+shows `overlay` for the live root filesystem.
+
 ## Uninstall validation
 
 ```bash
@@ -307,9 +310,6 @@ Expected outcome:
 - checkout remains present
 - persistent mount units are disabled
 - runtime env files and wrapper are removed
-
-Only run destructive read-only rollback checks after `findmnt -no FSTYPE,SOURCE /`
-shows `overlay` for the live root filesystem.
 
 ## What to record
 

--- a/docs/cli-service-test.md
+++ b/docs/cli-service-test.md
@@ -199,11 +199,11 @@ After reboot:
 
 ```bash
 ssh <pi-host> '
-  sudo -n /opt/bluetooth_2_usb/scripts/smoketest.sh --verbose
+  sudo -n env SMOKETEST_POST_REBOOT=1 /opt/bluetooth_2_usb/scripts/smoketest.sh --verbose
   findmnt -no FSTYPE,SOURCE /
   findmnt /var/lib/bluetooth
   findmnt /mnt/b2u-persist
-  sudo bash -lc '"'"'. /opt/bluetooth_2_usb/scripts/lib/boot.sh; test -s "$(boot_initramfs_target_path)" && printf "boot-initramfs %s\n" "$(boot_initramfs_target_path)"'"'"'
+  sudo bash -lc '"'"'. /opt/bluetooth_2_usb/scripts/lib/boot.sh; p="$(boot_initramfs_target_path || true)"; [ -s "$p" ] && printf "boot-initramfs %s\n" "$p"'"'"'
   grep "^B2U_" /etc/default/bluetooth_2_usb_readonly
 '
 ```

--- a/docs/cli-service-test.md
+++ b/docs/cli-service-test.md
@@ -200,8 +200,10 @@ After reboot:
 ```bash
 ssh <pi-host> '
   sudo -n /opt/bluetooth_2_usb/scripts/smoketest.sh --verbose
+  findmnt -no FSTYPE,SOURCE /
   findmnt /var/lib/bluetooth
   findmnt /mnt/b2u-persist
+  sudo bash -lc '"'"'. /opt/bluetooth_2_usb/scripts/lib/boot.sh; test -s "$(boot_initramfs_target_path)" && printf "boot-initramfs %s\n" "$(boot_initramfs_target_path)"'"'"'
   grep "^B2U_" /etc/default/bluetooth_2_usb_readonly
 '
 ```
@@ -305,6 +307,9 @@ Expected outcome:
 - checkout remains present
 - persistent mount units are disabled
 - runtime env files and wrapper are removed
+
+Only run destructive read-only rollback checks after `findmnt -no FSTYPE,SOURCE /`
+shows `overlay` for the live root filesystem.
 
 ## What to record
 

--- a/docs/persistent-readonly.md
+++ b/docs/persistent-readonly.md
@@ -68,6 +68,8 @@ After reboot:
 
 ```bash
 sudo /opt/bluetooth_2_usb/scripts/smoketest.sh --verbose
+findmnt -no FSTYPE,SOURCE /
+sudo bash -lc '. /opt/bluetooth_2_usb/scripts/lib/boot.sh; test -s "$(boot_initramfs_target_path)" && printf "boot initramfs: %s\n" "$(boot_initramfs_target_path)"'
 ```
 
 If `readonly-enable.sh` fails while `overlayroot` is being installed and the
@@ -82,6 +84,12 @@ sudo /opt/bluetooth_2_usb/scripts/readonly-enable.sh
 
 That failure mode has been observed on current Raspberry Pi OS releases when
 `initramfs-tools` cannot infer the root device during `overlayroot` setup.
+
+When a custom kernel image is selected in `config.txt`, `readonly-enable.sh`
+refreshes the initramfs for the running kernel and installs it under the boot
+filename expected by the firmware. Keep the running kernel fully installed,
+including `/lib/modules/$(uname -r)` and `config-$(uname -r)`, so that
+`update-initramfs` can rebuild the image cleanly.
 
 ## Disable read-only mode
 

--- a/docs/persistent-readonly.md
+++ b/docs/persistent-readonly.md
@@ -67,7 +67,7 @@ sudo reboot
 After reboot:
 
 ```bash
-sudo /opt/bluetooth_2_usb/scripts/smoketest.sh --verbose
+sudo env SMOKETEST_POST_REBOOT=1 /opt/bluetooth_2_usb/scripts/smoketest.sh --verbose
 findmnt -no FSTYPE,SOURCE /
 sudo bash -lc '. /opt/bluetooth_2_usb/scripts/lib/boot.sh; p="$(boot_initramfs_target_path || true)"; [ -s "$p" ] && printf "boot initramfs: %s\n" "$p"'
 ```

--- a/docs/persistent-readonly.md
+++ b/docs/persistent-readonly.md
@@ -69,7 +69,7 @@ After reboot:
 ```bash
 sudo /opt/bluetooth_2_usb/scripts/smoketest.sh --verbose
 findmnt -no FSTYPE,SOURCE /
-sudo bash -lc '. /opt/bluetooth_2_usb/scripts/lib/boot.sh; test -s "$(boot_initramfs_target_path)" && printf "boot initramfs: %s\n" "$(boot_initramfs_target_path)"'
+sudo bash -lc '. /opt/bluetooth_2_usb/scripts/lib/boot.sh; p="$(boot_initramfs_target_path || true)"; [ -s "$p" ] && printf "boot initramfs: %s\n" "$p"'
 ```
 
 If `readonly-enable.sh` fails while `overlayroot` is being installed and the

--- a/docs/remote-wakeup-kernel.md
+++ b/docs/remote-wakeup-kernel.md
@@ -155,6 +155,17 @@ Typical image names:
 - Pi 4B: `kernel8-b2u-wake.img`
 - Pi Zero W: `kernel-b2u-wake.img`
 
+With `auto_initramfs=1`, Raspberry Pi firmware derives the boot initramfs name
+from the kernel image name. That means these image names map to these boot
+initramfs targets:
+
+- Pi 4B: `kernel8-b2u-wake.img` -> `initramfs8-b2u-wake`
+- Pi Zero W: `kernel-b2u-wake.img` -> `initramfs-b2u-wake`
+
+When you later enable persistent read-only mode, `readonly-enable.sh` rebuilds
+the initramfs for the running kernel and installs the matching boot initramfs
+file automatically.
+
 Keep the stock kernel entry available so rollback is trivial.
 
 ## Verification

--- a/docs/remote-wakeup-kernel.md
+++ b/docs/remote-wakeup-kernel.md
@@ -95,6 +95,21 @@ Use a fixed local version suffix:
 -b2u-wake
 ```
 
+## Target matrix
+
+Use this matrix as the source of truth for board-specific build targets, custom
+kernel image names, and the boot initramfs name Raspberry Pi firmware expects
+when `auto_initramfs=1` is enabled.
+
+| Target | Status | Build target | Expected image | Boot initramfs target | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Raspberry Pi 4B | validated | `ARCH=arm64`, `bcm2711_defconfig`, `KERNEL=kernel8`, `CROSS_COMPILE=aarch64-linux-gnu-` | `kernel8-b2u-wake.img` | `initramfs8-b2u-wake` | Tested on Raspberry Pi 4 Model B Rev 1.4 |
+| Raspberry Pi Zero W | validated | `ARCH=arm`, `bcmrpi_defconfig`, `KERNEL=kernel`, `CROSS_COMPILE=arm-linux-gnueabihf-` | `kernel-b2u-wake.img` | `initramfs-b2u-wake` | GCC path validated; LLVM fallback also validated |
+| Raspberry Pi 5 | unvalidated | `ARCH=arm64`, `bcm2712_defconfig`, `KERNEL=kernel_2712`, `CROSS_COMPILE=aarch64-linux-gnu-` | `kernel_2712-b2u-wake.img` | `initramfs_2712-b2u-wake` | USB-C gadget path shares the board's USB-C connectivity |
+| Raspberry Pi 4B 32-bit | unvalidated | `ARCH=arm`, `bcm2711_defconfig`, `KERNEL=kernel7l`, `CROSS_COMPILE=arm-linux-gnueabihf-` | `kernel7l-b2u-wake.img` | `initramfs7l-b2u-wake` | Use only for 32-bit Pi OS on Pi 4 |
+| Raspberry Pi Zero 2 W 64-bit | unvalidated | `ARCH=arm64`, `bcm2711_defconfig`, `KERNEL=kernel8`, `CROSS_COMPILE=aarch64-linux-gnu-` | `kernel8-b2u-wake.img` | `initramfs8-b2u-wake` | Shares the Pi 4B 64-bit image/initramfs naming |
+| Raspberry Pi Zero 2 W 32-bit | unvalidated | `ARCH=arm`, `bcm2709_defconfig`, `KERNEL=kernel7`, `CROSS_COMPILE=arm-linux-gnueabihf-` | `kernel7-b2u-wake.img` | `initramfs7-b2u-wake` | 32-bit only |
+
 ## Validated build paths
 
 ### Raspberry Pi 4B
@@ -151,7 +166,8 @@ Notes for the LLVM fallback:
 These build paths are unvalidated for this project. They are included so you
 can build and deploy the matching custom kernel and let `readonly-enable.sh`
 install the corresponding boot initramfs automatically when you later enable
-persistent read-only mode.
+persistent read-only mode. Use the target matrix above for the expected image
+and initramfs filenames.
 
 ### Raspberry Pi 5
 
@@ -165,17 +181,6 @@ make -j"${JOBS}" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- Image modules dtbs
 make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- kernelrelease
 ```
 
-Custom image name:
-
-- `kernel_2712-b2u-wake.img`
-
-Boot initramfs mapping:
-
-- `kernel_2712-b2u-wake.img` -> `initramfs_2712-b2u-wake`
-
-The USB-C gadget path shares the board's USB-C connectivity, so plan power and
-data cabling accordingly before validating host wake or USB gadget behavior.
-
 ### Raspberry Pi 4B 32-bit
 
 ```bash
@@ -187,14 +192,6 @@ scripts/config --set-str LOCALVERSION "-b2u-wake"
 make -j"${JOBS}" ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- LOCALVERSION= zImage modules dtbs
 make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- LOCALVERSION= kernelrelease
 ```
-
-Custom image name:
-
-- `kernel7l-b2u-wake.img`
-
-Boot initramfs mapping:
-
-- `kernel7l-b2u-wake.img` -> `initramfs7l-b2u-wake`
 
 ### Raspberry Pi Zero 2 W 64-bit
 
@@ -208,14 +205,6 @@ make -j"${JOBS}" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- Image modules dtbs
 make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- kernelrelease
 ```
 
-Custom image name:
-
-- `kernel8-b2u-wake.img`
-
-Boot initramfs mapping:
-
-- `kernel8-b2u-wake.img` -> `initramfs8-b2u-wake`
-
 ### Raspberry Pi Zero 2 W 32-bit
 
 ```bash
@@ -228,39 +217,15 @@ make -j"${JOBS}" ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- LOCALVERSION= zImag
 make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- LOCALVERSION= kernelrelease
 ```
 
-Custom image name:
-
-- `kernel7-b2u-wake.img`
-
-Boot initramfs mapping:
-
-- `kernel7-b2u-wake.img` -> `initramfs7-b2u-wake`
-
 ## Deploy to the Pi
 
 Copy the built kernel image, modules, DTBs, overlays, and matching
 `config-<kernelrelease>` to the Pi. Then set the custom kernel image in
-`config.txt`.
-
-Typical image names:
-
-- Pi 4B: `kernel8-b2u-wake.img`
-- Pi Zero W: `kernel-b2u-wake.img`
-- Pi 5: `kernel_2712-b2u-wake.img`
-- Pi 4B 32-bit: `kernel7l-b2u-wake.img`
-- Pi Zero 2 W 64-bit: `kernel8-b2u-wake.img`
-- Pi Zero 2 W 32-bit: `kernel7-b2u-wake.img`
+`config.txt` using the image name from the target matrix above.
 
 With `auto_initramfs=1`, Raspberry Pi firmware derives the boot initramfs name
-from the kernel image name. That means these image names map to these boot
-initramfs targets:
-
-- Pi 4B: `kernel8-b2u-wake.img` -> `initramfs8-b2u-wake`
-- Pi Zero W: `kernel-b2u-wake.img` -> `initramfs-b2u-wake`
-- Pi 5: `kernel_2712-b2u-wake.img` -> `initramfs_2712-b2u-wake`
-- Pi 4B 32-bit: `kernel7l-b2u-wake.img` -> `initramfs7l-b2u-wake`
-- Pi Zero 2 W 64-bit: `kernel8-b2u-wake.img` -> `initramfs8-b2u-wake`
-- Pi Zero 2 W 32-bit: `kernel7-b2u-wake.img` -> `initramfs7-b2u-wake`
+from the kernel image name. Use the matching boot initramfs target from the
+same matrix when checking or troubleshooting boot artifacts.
 
 When you later enable persistent read-only mode, `readonly-enable.sh` rebuilds
 the initramfs for the running kernel and installs the matching boot initramfs

--- a/docs/remote-wakeup-kernel.md
+++ b/docs/remote-wakeup-kernel.md
@@ -12,7 +12,9 @@ not part of the stock Bluetooth-2-USB install path.
 - rollback should be prepared before the first reboot
 - host suspend and remote wake behavior remain platform-specific even with the
   patch
-- this guide documents only the setups that have been validated for this project
+- the tested setups below are validated for this project
+- the additional build paths below are provided for unvalidated targets that
+  follow the same custom-kernel and persistent read-only flow
 
 ## Tested setups
 
@@ -52,13 +54,13 @@ General build dependencies:
 sudo apt install bc bison flex libssl-dev make libc6-dev libncurses5-dev
 ```
 
-64-bit cross toolchain for Pi 4B:
+64-bit cross toolchain for Pi 4B, Pi 5, and Zero 2 W:
 
 ```bash
 sudo apt install crossbuild-essential-arm64
 ```
 
-32-bit cross toolchain for Pi Zero W:
+32-bit cross toolchain for Pi Zero W, Pi 4B 32-bit, and Zero 2 W 32-bit:
 
 ```bash
 sudo apt install crossbuild-essential-armhf
@@ -144,6 +146,96 @@ Notes for the LLVM fallback:
 - pass `LOCALVERSION=` on the build and `kernelrelease` commands so the final
   release string stays `...-b2u-wake` instead of `...-b2u-wake+`
 
+## Additional unvalidated targets
+
+These build paths are unvalidated for this project. They are included so you
+can build and deploy the matching custom kernel and let `readonly-enable.sh`
+install the corresponding boot initramfs automatically when you later enable
+persistent read-only mode.
+
+### Raspberry Pi 5
+
+```bash
+cd ~/src/rpi-linux-wakeup
+export JOBS="$(nproc)"
+export KERNEL=kernel_2712
+make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- bcm2712_defconfig
+scripts/config --set-str LOCALVERSION "-b2u-wake"
+make -j"${JOBS}" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- Image modules dtbs
+make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- kernelrelease
+```
+
+Custom image name:
+
+- `kernel_2712-b2u-wake.img`
+
+Boot initramfs mapping:
+
+- `kernel_2712-b2u-wake.img` -> `initramfs_2712-b2u-wake`
+
+The USB-C gadget path shares the board's USB-C connectivity, so plan power and
+data cabling accordingly before validating host wake or USB gadget behavior.
+
+### Raspberry Pi 4B 32-bit
+
+```bash
+cd ~/src/rpi-linux-wakeup
+export JOBS="$(nproc)"
+export KERNEL=kernel7l
+make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- bcm2711_defconfig
+scripts/config --set-str LOCALVERSION "-b2u-wake"
+make -j"${JOBS}" ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- LOCALVERSION= zImage modules dtbs
+make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- LOCALVERSION= kernelrelease
+```
+
+Custom image name:
+
+- `kernel7l-b2u-wake.img`
+
+Boot initramfs mapping:
+
+- `kernel7l-b2u-wake.img` -> `initramfs7l-b2u-wake`
+
+### Raspberry Pi Zero 2 W 64-bit
+
+```bash
+cd ~/src/rpi-linux-wakeup
+export JOBS="$(nproc)"
+export KERNEL=kernel8
+make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- bcm2711_defconfig
+scripts/config --set-str LOCALVERSION "-b2u-wake"
+make -j"${JOBS}" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- Image modules dtbs
+make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- kernelrelease
+```
+
+Custom image name:
+
+- `kernel8-b2u-wake.img`
+
+Boot initramfs mapping:
+
+- `kernel8-b2u-wake.img` -> `initramfs8-b2u-wake`
+
+### Raspberry Pi Zero 2 W 32-bit
+
+```bash
+cd ~/src/rpi-linux-wakeup
+export JOBS="$(nproc)"
+export KERNEL=kernel7
+make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- bcm2709_defconfig
+scripts/config --set-str LOCALVERSION "-b2u-wake"
+make -j"${JOBS}" ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- LOCALVERSION= zImage modules dtbs
+make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- LOCALVERSION= kernelrelease
+```
+
+Custom image name:
+
+- `kernel7-b2u-wake.img`
+
+Boot initramfs mapping:
+
+- `kernel7-b2u-wake.img` -> `initramfs7-b2u-wake`
+
 ## Deploy to the Pi
 
 Copy the built kernel image, modules, DTBs, overlays, and matching
@@ -154,6 +246,10 @@ Typical image names:
 
 - Pi 4B: `kernel8-b2u-wake.img`
 - Pi Zero W: `kernel-b2u-wake.img`
+- Pi 5: `kernel_2712-b2u-wake.img`
+- Pi 4B 32-bit: `kernel7l-b2u-wake.img`
+- Pi Zero 2 W 64-bit: `kernel8-b2u-wake.img`
+- Pi Zero 2 W 32-bit: `kernel7-b2u-wake.img`
 
 With `auto_initramfs=1`, Raspberry Pi firmware derives the boot initramfs name
 from the kernel image name. That means these image names map to these boot
@@ -161,6 +257,10 @@ initramfs targets:
 
 - Pi 4B: `kernel8-b2u-wake.img` -> `initramfs8-b2u-wake`
 - Pi Zero W: `kernel-b2u-wake.img` -> `initramfs-b2u-wake`
+- Pi 5: `kernel_2712-b2u-wake.img` -> `initramfs_2712-b2u-wake`
+- Pi 4B 32-bit: `kernel7l-b2u-wake.img` -> `initramfs7l-b2u-wake`
+- Pi Zero 2 W 64-bit: `kernel8-b2u-wake.img` -> `initramfs8-b2u-wake`
+- Pi Zero 2 W 32-bit: `kernel7-b2u-wake.img` -> `initramfs7-b2u-wake`
 
 When you later enable persistent read-only mode, `readonly-enable.sh` rebuilds
 the initramfs for the running kernel and installs the matching boot initramfs
@@ -215,4 +315,4 @@ another machine to restore the stock kernel selection.
 
 - this is still a custom-kernel workflow, not a stock-project feature
 - host suspend and wake behavior depend on the host platform as well as the Pi
-- only the validated Pi 4B and Pi Zero W paths are documented here on purpose
+- Pi 5, Pi 4B 32-bit, and Zero 2 W 32/64-bit are unvalidated build paths

--- a/docs/remote-wakeup-kernel.md
+++ b/docs/remote-wakeup-kernel.md
@@ -107,7 +107,7 @@ when `auto_initramfs=1` is enabled.
 | Raspberry Pi Zero W | validated | `ARCH=arm`, `bcmrpi_defconfig`, `KERNEL=kernel`, `CROSS_COMPILE=arm-linux-gnueabihf-` | `kernel-b2u-wake.img` | `initramfs-b2u-wake` | GCC path validated; LLVM fallback also validated |
 | Raspberry Pi 5 | unvalidated | `ARCH=arm64`, `bcm2712_defconfig`, `KERNEL=kernel_2712`, `CROSS_COMPILE=aarch64-linux-gnu-` | `kernel_2712-b2u-wake.img` | `initramfs_2712-b2u-wake` | USB-C gadget path shares the board's USB-C connectivity |
 | Raspberry Pi 4B 32-bit | unvalidated | `ARCH=arm`, `bcm2711_defconfig`, `KERNEL=kernel7l`, `CROSS_COMPILE=arm-linux-gnueabihf-` | `kernel7l-b2u-wake.img` | `initramfs7l-b2u-wake` | Use only for 32-bit Pi OS on Pi 4 |
-| Raspberry Pi Zero 2 W 64-bit | unvalidated | `ARCH=arm64`, `bcm2711_defconfig`, `KERNEL=kernel8`, `CROSS_COMPILE=aarch64-linux-gnu-` | `kernel8-b2u-wake.img` | `initramfs8-b2u-wake` | Shares the Pi 4B 64-bit image/initramfs naming |
+| Raspberry Pi Zero 2 W 64-bit | unvalidated | `ARCH=arm64`, `bcm2709_defconfig`, `KERNEL=kernel8`, `CROSS_COMPILE=aarch64-linux-gnu-` | `kernel8-b2u-wake.img` | `initramfs8-b2u-wake` | Shares the Pi 4B 64-bit image/initramfs naming |
 | Raspberry Pi Zero 2 W 32-bit | unvalidated | `ARCH=arm`, `bcm2709_defconfig`, `KERNEL=kernel7`, `CROSS_COMPILE=arm-linux-gnueabihf-` | `kernel7-b2u-wake.img` | `initramfs7-b2u-wake` | 32-bit only |
 
 ## Validated build paths

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -93,9 +93,15 @@ write_command_block() {
   local command="$3"
   local tmp
   local status=0
+  local timed_out=0
 
   tmp="$(mktemp)"
-  timeout "$timeout_secs" bash --noprofile --norc -c "$command" >"$tmp" 2>&1 || status=$?
+  if run_command_with_timeout_tracking "$timeout_secs" "$command" "$tmp"; then
+    status=0
+  else
+    status=$?
+  fi
+  timed_out=$TIMEOUT_EXPIRED
 
   write_heading "$title"
   printf '```console\n' >>"$REPORT_BODY"
@@ -105,14 +111,54 @@ write_command_block() {
   else
     printf '<no output>\n' >>"$REPORT_BODY"
   fi
-  case "$status" in
-    0) ;;
-    124) printf '[timed out after %ss]\n' "$timeout_secs" >>"$REPORT_BODY" ;;
-    *) printf '[command exited with status %s]\n' "$status" >>"$REPORT_BODY" ;;
-  esac
+  if [[ $timed_out -eq 1 ]]; then
+    printf '[timed out after %ss]\n' "$timeout_secs" >>"$REPORT_BODY"
+  elif [[ $status -ne 0 ]]; then
+    printf '[command exited with status %s]\n' "$status" >>"$REPORT_BODY"
+  fi
   printf '```\n\n' >>"$REPORT_BODY"
 
   rm -f "$tmp"
+}
+
+TIMEOUT_EXPIRED=0
+
+run_command_with_timeout_tracking() {
+  local timeout_secs="$1"
+  local command="$2"
+  local output_path="$3"
+  local status=0
+  local timed_out_marker=""
+  local child_pid=""
+  local watcher_pid=""
+
+  TIMEOUT_EXPIRED=0
+  timed_out_marker="$(mktemp)"
+  rm -f "$timed_out_marker"
+
+  setsid bash --noprofile --norc -c "$command" >"$output_path" 2>&1 &
+  child_pid=$!
+  (
+    sleep "$timeout_secs"
+    if kill -0 -- "-$child_pid" 2>/dev/null || kill -0 "$child_pid" 2>/dev/null; then
+      : >"$timed_out_marker"
+      kill -TERM -- "-$child_pid" 2>/dev/null || kill -TERM "$child_pid" 2>/dev/null || true
+      sleep 2
+      kill -KILL -- "-$child_pid" 2>/dev/null || kill -KILL "$child_pid" 2>/dev/null || true
+    fi
+  ) &
+  watcher_pid=$!
+
+  wait "$child_pid" || status=$?
+  kill "$watcher_pid" 2>/dev/null || true
+  wait "$watcher_pid" 2>/dev/null || true
+
+  if [[ -f "$timed_out_marker" ]]; then
+    TIMEOUT_EXPIRED=1
+  fi
+  rm -f "$timed_out_marker"
+
+  return "$status"
 }
 
 stop_service_for_debug() {
@@ -130,6 +176,7 @@ run_live_debug_block() {
   local tee_pid=""
   local child_pid=""
   local interrupted=""
+  local timed_out=0
 
   tmp="$(mktemp)"
   fifo="$(mktemp -u)"
@@ -145,7 +192,12 @@ run_live_debug_block() {
 
   if [[ -n "$DURATION" ]]; then
     info "Live debug duration: ${DURATION}s"
-    timeout "$DURATION" bash --noprofile --norc -c "$command" >"$fifo" 2>&1 || status=$?
+    if run_command_with_timeout_tracking "$DURATION" "$command" "$fifo"; then
+      status=0
+    else
+      status=$?
+    fi
+    timed_out=$TIMEOUT_EXPIRED
   else
     info "Live debug duration: until interrupted"
     trap 'interrupted="INT"; STOP_SIGNAL="INT"; [[ -n "$child_pid" ]] && kill -INT -- "-$child_pid" 2>/dev/null || true' INT
@@ -167,11 +219,11 @@ run_live_debug_block() {
     printf '<no output>\n' >>"$REPORT_BODY"
   fi
 
-  case "$status" in
-    0) ;;
-    124) printf '[timed out after %ss]\n' "$DURATION" >>"$REPORT_BODY" ;;
-    *) [[ -n "$interrupted" ]] || printf '[command exited with status %s]\n' "$status" >>"$REPORT_BODY" ;;
-  esac
+  if [[ $timed_out -eq 1 ]]; then
+    printf '[timed out after %ss]\n' "$DURATION" >>"$REPORT_BODY"
+  elif [[ $status -ne 0 ]]; then
+    [[ -n "$interrupted" ]] || printf '[command exited with status %s]\n' "$status" >>"$REPORT_BODY"
+  fi
   if [[ -n "$interrupted" ]]; then
     printf '[interrupted by %s]\n' "$interrupted" >>"$REPORT_BODY"
   fi
@@ -185,7 +237,7 @@ run_live_debug_block() {
       TERM) return 143 ;;
     esac
   fi
-  if [[ -n "$DURATION" && $status -eq 124 ]]; then
+  if [[ $timed_out -eq 1 ]]; then
     return 0
   fi
   return "$status"

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -185,6 +185,9 @@ run_live_debug_block() {
       TERM) return 143 ;;
     esac
   fi
+  if [[ -n "$DURATION" && $status -eq 124 ]]; then
+    return 0
+  fi
   return "$status"
 }
 

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -205,12 +205,22 @@ run_live_debug_block() {
 
   if [[ -n "$DURATION" ]]; then
     info "Live debug duration: ${DURATION}s"
+    trap 'interrupted="INT"; STOP_SIGNAL="INT"' INT
+    trap 'interrupted="TERM"; STOP_SIGNAL="TERM"' TERM
     if run_command_with_timeout_tracking "$DURATION" "$command" "$fifo"; then
       status=0
     else
       status=$?
     fi
     timed_out=$TIMEOUT_EXPIRED
+    trap 'STOP_SIGNAL="INT"' INT
+    trap 'STOP_SIGNAL="TERM"' TERM
+    if [[ -n "$interrupted" ]]; then
+      case "$interrupted" in
+        INT) status=130 ;;
+        TERM) status=143 ;;
+      esac
+    fi
   else
     info "Live debug duration: until interrupted"
     trap 'interrupted="INT"; STOP_SIGNAL="INT"; [[ -n "$child_pid" ]] && kill -INT -- "-$child_pid" 2>/dev/null || true' INT

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -123,6 +123,17 @@ write_command_block() {
 
 TIMEOUT_EXPIRED=0
 
+terminate_process_group() {
+  local child_pid="$1"
+
+  [[ -n "$child_pid" ]] || return 0
+  if kill -0 -- "-$child_pid" 2>/dev/null || kill -0 "$child_pid" 2>/dev/null; then
+    kill -TERM -- "-$child_pid" 2>/dev/null || kill -TERM "$child_pid" 2>/dev/null || true
+    sleep 2
+    kill -KILL -- "-$child_pid" 2>/dev/null || kill -KILL "$child_pid" 2>/dev/null || true
+  fi
+}
+
 run_command_with_timeout_tracking() {
   local timeout_secs="$1"
   local command="$2"
@@ -142,14 +153,16 @@ run_command_with_timeout_tracking() {
     sleep "$timeout_secs"
     if kill -0 -- "-$child_pid" 2>/dev/null || kill -0 "$child_pid" 2>/dev/null; then
       : >"$timed_out_marker"
-      kill -TERM -- "-$child_pid" 2>/dev/null || kill -TERM "$child_pid" 2>/dev/null || true
-      sleep 2
-      kill -KILL -- "-$child_pid" 2>/dev/null || kill -KILL "$child_pid" 2>/dev/null || true
+      terminate_process_group "$child_pid"
     fi
   ) &
   watcher_pid=$!
 
   wait "$child_pid" || status=$?
+  if [[ -n "${STOP_SIGNAL:-}" && $status -ne 0 ]]; then
+    terminate_process_group "$child_pid"
+    wait "$child_pid" 2>/dev/null || true
+  fi
   kill "$watcher_pid" 2>/dev/null || true
   wait "$watcher_pid" 2>/dev/null || true
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -53,7 +53,7 @@ OVERLAY_LINE="$(board_overlay_line "$MODEL")"
 MODULES="$(required_boot_modules_csv)"
 PRE_REBOOT_EXIT=3
 
-info "Detected model: ${MODEL:-unknown}"
+info "Detected model: ${MODEL}"
 info "Using boot directory: ${BOOT_DIR}"
 info "Detected dwc2 mode: ${DWC2_MODE}"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -47,7 +47,7 @@ require_commands apt-get awk grep git install python3 sed systemctl
 BOOT_DIR="$(detect_boot_dir)"
 CONFIG_TXT="$(boot_config_path)"
 CMDLINE_TXT="$(boot_cmdline_path)"
-MODEL="$(tr -d '\0' </proc/device-tree/model 2>/dev/null || true)"
+MODEL="$(current_pi_model)" || fail "Could not determine Raspberry Pi model from /proc/device-tree/model."
 DWC2_MODE="$(dwc2_mode)"
 OVERLAY_LINE="$(board_overlay_line "$MODEL")"
 MODULES="$(required_boot_modules_csv)"

--- a/scripts/lib/bluetooth.sh
+++ b/scripts/lib/bluetooth.sh
@@ -33,7 +33,10 @@ bluetooth_rfkill_root() {
 }
 
 bluetooth_controller_powered() {
-  bluetoothctl_show 2>/dev/null | _bluetooth_controller_powered_from_stream
+  local output
+
+  output="$(bluetoothctl_show 2>/dev/null)" || return 1
+  _bluetooth_controller_powered_from_stream <<<"$output"
 }
 
 bluetooth_controller_powered_from_file() {
@@ -44,7 +47,10 @@ bluetooth_controller_powered_from_file() {
 }
 
 bluetooth_paired_count() {
-  bluetoothctl_paired_devices 2>/dev/null | grep -c '^Device ' || true
+  local output
+
+  output="$(bluetoothctl_paired_devices 2>/dev/null)" || return 1
+  grep -c '^Device ' <<<"$output"
 }
 
 _bluetooth_rfkill_records() {

--- a/scripts/lib/bluetooth.sh
+++ b/scripts/lib/bluetooth.sh
@@ -50,7 +50,7 @@ bluetooth_paired_count() {
   local output
 
   output="$(bluetoothctl_paired_devices 2>/dev/null)" || return 1
-  grep -c '^Device ' <<<"$output"
+  awk 'BEGIN { count = 0 } /^Device / { count++ } END { print count }' <<<"$output"
 }
 
 _bluetooth_rfkill_records() {

--- a/scripts/lib/boot.sh
+++ b/scripts/lib/boot.sh
@@ -23,7 +23,9 @@ detect_boot_dir() {
 default_kernel_image() {
   local model arm_64bit
 
-  model="$(current_pi_model)"
+  if ! model="$(current_pi_model)"; then
+    model=""
+  fi
   arm_64bit="$(effective_arm_64bit)"
 
   case "$model" in
@@ -203,7 +205,10 @@ current_kernel_release() {
 }
 
 root_overlay_active() {
-  [[ "$(findmnt -n -o FSTYPE --target / 2>/dev/null || true)" == "overlay" ]]
+  local root_fstype
+
+  root_fstype="$(current_root_filesystem_type)" || return 1
+  [[ "$root_fstype" == "overlay" ]]
 }
 
 versioned_initrd_candidates() {
@@ -254,9 +259,9 @@ run_update_initramfs() {
 
   output="$(update-initramfs "$action" -k "$kernel_release" 2>&1)" || status=$?
   filtered_output="$(
-    printf '%s\n' "$output" | sed \
-      -e '/^WARNING: Unsupported initramfs version (.*) - skipping setup$/d' \
-      -e '/^NOTE: Manual boot configuration may be required$/d'
+    printf '%s\n' "$output" | sed -E \
+      -e '/^WARNING:.*Unsupported initramfs version/d' \
+      -e '/^NOTE:.*Manual boot configuration/d'
   )"
 
   if [[ -n "$filtered_output" ]]; then
@@ -268,16 +273,14 @@ run_update_initramfs() {
 
 build_or_refresh_initramfs_for_running_kernel() {
   local kernel_release="${1:-$(current_kernel_release)}"
-  local action
   local image_path
 
   if find_versioned_initramfs_image "$kernel_release" >/dev/null 2>&1; then
-    action="-u"
+    run_update_initramfs "-u" "$kernel_release" || run_update_initramfs "-c" "$kernel_release" || fail "update-initramfs failed for kernel ${kernel_release}."
   else
-    action="-c"
+    run_update_initramfs "-c" "$kernel_release" || fail "update-initramfs failed for kernel ${kernel_release}."
   fi
 
-  run_update_initramfs "$action" "$kernel_release" || fail "update-initramfs failed for kernel ${kernel_release}."
   image_path="$(find_versioned_initramfs_image "$kernel_release" || true)"
   [[ -n "$image_path" ]] || fail "update-initramfs completed, but no initramfs image was found for kernel ${kernel_release}."
   printf '%s\n' "$image_path"
@@ -380,11 +383,25 @@ board_overlay_line() {
 }
 
 current_pi_model() {
-  tr -d '\0' </proc/device-tree/model 2>/dev/null || true
+  local model_file="/proc/device-tree/model"
+
+  [[ -r "$model_file" ]] || return 1
+  tr -d '\0' <"$model_file"
+}
+
+current_root_filesystem_type() {
+  local root_fstype
+
+  root_fstype="$(findmnt -n -o FSTYPE --target / 2>/dev/null)" || return 1
+  [[ -n "$root_fstype" ]] || return 1
+  printf '%s\n' "$root_fstype"
 }
 
 expected_dwc2_overlay_line() {
-  board_overlay_line "$(current_pi_model)"
+  local model
+
+  model="$(current_pi_model)" || fail "Could not determine Raspberry Pi model from /proc/device-tree/model."
+  board_overlay_line "$model"
 }
 
 normalize_dwc2_overlay() {

--- a/scripts/lib/boot.sh
+++ b/scripts/lib/boot.sh
@@ -197,6 +197,10 @@ boot_initramfs_target_path() {
   local target_file="${1:-$(expected_boot_initramfs_file)}"
 
   [[ -n "$target_file" ]] || return 1
+  if [[ "$target_file" == /* || "$target_file" == *"/"* || "$target_file" == *".."* ]]; then
+    printf '%s\n' "Unsafe initramfs target file in $(boot_config_path): ${target_file}" >&2
+    return 1
+  fi
   printf '%s/%s\n' "$(detect_boot_dir)" "$target_file"
 }
 
@@ -207,8 +211,16 @@ current_kernel_release() {
 root_overlay_active() {
   local root_fstype
 
-  root_fstype="$(current_root_filesystem_type)" || return 1
-  [[ "$root_fstype" == "overlay" ]]
+  if ! root_fstype="$(current_root_filesystem_type)"; then
+    printf '%s\n' "unknown"
+    return 1
+  fi
+
+  if [[ "$root_fstype" == "overlay" ]]; then
+    printf '%s\n' "yes"
+  else
+    printf '%s\n' "no"
+  fi
 }
 
 versioned_initrd_candidates() {
@@ -273,9 +285,15 @@ run_update_initramfs() {
 
 build_or_refresh_initramfs_for_running_kernel() {
   local kernel_release="${1:-$(current_kernel_release)}"
+  local target_path="${2:-}"
+  local existing_image_path=""
   local image_path
 
-  if find_versioned_initramfs_image "$kernel_release" >/dev/null 2>&1; then
+  existing_image_path="$(find_versioned_initramfs_image "$kernel_release" || true)"
+  if [[ -n "$existing_image_path" ]]; then
+    if [[ -n "$target_path" && "$existing_image_path" == "$target_path" && -f "$target_path" ]]; then
+      backup_file "$target_path" || fail "Failed to back up ${target_path}"
+    fi
     run_update_initramfs "-u" "$kernel_release" || run_update_initramfs "-c" "$kernel_release" || fail "update-initramfs failed for kernel ${kernel_release}."
   else
     run_update_initramfs "-c" "$kernel_release" || fail "update-initramfs failed for kernel ${kernel_release}."
@@ -304,19 +322,28 @@ install_expected_boot_initramfs() {
 }
 
 ensure_bootable_initramfs_for_current_kernel() {
+  local kernel_release
   local target_path
   local image_path
+  local overlay_state
 
+  kernel_release="$(current_kernel_release)"
   target_path="$(boot_initramfs_target_path || true)"
   [[ -n "$target_path" ]] || fail "Boot initramfs target is not configured. Set auto_initramfs=1 or add an initramfs entry to $(boot_config_path)."
-  if root_overlay_active; then
+  if ! overlay_state="$(root_overlay_active)"; then
+    fail "Unable to determine live root overlay state; aborting initramfs operations."
+  fi
+  if [[ "$overlay_state" == "unknown" ]]; then
+    fail "Unable to determine live root overlay state; aborting initramfs operations."
+  fi
+  if [[ "$overlay_state" == "yes" ]]; then
     [[ -s "$target_path" ]] || fail "Boot initramfs target ${target_path} is missing while the live root overlay is active. Disable read-only mode before rebuilding initramfs."
     printf '%s\n' "$target_path"
     return 0
   fi
   ensure_initramfs_tools_ready
-  ensure_kernel_artifacts_present_for_initramfs
-  image_path="$(build_or_refresh_initramfs_for_running_kernel)"
+  ensure_kernel_artifacts_present_for_initramfs "$kernel_release"
+  image_path="$(build_or_refresh_initramfs_for_running_kernel "$kernel_release" "$target_path")"
   install_expected_boot_initramfs "$image_path" "$target_path" >/dev/null
   printf '%s\n' "$target_path"
 }

--- a/scripts/lib/boot.sh
+++ b/scripts/lib/boot.sh
@@ -208,7 +208,9 @@ current_kernel_release() {
   uname -r
 }
 
-root_overlay_active() {
+# The exit status reflects whether detection succeeded; the emitted value is the
+# overlay state ("yes", "no", or "unknown"), not a boolean predicate.
+root_overlay_state() {
   local root_fstype
 
   if ! root_fstype="$(current_root_filesystem_type)"; then
@@ -330,7 +332,7 @@ ensure_bootable_initramfs_for_current_kernel() {
   kernel_release="$(current_kernel_release)"
   target_path="$(boot_initramfs_target_path || true)"
   [[ -n "$target_path" ]] || fail "Boot initramfs target is not configured. Set auto_initramfs=1 or add an initramfs entry to $(boot_config_path)."
-  if ! overlay_state="$(root_overlay_active)"; then
+  if ! overlay_state="$(root_overlay_state)"; then
     fail "Unable to determine live root overlay state; aborting initramfs operations."
   fi
   if [[ "$overlay_state" == "unknown" ]]; then

--- a/scripts/lib/boot.sh
+++ b/scripts/lib/boot.sh
@@ -21,11 +21,47 @@ detect_boot_dir() {
 }
 
 default_kernel_image() {
-  if [[ "$(uname -m)" == "aarch64" ]]; then
-    printf '%s\n' "kernel8.img"
-  else
-    printf '%s\n' "kernel.img"
-  fi
+  local model arm_64bit
+
+  model="$(current_pi_model)"
+  arm_64bit="$(effective_arm_64bit)"
+
+  case "$model" in
+    *"Raspberry Pi 500"* | *"Raspberry Pi 5"* | *"Compute Module 5"*)
+      printf '%s\n' "kernel_2712.img"
+      ;;
+    *"Raspberry Pi 400"* | *"Raspberry Pi 4"* | *"Compute Module 4"*)
+      if [[ "$arm_64bit" == "1" ]]; then
+        printf '%s\n' "kernel8.img"
+      else
+        printf '%s\n' "kernel7l.img"
+      fi
+      ;;
+    *"Raspberry Pi 2"* | *"Raspberry Pi 3"* | *"Raspberry Pi Zero 2"* | *"Compute Module 3"*)
+      if [[ "$arm_64bit" == "1" ]]; then
+        printf '%s\n' "kernel8.img"
+      else
+        printf '%s\n' "kernel7.img"
+      fi
+      ;;
+    *)
+      case "$(uname -m)" in
+        aarch64)
+          printf '%s\n' "kernel8.img"
+          ;;
+        armv7l)
+          if grep -q '^Features.*\blpae\b' /proc/cpuinfo 2>/dev/null; then
+            printf '%s\n' "kernel7l.img"
+          else
+            printf '%s\n' "kernel7.img"
+          fi
+          ;;
+        *)
+          printf '%s\n' "kernel.img"
+          ;;
+      esac
+      ;;
+  esac
 }
 
 boot_config_path() {
@@ -48,10 +84,16 @@ import sys
 config_path = Path(sys.argv[1])
 target_key = sys.argv[2]
 value = ""
+current_section = ""
 
 for raw_line in config_path.read_text(encoding="utf-8").splitlines():
     line = raw_line.split("#", 1)[0].strip()
-    if not line or line.startswith("[") or "=" not in line:
+    if not line:
+        continue
+    if line.startswith("[") and line.endswith("]"):
+        current_section = line[1:-1].strip().lower()
+        continue
+    if "=" not in line or current_section not in ("", "all"):
         continue
     key, current_value = line.split("=", 1)
     if key.strip() == target_key:
@@ -83,10 +125,16 @@ import sys
 
 config_path = Path(sys.argv[1])
 value = ""
+current_section = ""
 
 for raw_line in config_path.read_text(encoding="utf-8").splitlines():
     line = raw_line.split("#", 1)[0].strip()
-    if not line or line.startswith("["):
+    if not line:
+        continue
+    if line.startswith("[") and line.endswith("]"):
+        current_section = line[1:-1].strip().lower()
+        continue
+    if current_section not in ("", "all"):
         continue
     if not line.startswith("initramfs "):
         continue
@@ -101,6 +149,21 @@ PY
 
 auto_initramfs_enabled() {
   [[ "$(boot_config_assignment_value "auto_initramfs")" == "1" ]]
+}
+
+effective_arm_64bit() {
+  local configured_value
+
+  configured_value="$(boot_config_assignment_value "arm_64bit")"
+  if [[ "$configured_value" == "1" ]]; then
+    printf '%s\n' "1"
+  elif [[ "$configured_value" == "0" ]]; then
+    printf '%s\n' "0"
+  elif [[ "$(uname -m)" == "aarch64" ]]; then
+    printf '%s\n' "1"
+  else
+    printf '%s\n' "0"
+  fi
 }
 
 expected_auto_initramfs_name() {
@@ -139,7 +202,7 @@ current_kernel_release() {
   uname -r
 }
 
-live_root_overlay_active() {
+root_overlay_active() {
   [[ "$(findmnt -n -o FSTYPE --target / 2>/dev/null || true)" == "overlay" ]]
 }
 
@@ -245,7 +308,7 @@ ensure_bootable_initramfs_for_current_kernel() {
   ensure_kernel_artifacts_present_for_initramfs
   target_path="$(boot_initramfs_target_path || true)"
   [[ -n "$target_path" ]] || fail "Boot initramfs target is not configured. Set auto_initramfs=1 or add an initramfs entry to $(boot_config_path)."
-  if live_root_overlay_active; then
+  if root_overlay_active; then
     [[ -s "$target_path" ]] || fail "Boot initramfs target ${target_path} is missing while the live root overlay is active. Disable read-only mode before rebuilding initramfs."
     printf '%s\n' "$target_path"
     return 0

--- a/scripts/lib/boot.sh
+++ b/scripts/lib/boot.sh
@@ -332,10 +332,8 @@ ensure_bootable_initramfs_for_current_kernel() {
   kernel_release="$(current_kernel_release)"
   target_path="$(boot_initramfs_target_path || true)"
   [[ -n "$target_path" ]] || fail "Boot initramfs target is not configured. Set auto_initramfs=1 or add an initramfs entry to $(boot_config_path)."
-  if ! overlay_state="$(root_overlay_state)"; then
-    fail "Unable to determine live root overlay state; aborting initramfs operations."
-  fi
-  if [[ "$overlay_state" == "unknown" ]]; then
+  overlay_state="$(root_overlay_state || true)"
+  if [[ "$overlay_state" != "yes" && "$overlay_state" != "no" ]]; then
     fail "Unable to determine live root overlay state; aborting initramfs operations."
   fi
   if [[ "$overlay_state" == "yes" ]]; then

--- a/scripts/lib/boot.sh
+++ b/scripts/lib/boot.sh
@@ -304,8 +304,6 @@ ensure_bootable_initramfs_for_current_kernel() {
   local target_path
   local image_path
 
-  ensure_initramfs_tools_ready
-  ensure_kernel_artifacts_present_for_initramfs
   target_path="$(boot_initramfs_target_path || true)"
   [[ -n "$target_path" ]] || fail "Boot initramfs target is not configured. Set auto_initramfs=1 or add an initramfs entry to $(boot_config_path)."
   if root_overlay_active; then
@@ -313,6 +311,8 @@ ensure_bootable_initramfs_for_current_kernel() {
     printf '%s\n' "$target_path"
     return 0
   fi
+  ensure_initramfs_tools_ready
+  ensure_kernel_artifacts_present_for_initramfs
   image_path="$(build_or_refresh_initramfs_for_running_kernel)"
   install_expected_boot_initramfs "$image_path" "$target_path" >/dev/null
   printf '%s\n' "$target_path"

--- a/scripts/lib/boot.sh
+++ b/scripts/lib/boot.sh
@@ -20,12 +20,239 @@ detect_boot_dir() {
   fi
 }
 
+default_kernel_image() {
+  if [[ "$(uname -m)" == "aarch64" ]]; then
+    printf '%s\n' "kernel8.img"
+  else
+    printf '%s\n' "kernel.img"
+  fi
+}
+
 boot_config_path() {
   printf '%s/config.txt\n' "$(detect_boot_dir)"
 }
 
 boot_cmdline_path() {
   printf '%s/cmdline.txt\n' "$(detect_boot_dir)"
+}
+
+boot_config_assignment_value() {
+  local key="$1"
+  local config_file="${2:-$(boot_config_path)}"
+
+  [[ -f "$config_file" ]] || return 0
+  python3 - "$config_file" "$key" <<'PY'
+from pathlib import Path
+import sys
+
+config_path = Path(sys.argv[1])
+target_key = sys.argv[2]
+value = ""
+
+for raw_line in config_path.read_text(encoding="utf-8").splitlines():
+    line = raw_line.split("#", 1)[0].strip()
+    if not line or line.startswith("[") or "=" not in line:
+        continue
+    key, current_value = line.split("=", 1)
+    if key.strip() == target_key:
+        value = current_value.strip()
+
+if value:
+    print(value)
+PY
+}
+
+configured_kernel_image() {
+  local value
+
+  value="$(boot_config_assignment_value "kernel")"
+  if [[ -n "$value" ]]; then
+    printf '%s\n' "$value"
+  else
+    default_kernel_image
+  fi
+}
+
+configured_initramfs_file() {
+  local config_file="${1:-$(boot_config_path)}"
+
+  [[ -f "$config_file" ]] || return 0
+  python3 - "$config_file" <<'PY'
+from pathlib import Path
+import sys
+
+config_path = Path(sys.argv[1])
+value = ""
+
+for raw_line in config_path.read_text(encoding="utf-8").splitlines():
+    line = raw_line.split("#", 1)[0].strip()
+    if not line or line.startswith("["):
+        continue
+    if not line.startswith("initramfs "):
+        continue
+    parts = line.split()
+    if len(parts) >= 2:
+        value = parts[1]
+
+if value:
+    print(value)
+PY
+}
+
+auto_initramfs_enabled() {
+  [[ "$(boot_config_assignment_value "auto_initramfs")" == "1" ]]
+}
+
+expected_auto_initramfs_name() {
+  local kernel_image="${1:-$(configured_kernel_image)}"
+  local base_name
+
+  base_name="${kernel_image##*/}"
+  base_name="${base_name%.*}"
+  if [[ "$base_name" == kernel* ]]; then
+    printf '%s\n' "initramfs${base_name#kernel}"
+  fi
+}
+
+expected_boot_initramfs_file() {
+  local explicit_initramfs
+
+  explicit_initramfs="$(configured_initramfs_file)"
+  if [[ -n "$explicit_initramfs" ]]; then
+    printf '%s\n' "$explicit_initramfs"
+    return
+  fi
+
+  if auto_initramfs_enabled; then
+    expected_auto_initramfs_name
+  fi
+}
+
+boot_initramfs_target_path() {
+  local target_file="${1:-$(expected_boot_initramfs_file)}"
+
+  [[ -n "$target_file" ]] || return 1
+  printf '%s/%s\n' "$(detect_boot_dir)" "$target_file"
+}
+
+current_kernel_release() {
+  uname -r
+}
+
+live_root_overlay_active() {
+  [[ "$(findmnt -n -o FSTYPE --target / 2>/dev/null || true)" == "overlay" ]]
+}
+
+versioned_initrd_candidates() {
+  local kernel_release="${1:-$(current_kernel_release)}"
+  local boot_dir
+
+  boot_dir="$(detect_boot_dir)"
+  printf '%s\n' "/boot/initrd.img-${kernel_release}"
+  if [[ "$boot_dir" != "/boot" ]]; then
+    printf '%s\n' "${boot_dir}/initrd.img-${kernel_release}"
+  fi
+}
+
+find_versioned_initramfs_image() {
+  local kernel_release="${1:-$(current_kernel_release)}"
+  local candidate
+
+  while IFS= read -r candidate; do
+    if [[ -s "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done < <(versioned_initrd_candidates "$kernel_release")
+
+  return 1
+}
+
+ensure_initramfs_tools_ready() {
+  require_commands install python3 update-initramfs
+  command -v mkinitramfs >/dev/null 2>&1 || fail "mkinitramfs is missing. Install initramfs-tools before enabling read-only mode."
+}
+
+ensure_kernel_artifacts_present_for_initramfs() {
+  local kernel_release="${1:-$(current_kernel_release)}"
+
+  [[ -d "/lib/modules/${kernel_release}" ]] || fail "Kernel modules for ${kernel_release} are missing at /lib/modules/${kernel_release}."
+  if [[ ! -f "/boot/config-${kernel_release}" && ! -f /proc/config.gz ]]; then
+    fail "Kernel configuration for ${kernel_release} is unavailable. Expected /boot/config-${kernel_release} or /proc/config.gz."
+  fi
+}
+
+run_update_initramfs() {
+  local action="$1"
+  local kernel_release="$2"
+  local output=""
+  local status=0
+  local filtered_output=""
+
+  output="$(update-initramfs "$action" -k "$kernel_release" 2>&1)" || status=$?
+  filtered_output="$(
+    printf '%s\n' "$output" | sed \
+      -e '/^WARNING: Unsupported initramfs version (.*) - skipping setup$/d' \
+      -e '/^NOTE: Manual boot configuration may be required$/d'
+  )"
+
+  if [[ -n "$filtered_output" ]]; then
+    printf '%s\n' "$filtered_output" >&2
+  fi
+
+  return "$status"
+}
+
+build_or_refresh_initramfs_for_running_kernel() {
+  local kernel_release="${1:-$(current_kernel_release)}"
+  local action
+  local image_path
+
+  if find_versioned_initramfs_image "$kernel_release" >/dev/null 2>&1; then
+    action="-u"
+  else
+    action="-c"
+  fi
+
+  run_update_initramfs "$action" "$kernel_release" || fail "update-initramfs failed for kernel ${kernel_release}."
+  image_path="$(find_versioned_initramfs_image "$kernel_release" || true)"
+  [[ -n "$image_path" ]] || fail "update-initramfs completed, but no initramfs image was found for kernel ${kernel_release}."
+  printf '%s\n' "$image_path"
+}
+
+install_expected_boot_initramfs() {
+  local source_image="$1"
+  local target_path="$2"
+
+  [[ -s "$source_image" ]] || fail "Initramfs source image is missing or empty: ${source_image}"
+  [[ -n "$target_path" ]] || fail "Boot initramfs target path must not be empty."
+  mkdir -p "$(dirname "$target_path")"
+  if [[ "$source_image" != "$target_path" ]]; then
+    if [[ -f "$target_path" ]]; then
+      backup_file "$target_path" || fail "Failed to back up ${target_path}"
+    fi
+    install -m 0644 "$source_image" "$target_path" || fail "Failed to install ${target_path}"
+  fi
+  [[ -s "$target_path" ]] || fail "Boot initramfs target is missing or empty after install: ${target_path}"
+  printf '%s\n' "$target_path"
+}
+
+ensure_bootable_initramfs_for_current_kernel() {
+  local target_path
+  local image_path
+
+  ensure_initramfs_tools_ready
+  ensure_kernel_artifacts_present_for_initramfs
+  target_path="$(boot_initramfs_target_path || true)"
+  [[ -n "$target_path" ]] || fail "Boot initramfs target is not configured. Set auto_initramfs=1 or add an initramfs entry to $(boot_config_path)."
+  if live_root_overlay_active; then
+    [[ -s "$target_path" ]] || fail "Boot initramfs target ${target_path} is missing while the live root overlay is active. Disable read-only mode before rebuilding initramfs."
+    printf '%s\n' "$target_path"
+    return 0
+  fi
+  image_path="$(build_or_refresh_initramfs_for_running_kernel)"
+  install_expected_boot_initramfs "$image_path" "$target_path" >/dev/null
+  printf '%s\n' "$target_path"
 }
 
 kernel_config_snippet() {

--- a/scripts/lib/install.sh
+++ b/scripts/lib/install.sh
@@ -152,7 +152,9 @@ service_installed() {
   local unit_files
   local unit_name_regex
 
-  unit_files="$(systemctl list-unit-files --type=service --no-legend --no-pager 2>/dev/null)" || return 1
+  if ! unit_files="$(systemctl list-unit-files --type=service --no-legend --no-pager 2>/dev/null)"; then
+    return 2
+  fi
   unit_name_regex="$(printf '%s\n' "$B2U_SERVICE_UNIT" | sed 's/[][(){}.^$*+?|\\/]/\\&/g')"
-  grep -Eq "^${unit_name_regex}[[:space:]]" <<<"$unit_files"
+  grep -Eq "^${unit_name_regex}[[:space:]]" <<<"$unit_files" || return 1
 }

--- a/scripts/lib/install.sh
+++ b/scripts/lib/install.sh
@@ -149,5 +149,8 @@ rebuild_venv_atomically() {
 }
 
 service_installed() {
-  systemctl list-unit-files --type=service 2>/dev/null | grep -Fq "${B2U_SERVICE_UNIT}"
+  local unit_files
+
+  unit_files="$(systemctl list-unit-files --type=service 2>/dev/null)" || return 1
+  grep -Fq "${B2U_SERVICE_UNIT}" <<<"$unit_files"
 }

--- a/scripts/lib/install.sh
+++ b/scripts/lib/install.sh
@@ -150,7 +150,9 @@ rebuild_venv_atomically() {
 
 service_installed() {
   local unit_files
+  local unit_name_regex
 
-  unit_files="$(systemctl list-unit-files --type=service 2>/dev/null)" || return 1
-  grep -Fq "${B2U_SERVICE_UNIT}" <<<"$unit_files"
+  unit_files="$(systemctl list-unit-files --type=service --no-legend --no-pager 2>/dev/null)" || return 1
+  unit_name_regex="$(printf '%s\n' "$B2U_SERVICE_UNIT" | sed 's/[][(){}.^$*+?|\\/]/\\&/g')"
+  grep -Eq "^${unit_name_regex}[[:space:]]" <<<"$unit_files"
 }

--- a/scripts/lib/readonly.sh
+++ b/scripts/lib/readonly.sh
@@ -36,6 +36,26 @@ overlay_status() {
   esac
 }
 
+overlay_configured_status() {
+  local state
+
+  if ! command -v raspi-config >/dev/null 2>&1; then
+    printf '%s\n' "unknown"
+    return
+  fi
+
+  if state="$(raspi-config nonint get_overlay_conf 2>/dev/null)"; then
+    state="$(printf '%s' "$state" | tr -d '[:space:]')"
+  else
+    state=""
+  fi
+  case "$state" in
+    0) printf '%s\n' "enabled" ;;
+    1) printf '%s\n' "disabled" ;;
+    *) printf '%s\n' "unknown" ;;
+  esac
+}
+
 root_overlay_report() {
   findmnt -n -o TARGET,SOURCE,FSTYPE,OPTIONS --target / 2>/dev/null || true
 }

--- a/scripts/lib/readonly.sh
+++ b/scripts/lib/readonly.sh
@@ -28,6 +28,14 @@ overlay_status() {
   esac
 }
 
+root_overlay_active() {
+  [[ "$(findmnt -n -o FSTYPE --target / 2>/dev/null || true)" == "overlay" ]]
+}
+
+root_overlay_report() {
+  findmnt -n -o TARGET,SOURCE,FSTYPE,OPTIONS --target / 2>/dev/null || true
+}
+
 readonly_stack_packages_healthy() {
   local pkg status
 
@@ -121,7 +129,7 @@ bluetooth_state_persistent() {
 }
 
 readonly_mode() {
-  if [[ "$(overlay_status)" == "enabled" ]] && bluetooth_state_persistent; then
+  if root_overlay_active && bluetooth_state_persistent; then
     printf '%s\n' "persistent"
   else
     printf '%s\n' "disabled"

--- a/scripts/lib/readonly.sh
+++ b/scripts/lib/readonly.sh
@@ -22,10 +22,12 @@ overlay_status() {
     return
   fi
 
-  if state="$(raspi-config nonint get_overlay_conf 2>/dev/null | tr -d '[:space:]')"; then
-    :
+  if state="$(raspi-config nonint get_overlay_conf 2>/dev/null)"; then
+    state="$(printf '%s' "$state" | tr -d '[:space:]')"
+  elif state="$(raspi-config nonint get_overlay_now 2>/dev/null)"; then
+    state="$(printf '%s' "$state" | tr -d '[:space:]')"
   else
-    state="$(raspi-config nonint get_overlay_now 2>/dev/null | tr -d '[:space:]')"
+    state=""
   fi
   case "$state" in
     0) printf '%s\n' "enabled" ;;
@@ -131,7 +133,14 @@ bluetooth_state_persistent() {
 }
 
 readonly_mode() {
-  if root_overlay_active && bluetooth_state_persistent; then
+  local root_fstype
+
+  if ! root_fstype="$(current_root_filesystem_type)"; then
+    printf '%s\n' "unknown"
+    return 0
+  fi
+
+  if [[ "$root_fstype" == "overlay" ]] && bluetooth_state_persistent; then
     printf '%s\n' "persistent"
   else
     printf '%s\n' "disabled"

--- a/scripts/lib/readonly.sh
+++ b/scripts/lib/readonly.sh
@@ -10,6 +10,8 @@ _b2u_readonly_lib_dir="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${_b2u_readonly_lib_dir}/paths.sh"
 # shellcheck source=./common.sh
 source "${_b2u_readonly_lib_dir}/common.sh"
+# shellcheck source=./boot.sh
+source "${_b2u_readonly_lib_dir}/boot.sh"
 unset _b2u_readonly_lib_dir
 
 overlay_status() {
@@ -26,10 +28,6 @@ overlay_status() {
     1) printf '%s\n' "disabled" ;;
     *) printf '%s\n' "unknown" ;;
   esac
-}
-
-root_overlay_active() {
-  [[ "$(findmnt -n -o FSTYPE --target / 2>/dev/null || true)" == "overlay" ]]
 }
 
 root_overlay_report() {

--- a/scripts/lib/readonly.sh
+++ b/scripts/lib/readonly.sh
@@ -132,6 +132,11 @@ bluetooth_state_persistent() {
   [[ "$mount_source" == "${persist_mount_source}[${relative_subdir}]" ]]
 }
 
+# Returns "persistent" only when the live root filesystem is overlay-backed and
+# Bluetooth state persistence is active. Otherwise it returns "disabled", with
+# "unknown" reserved for root-filesystem detection failures. Callers that need
+# finer-grained state should check current_root_filesystem_type() and
+# bluetooth_state_persistent() separately; scripts/smoketest.sh does that.
 readonly_mode() {
   local root_fstype
 

--- a/scripts/lib/readonly.sh
+++ b/scripts/lib/readonly.sh
@@ -22,7 +22,11 @@ overlay_status() {
     return
   fi
 
-  state="$(raspi-config nonint get_overlay_now 2>/dev/null | tr -d '[:space:]')"
+  if state="$(raspi-config nonint get_overlay_conf 2>/dev/null | tr -d '[:space:]')"; then
+    :
+  else
+    state="$(raspi-config nonint get_overlay_now 2>/dev/null | tr -d '[:space:]')"
+  fi
   case "$state" in
     0) printf '%s\n' "enabled" ;;
     1) printf '%s\n' "disabled" ;;

--- a/scripts/readonly-enable.sh
+++ b/scripts/readonly-enable.sh
@@ -50,16 +50,10 @@ if ! bluetooth_state_persistent; then
   fail "Persistent Bluetooth state is not active. Run ./scripts/readonly-setup.sh --device /dev/... first."
 fi
 
-if [[ "$(overlay_status)" != "enabled" ]]; then
-  if ! raspi-config nonint enable_overlayfs; then
-    fail "Failed to enable OverlayFS through raspi-config."
-  fi
-fi
-
 if ! readonly_stack_packages_healthy; then
   warn "OverlayFS package state is incomplete:"
   readonly_stack_package_report
-  fail "OverlayFS may be toggled on, but package setup did not complete cleanly. Repair the package state before rebooting. On current Raspberry Pi OS releases this can require setting MODULES=most in /etc/initramfs-tools/initramfs.conf, then rerunning sudo dpkg --configure -a."
+  fail "OverlayFS package setup did not complete cleanly. Repair the package state before enabling read-only mode. On current Raspberry Pi OS releases this can require setting MODULES=most in /etc/initramfs-tools/initramfs.conf, then rerunning sudo dpkg --configure -a."
 fi
 
 KERNEL_RELEASE="$(current_kernel_release)"
@@ -77,6 +71,15 @@ if ! BOOT_INITRAMFS_TARGET_PATH="$(ensure_bootable_initramfs_for_current_kernel)
   fail "Failed to prepare the boot initramfs for read-only mode. Fix the kernel or initramfs setup above, then rerun ./scripts/readonly-enable.sh."
 fi
 ok "Boot initramfs is ready at ${BOOT_INITRAMFS_TARGET_PATH}"
+
+if [[ "$(overlay_status)" != "enabled" ]]; then
+  if ! raspi-config nonint enable_overlayfs; then
+    fail "Failed to enable OverlayFS through raspi-config."
+  fi
+fi
+if [[ "$(overlay_status)" != "enabled" ]]; then
+  fail "OverlayFS is still not enabled after raspi-config completed."
+fi
 
 write_readonly_config "persistent" "$B2U_PERSIST_MOUNT" "$B2U_PERSIST_BLUETOOTH_DIR" "$B2U_PERSIST_SPEC" "$B2U_PERSIST_DEVICE"
 ok "OverlayFS has been enabled"

--- a/scripts/readonly-enable.sh
+++ b/scripts/readonly-enable.sh
@@ -72,13 +72,21 @@ if ! BOOT_INITRAMFS_TARGET_PATH="$(ensure_bootable_initramfs_for_current_kernel)
 fi
 ok "Boot initramfs is ready at ${BOOT_INITRAMFS_TARGET_PATH}"
 
-if [[ "$(overlay_status)" != "enabled" ]]; then
+OVERLAY_STATUS_NOW="$(overlay_status)"
+if [[ "$OVERLAY_STATUS_NOW" != "enabled" ]]; then
   if ! raspi-config nonint enable_overlayfs; then
     fail "Failed to enable OverlayFS through raspi-config."
   fi
 fi
-if [[ "$(overlay_status)" != "enabled" ]]; then
-  fail "OverlayFS is still not enabled after raspi-config completed."
+OVERLAY_STATUS_NOW="$(overlay_status)"
+if [[ "$OVERLAY_STATUS_NOW" != "enabled" ]]; then
+  if [[ "$(overlay_configured_status)" == "enabled" ]]; then
+    warn "OverlayFS is configured for the next boot, but the live root is still writable until reboot."
+  elif grep -Eq '(^| )overlayroot=tmpfs($| )' "$(boot_cmdline_path)" 2>/dev/null; then
+    warn "OverlayFS enablement is pending reboot; $(boot_cmdline_path) contains overlayroot=tmpfs even though the live status still reports disabled."
+  else
+    fail "OverlayFS is still not configured after raspi-config completed."
+  fi
 fi
 
 write_readonly_config "persistent" "$B2U_PERSIST_MOUNT" "$B2U_PERSIST_BLUETOOTH_DIR" "$B2U_PERSIST_SPEC" "$B2U_PERSIST_DEVICE"

--- a/scripts/readonly-enable.sh
+++ b/scripts/readonly-enable.sh
@@ -62,11 +62,11 @@ CONFIGURED_INITRAMFS_FILE="$(configured_initramfs_file)"
 EXPECTED_BOOT_INITRAMFS_FILE="$(expected_boot_initramfs_file || true)"
 VERSIONED_INITRDS="$(versioned_initrd_candidates "$KERNEL_RELEASE" | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
 
-warn "Kernel release: ${KERNEL_RELEASE}"
-warn "Configured kernel image: ${CONFIGURED_KERNEL_IMAGE}"
-warn "Explicit initramfs entry: ${CONFIGURED_INITRAMFS_FILE:-<none>}"
-warn "Expected boot initramfs file: ${EXPECTED_BOOT_INITRAMFS_FILE:-<none>}"
-warn "Versioned initramfs candidates: ${VERSIONED_INITRDS:-<none>}"
+info "Kernel release: ${KERNEL_RELEASE}"
+info "Configured kernel image: ${CONFIGURED_KERNEL_IMAGE}"
+info "Explicit initramfs entry: ${CONFIGURED_INITRAMFS_FILE:-<none>}"
+info "Expected boot initramfs file: ${EXPECTED_BOOT_INITRAMFS_FILE:-<none>}"
+info "Versioned initramfs candidates: ${VERSIONED_INITRDS:-<none>}"
 if ! BOOT_INITRAMFS_TARGET_PATH="$(ensure_bootable_initramfs_for_current_kernel)"; then
   fail "Failed to prepare the boot initramfs for read-only mode. Fix the kernel or initramfs setup above, then rerun ./scripts/readonly-enable.sh."
 fi

--- a/scripts/readonly-enable.sh
+++ b/scripts/readonly-enable.sh
@@ -62,12 +62,12 @@ CONFIGURED_INITRAMFS_FILE="$(configured_initramfs_file)"
 EXPECTED_BOOT_INITRAMFS_FILE="$(expected_boot_initramfs_file || true)"
 VERSIONED_INITRDS="$(versioned_initrd_candidates "$KERNEL_RELEASE" | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
 
+warn "Kernel release: ${KERNEL_RELEASE}"
+warn "Configured kernel image: ${CONFIGURED_KERNEL_IMAGE}"
+warn "Explicit initramfs entry: ${CONFIGURED_INITRAMFS_FILE:-<none>}"
+warn "Expected boot initramfs file: ${EXPECTED_BOOT_INITRAMFS_FILE:-<none>}"
+warn "Versioned initramfs candidates: ${VERSIONED_INITRDS:-<none>}"
 if ! BOOT_INITRAMFS_TARGET_PATH="$(ensure_bootable_initramfs_for_current_kernel)"; then
-  warn "Kernel release: ${KERNEL_RELEASE}"
-  warn "Configured kernel image: ${CONFIGURED_KERNEL_IMAGE}"
-  warn "Explicit initramfs entry: ${CONFIGURED_INITRAMFS_FILE:-<none>}"
-  warn "Expected boot initramfs file: ${EXPECTED_BOOT_INITRAMFS_FILE:-<none>}"
-  warn "Versioned initramfs candidates: ${VERSIONED_INITRDS:-<none>}"
   fail "Failed to prepare the boot initramfs for read-only mode. Fix the kernel or initramfs setup above, then rerun ./scripts/readonly-enable.sh."
 fi
 ok "Boot initramfs is ready at ${BOOT_INITRAMFS_TARGET_PATH}"

--- a/scripts/readonly-enable.sh
+++ b/scripts/readonly-enable.sh
@@ -8,6 +8,8 @@ SCRIPTS_DIR="${SCRIPT_DIR}"
 source "${SCRIPTS_DIR}/lib/paths.sh"
 # shellcheck source=./lib/common.sh
 source "${SCRIPTS_DIR}/lib/common.sh"
+# shellcheck source=./lib/boot.sh
+source "${SCRIPTS_DIR}/lib/boot.sh"
 # shellcheck source=./lib/readonly.sh
 source "${SCRIPTS_DIR}/lib/readonly.sh"
 
@@ -59,6 +61,22 @@ if ! readonly_stack_packages_healthy; then
   readonly_stack_package_report
   fail "OverlayFS may be toggled on, but package setup did not complete cleanly. Repair the package state before rebooting. On current Raspberry Pi OS releases this can require setting MODULES=most in /etc/initramfs-tools/initramfs.conf, then rerunning sudo dpkg --configure -a."
 fi
+
+KERNEL_RELEASE="$(current_kernel_release)"
+CONFIGURED_KERNEL_IMAGE="$(configured_kernel_image)"
+CONFIGURED_INITRAMFS_FILE="$(configured_initramfs_file)"
+EXPECTED_BOOT_INITRAMFS_FILE="$(expected_boot_initramfs_file || true)"
+VERSIONED_INITRDS="$(versioned_initrd_candidates "$KERNEL_RELEASE" | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+
+if ! BOOT_INITRAMFS_TARGET_PATH="$(ensure_bootable_initramfs_for_current_kernel)"; then
+  warn "Kernel release: ${KERNEL_RELEASE}"
+  warn "Configured kernel image: ${CONFIGURED_KERNEL_IMAGE}"
+  warn "Explicit initramfs entry: ${CONFIGURED_INITRAMFS_FILE:-<none>}"
+  warn "Expected boot initramfs file: ${EXPECTED_BOOT_INITRAMFS_FILE:-<none>}"
+  warn "Versioned initramfs candidates: ${VERSIONED_INITRDS:-<none>}"
+  fail "Failed to prepare the boot initramfs for read-only mode. Fix the kernel or initramfs setup above, then rerun ./scripts/readonly-enable.sh."
+fi
+ok "Boot initramfs is ready at ${BOOT_INITRAMFS_TARGET_PATH}"
 
 write_readonly_config "persistent" "$B2U_PERSIST_MOUNT" "$B2U_PERSIST_BLUETOOTH_DIR" "$B2U_PERSIST_SPEC" "$B2U_PERSIST_DEVICE"
 ok "OverlayFS has been enabled"

--- a/scripts/smoketest.sh
+++ b/scripts/smoketest.sh
@@ -91,6 +91,7 @@ if ROOT_FILESYSTEM_TYPE="$(current_root_filesystem_type)"; then
     ROOT_OVERLAY_ACTIVE="no"
   fi
 else
+  ROOT_FILESYSTEM_TYPE="unknown"
   if [[ "$ALLOW_NON_PI" == "1" ]]; then
     soft_warn "Could not determine the live root filesystem type"
   elif [[ "$OVERLAY_STATUS" == "enabled" && "$SMOKETEST_POST_REBOOT" != "1" ]]; then

--- a/scripts/smoketest.sh
+++ b/scripts/smoketest.sh
@@ -333,16 +333,24 @@ else
   ok "Root overlay is inactive"
 fi
 
-if [[ -n "$EXPECTED_BOOT_INITRAMFS_PATH" ]]; then
+if [[ "$OVERLAY_STATUS" == "enabled" || "$ROOT_OVERLAY_ACTIVE" == "yes" || "$READONLY_MODE" == "persistent" ]]; then
+  if [[ -n "$EXPECTED_BOOT_INITRAMFS_PATH" ]]; then
+    if [[ -s "$EXPECTED_BOOT_INITRAMFS_PATH" ]]; then
+      ok "Boot initramfs is present (${EXPECTED_BOOT_INITRAMFS_PATH})"
+    else
+      warn "Boot initramfs is missing or empty (${EXPECTED_BOOT_INITRAMFS_PATH})"
+      EXIT_CODE=1
+    fi
+  else
+    warn "Boot initramfs target could not be determined"
+    EXIT_CODE=1
+  fi
+elif [[ -n "$EXPECTED_BOOT_INITRAMFS_PATH" ]]; then
   if [[ -s "$EXPECTED_BOOT_INITRAMFS_PATH" ]]; then
     ok "Boot initramfs is present (${EXPECTED_BOOT_INITRAMFS_PATH})"
   else
-    warn "Boot initramfs is missing or empty (${EXPECTED_BOOT_INITRAMFS_PATH})"
-    EXIT_CODE=1
+    soft_warn "Boot initramfs is not present yet (${EXPECTED_BOOT_INITRAMFS_PATH})"
   fi
-elif [[ "$OVERLAY_STATUS" == "enabled" ]]; then
-  warn "Boot initramfs target could not be determined"
-  EXIT_CODE=1
 fi
 
 if machine_id_valid; then

--- a/scripts/smoketest.sh
+++ b/scripts/smoketest.sh
@@ -488,7 +488,12 @@ if [[ $VERBOSE -eq 1 ]]; then
   echo "Allow non-Pi overlay bypass: ${ALLOW_NON_PI}"
   echo "Root filesystem type: ${ROOT_FILESYSTEM_TYPE}"
   echo "Root overlay active: ${ROOT_OVERLAY_ACTIVE}"
-  echo "Root mount: $(root_overlay_report)"
+  ROOT_MOUNT_REPORT="$(root_overlay_report)"
+  if [[ -n "$ROOT_MOUNT_REPORT" ]]; then
+    printf 'Root mount:\n%s\n' "$ROOT_MOUNT_REPORT"
+  else
+    echo "Root mount: <unknown>"
+  fi
   echo "Bluetooth state persistent: ${BLUETOOTH_STATE_PERSISTENT}"
   echo "Smoketest post-reboot mode: ${SMOKETEST_POST_REBOOT}"
   echo "Relayable device count: ${RELAYABLE_COUNT:-unknown}"

--- a/scripts/smoketest.sh
+++ b/scripts/smoketest.sh
@@ -18,6 +18,7 @@ VENV_DIR="${B2U_INSTALL_DIR}/venv"
 VERBOSE=0
 EXIT_CODE=0
 SOFT_WARNINGS=0
+SMOKETEST_POST_REBOOT="${SMOKETEST_POST_REBOOT:-0}"
 
 usage() {
   cat <<EOF
@@ -70,14 +71,22 @@ DWC2_MODE="$(dwc2_mode)"
 IFS=',' read -r -a REQUIRED_MODULES <<<"$(required_boot_modules_csv)"
 EXPECTED_OVERLAY_LINE="$(expected_dwc2_overlay_line)"
 OVERLAY_STATUS="$(overlay_status)"
-ROOT_OVERLAY_ACTIVE="no"
+ROOT_OVERLAY_ACTIVE="unknown"
+ROOT_FILESYSTEM_TYPE="unknown"
 BLUETOOTH_STATE_PERSISTENT="no"
 CONFIGURED_INITRAMFS_FILE="$(configured_initramfs_file)"
 EXPECTED_BOOT_INITRAMFS_FILE="$(expected_boot_initramfs_file || true)"
 EXPECTED_BOOT_INITRAMFS_PATH=""
 
-if root_overlay_active; then
-  ROOT_OVERLAY_ACTIVE="yes"
+if ROOT_FILESYSTEM_TYPE="$(current_root_filesystem_type)"; then
+  if [[ "$ROOT_FILESYSTEM_TYPE" == "overlay" ]]; then
+    ROOT_OVERLAY_ACTIVE="yes"
+  else
+    ROOT_OVERLAY_ACTIVE="no"
+  fi
+else
+  warn "Could not determine the live root filesystem type"
+  EXIT_CODE=1
 fi
 
 if bluetooth_state_persistent; then
@@ -322,6 +331,13 @@ esac
 
 if [[ "$ROOT_OVERLAY_ACTIVE" == "yes" ]]; then
   ok "Root overlay is active"
+elif [[ "$ROOT_OVERLAY_ACTIVE" == "unknown" ]]; then
+  warn "Could not determine whether the root overlay is active"
+  ROOT_MOUNT_REPORT="$(root_overlay_report)"
+  if [[ -n "$ROOT_MOUNT_REPORT" ]]; then
+    printf '%s\n' "$ROOT_MOUNT_REPORT"
+  fi
+  EXIT_CODE=1
 elif [[ "$OVERLAY_STATUS" == "enabled" ]]; then
   warn "Root overlay is not active"
   ROOT_MOUNT_REPORT="$(root_overlay_report)"
@@ -387,9 +403,17 @@ fi
 
 if [[ "$READONLY_MODE" == "persistent" ]]; then
   ok "Read-only mode is persistent"
+elif [[ "$READONLY_MODE" == "unknown" ]]; then
+  warn "Read-only mode could not be determined"
+  EXIT_CODE=1
 else
   if [[ "$OVERLAY_STATUS" == "disabled" && "$ROOT_OVERLAY_ACTIVE" == "no" ]]; then
     ok "Read-only mode is disabled"
+  elif [[ "$OVERLAY_STATUS" == "enabled" && "$ROOT_OVERLAY_ACTIVE" == "no" ]]; then
+    warn "Read-only mode is not persistent"
+    if [[ "$SMOKETEST_POST_REBOOT" == "1" ]]; then
+      EXIT_CODE=1
+    fi
   else
     warn "Read-only mode is not persistent"
     EXIT_CODE=1
@@ -414,6 +438,7 @@ if [[ $VERBOSE -eq 1 ]]; then
   echo "UDC state: ${UDC_STATE_VALUE:-<unknown>}"
   echo "Readonly mode: ${READONLY_MODE}"
   echo "OverlayFS configured: ${OVERLAY_STATUS}"
+  echo "Root filesystem type: ${ROOT_FILESYSTEM_TYPE}"
   echo "Root overlay active: ${ROOT_OVERLAY_ACTIVE}"
   echo "Root mount: $(root_overlay_report)"
   echo "Bluetooth state persistent: ${BLUETOOTH_STATE_PERSISTENT}"

--- a/scripts/smoketest.sh
+++ b/scripts/smoketest.sh
@@ -346,16 +346,32 @@ elif [[ "$OVERLAY_STATUS" == "enabled" ]]; then
 fi
 
 if machine_id_valid; then
-  ok "machine-id is stable"
+  if [[ "$READONLY_MODE" == "persistent" ]]; then
+    ok "machine-id is ready for persistent read-only mode"
+  else
+    ok "machine-id is stable"
+  fi
 elif [[ "$OVERLAY_STATUS" == "enabled" || "$READONLY_MODE" == "persistent" ]]; then
-  warn "machine-id is missing or invalid"
+  if [[ "$READONLY_MODE" == "persistent" ]]; then
+    warn "machine-id is missing or invalid for persistent read-only mode"
+  else
+    warn "machine-id is missing or invalid"
+  fi
   EXIT_CODE=1
 fi
 
 if [[ "$BLUETOOTH_STATE_PERSISTENT" == "yes" ]]; then
-  ok "Bluetooth state persistence is active"
+  if [[ "$READONLY_MODE" == "persistent" ]]; then
+    ok "Bluetooth state is mounted persistently"
+  else
+    ok "Bluetooth state persistence is active"
+  fi
 elif [[ "$OVERLAY_STATUS" == "enabled" || "$READONLY_MODE" == "persistent" ]]; then
-  warn "Bluetooth state persistence is not active"
+  if [[ "$READONLY_MODE" == "persistent" ]]; then
+    warn "Bluetooth state is not mounted persistently"
+  else
+    warn "Bluetooth state persistence is not active"
+  fi
   EXIT_CODE=1
 else
   ok "Bluetooth state persistence is not configured"
@@ -368,22 +384,6 @@ else
     ok "Read-only mode is disabled"
   else
     warn "Read-only mode is not persistent"
-    EXIT_CODE=1
-  fi
-fi
-
-if [[ "$READONLY_MODE" == "persistent" ]]; then
-  if machine_id_valid; then
-    ok "machine-id is ready for persistent read-only mode"
-  else
-    warn "machine-id is missing or invalid for persistent read-only mode"
-    EXIT_CODE=1
-  fi
-
-  if [[ "$BLUETOOTH_STATE_PERSISTENT" == "yes" ]]; then
-    ok "Bluetooth state is mounted persistently"
-  else
-    warn "Bluetooth state is not mounted persistently"
     EXIT_CODE=1
   fi
 fi

--- a/scripts/smoketest.sh
+++ b/scripts/smoketest.sh
@@ -69,6 +69,24 @@ UDC_STATE_VALUE=""
 DWC2_MODE="$(dwc2_mode)"
 IFS=',' read -r -a REQUIRED_MODULES <<<"$(required_boot_modules_csv)"
 EXPECTED_OVERLAY_LINE="$(expected_dwc2_overlay_line)"
+OVERLAY_STATUS="$(overlay_status)"
+ROOT_OVERLAY_ACTIVE="no"
+BLUETOOTH_STATE_PERSISTENT="no"
+CONFIGURED_INITRAMFS_FILE="$(configured_initramfs_file)"
+EXPECTED_BOOT_INITRAMFS_FILE="$(expected_boot_initramfs_file || true)"
+EXPECTED_BOOT_INITRAMFS_PATH=""
+
+if root_overlay_active; then
+  ROOT_OVERLAY_ACTIVE="yes"
+fi
+
+if bluetooth_state_persistent; then
+  BLUETOOTH_STATE_PERSISTENT="yes"
+fi
+
+if [[ -n "$EXPECTED_BOOT_INITRAMFS_FILE" ]]; then
+  EXPECTED_BOOT_INITRAMFS_PATH="$(boot_initramfs_target_path "$EXPECTED_BOOT_INITRAMFS_FILE" 2>/dev/null || true)"
+fi
 
 modules_load_has_required_modules() {
   local module
@@ -107,6 +125,14 @@ required_modules_list() {
 
   joined="$(printf '%s,' "${REQUIRED_MODULES[@]}")"
   printf '%s\n' "${joined%,}"
+}
+
+print_verbose_section_header() {
+  if [[ ${VERBOSE_SECTION_COUNT:-0} -gt 0 ]]; then
+    echo
+  fi
+  VERBOSE_SECTION_COUNT=$((VERBOSE_SECTION_COUNT + 1))
+  echo "## $1"
 }
 
 if grep -qxF "$EXPECTED_OVERLAY_LINE" "$CONFIG_TXT"; then
@@ -281,15 +307,80 @@ else
   EXIT_CODE=1
 fi
 
+case "$OVERLAY_STATUS" in
+  enabled)
+    ok "OverlayFS boot configuration is enabled"
+    ;;
+  disabled)
+    ok "OverlayFS boot configuration is disabled"
+    ;;
+  *)
+    warn "OverlayFS boot configuration status is unknown"
+    EXIT_CODE=1
+    ;;
+esac
+
+if [[ "$ROOT_OVERLAY_ACTIVE" == "yes" ]]; then
+  ok "Root overlay is active"
+elif [[ "$OVERLAY_STATUS" == "enabled" ]]; then
+  warn "Root overlay is not active"
+  ROOT_MOUNT_REPORT="$(root_overlay_report)"
+  if [[ -n "$ROOT_MOUNT_REPORT" ]]; then
+    printf '%s\n' "$ROOT_MOUNT_REPORT"
+  fi
+  EXIT_CODE=1
+else
+  ok "Root overlay is inactive"
+fi
+
+if [[ -n "$EXPECTED_BOOT_INITRAMFS_PATH" ]]; then
+  if [[ -s "$EXPECTED_BOOT_INITRAMFS_PATH" ]]; then
+    ok "Boot initramfs is present (${EXPECTED_BOOT_INITRAMFS_PATH})"
+  else
+    warn "Boot initramfs is missing or empty (${EXPECTED_BOOT_INITRAMFS_PATH})"
+    EXIT_CODE=1
+  fi
+elif [[ "$OVERLAY_STATUS" == "enabled" ]]; then
+  warn "Boot initramfs target could not be determined"
+  EXIT_CODE=1
+fi
+
+if machine_id_valid; then
+  ok "machine-id is stable"
+elif [[ "$OVERLAY_STATUS" == "enabled" || "$READONLY_MODE" == "persistent" ]]; then
+  warn "machine-id is missing or invalid"
+  EXIT_CODE=1
+fi
+
+if [[ "$BLUETOOTH_STATE_PERSISTENT" == "yes" ]]; then
+  ok "Bluetooth state persistence is active"
+elif [[ "$OVERLAY_STATUS" == "enabled" || "$READONLY_MODE" == "persistent" ]]; then
+  warn "Bluetooth state persistence is not active"
+  EXIT_CODE=1
+else
+  ok "Bluetooth state persistence is not configured"
+fi
+
+if [[ "$READONLY_MODE" == "persistent" ]]; then
+  ok "Read-only mode is persistent"
+else
+  if [[ "$OVERLAY_STATUS" == "disabled" && "$ROOT_OVERLAY_ACTIVE" == "no" ]]; then
+    ok "Read-only mode is disabled"
+  else
+    warn "Read-only mode is not persistent"
+    EXIT_CODE=1
+  fi
+fi
+
 if [[ "$READONLY_MODE" == "persistent" ]]; then
   if machine_id_valid; then
-    ok "machine-id is stable for persistent read-only mode"
+    ok "machine-id is ready for persistent read-only mode"
   else
     warn "machine-id is missing or invalid for persistent read-only mode"
     EXIT_CODE=1
   fi
 
-  if bluetooth_state_persistent; then
+  if [[ "$BLUETOOTH_STATE_PERSISTENT" == "yes" ]]; then
     ok "Bluetooth state is mounted persistently"
   else
     warn "Bluetooth state is not mounted persistently"
@@ -297,50 +388,49 @@ if [[ "$READONLY_MODE" == "persistent" ]]; then
   fi
 fi
 
-if [[ "$(overlay_status)" == "enabled" && "$READONLY_MODE" != "persistent" ]]; then
-  warn "OverlayFS is enabled without persistent Bluetooth state; this setup is unsupported."
-  EXIT_CODE=1
-fi
-
-info "OverlayFS status: $(overlay_status)"
-info "Read-only mode: ${READONLY_MODE}"
-info "Bluetooth state persistent: $(bluetooth_state_persistent && echo yes || echo no)"
-
 if [[ $VERBOSE -eq 1 ]]; then
-  echo "## Summary"
+  VERBOSE_SECTION_COUNT=0
+  print_verbose_section_header "Summary"
   echo "Boot config: ${CONFIG_TXT}"
   echo "Cmdline: ${CMDLINE_TXT}"
   echo "modules-load token: ${MODULES_LOAD_VALUE:-<missing>}"
   echo "required modules: $(required_modules_list)"
   echo "required modules status: $(required_modules_status)"
   echo "expected overlay line: ${EXPECTED_OVERLAY_LINE}"
+  echo "configured kernel image: $(configured_kernel_image)"
+  echo "configured initramfs file: ${CONFIGURED_INITRAMFS_FILE:-<none>}"
+  echo "expected boot initramfs file: ${EXPECTED_BOOT_INITRAMFS_FILE:-<none>}"
+  echo "expected boot initramfs path: ${EXPECTED_BOOT_INITRAMFS_PATH:-<none>}"
   echo "UDC controllers: ${UDC_LIST:-<none>}"
   echo "UDC state path: ${UDC_STATE_PATH:-<unknown>}"
   echo "UDC state: ${UDC_STATE_VALUE:-<unknown>}"
   echo "Readonly mode: ${READONLY_MODE}"
-  echo "OverlayFS: $(overlay_status)"
-  echo "Bluetooth state persistent: $(bluetooth_state_persistent && echo yes || echo no)"
+  echo "OverlayFS configured: ${OVERLAY_STATUS}"
+  echo "Root overlay active: ${ROOT_OVERLAY_ACTIVE}"
+  echo "Root mount: $(root_overlay_report)"
+  echo "Bluetooth state persistent: ${BLUETOOTH_STATE_PERSISTENT}"
   echo "Relayable device count: ${RELAYABLE_COUNT:-unknown}"
   echo "Paired Bluetooth device count: ${PAIRED_COUNT:-unknown}"
   echo "Non-fatal warning count: ${SOFT_WARNINGS}"
-  echo "## CLI validate-env output"
+  print_verbose_section_header "CLI validate-env output"
   cat "$VALIDATE_LOG"
-  echo "## Service config check"
+  print_verbose_section_header "Service config check"
   cat "$SERVICE_CONFIG_LOG"
-  echo "## bluetoothctl show"
+  print_verbose_section_header "bluetoothctl show"
   cat "$BLUETOOTH_SHOW_LOG"
-  echo "## btmgmt info"
+  print_verbose_section_header "btmgmt info"
   cat "$BTMGMT_INFO_LOG"
-  echo "## rfkill bluetooth"
+  print_verbose_section_header "rfkill bluetooth"
   cat "$RFKILL_LOG"
-  echo "## Device inventory"
+  print_verbose_section_header "Device inventory"
   cat "$LIST_DEVICES_JSON"
-  echo "## Mount details"
+  print_verbose_section_header "Mount details"
+  findmnt -n -T / 2>/dev/null || true
   findmnt -n -T /var/lib/bluetooth 2>/dev/null || true
   findmnt -n "$B2U_PERSIST_MOUNT" 2>/dev/null || true
-  echo "## Service status"
+  print_verbose_section_header "Service status"
   systemctl --no-pager --full status "${B2U_SERVICE_UNIT}" || true
-  echo "## Journal"
+  print_verbose_section_header "Journal"
   journalctl -b -u "${B2U_SERVICE_UNIT}" -n 100 --no-pager || true
 fi
 

--- a/scripts/smoketest.sh
+++ b/scripts/smoketest.sh
@@ -18,12 +18,14 @@ VENV_DIR="${B2U_INSTALL_DIR}/venv"
 VERBOSE=0
 EXIT_CODE=0
 SOFT_WARNINGS=0
+ALLOW_NON_PI="${ALLOW_NON_PI:-0}"
 SMOKETEST_POST_REBOOT="${SMOKETEST_POST_REBOOT:-0}"
 
 usage() {
   cat <<EOF
 Usage: sudo ./scripts/smoketest.sh [options]
   --verbose           Print detailed diagnostics, including journalctl
+  --allow-non-pi      Do not fail when OverlayFS detection is unavailable
 EOF
 }
 
@@ -31,6 +33,10 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --verbose)
       VERBOSE=1
+      shift
+      ;;
+    --allow-non-pi)
+      ALLOW_NON_PI=1
       shift
       ;;
     -h | --help)
@@ -302,11 +308,16 @@ else
   EXIT_CODE=1
 fi
 
-PAIRED_COUNT="$(bluetooth_paired_count)"
-if [[ "${PAIRED_COUNT:-0}" -gt 0 ]]; then
-  ok "Paired Bluetooth devices detected (${PAIRED_COUNT})"
+PAIRED_COUNT=0
+if PAIRED_COUNT="$(bluetooth_paired_count)"; then
+  if [[ "${PAIRED_COUNT:-0}" -gt 0 ]]; then
+    ok "Paired Bluetooth devices detected (${PAIRED_COUNT})"
+  else
+    soft_warn "No paired Bluetooth devices detected"
+  fi
 else
-  soft_warn "No paired Bluetooth devices detected"
+  warn "bluetoothctl failed while listing paired devices"
+  EXIT_CODE=1
 fi
 
 if [[ -d /var/lib/bluetooth ]]; then
@@ -325,7 +336,9 @@ case "$OVERLAY_STATUS" in
     ;;
   *)
     warn "OverlayFS boot configuration status is unknown"
-    EXIT_CODE=1
+    if [[ "$ALLOW_NON_PI" != "1" ]]; then
+      EXIT_CODE=1
+    fi
     ;;
 esac
 
@@ -414,6 +427,9 @@ else
     if [[ "$SMOKETEST_POST_REBOOT" == "1" ]]; then
       EXIT_CODE=1
     fi
+  elif [[ "$OVERLAY_STATUS" == "disabled" && "$ROOT_OVERLAY_ACTIVE" == "yes" ]]; then
+    warn "Read-only mode config drift: overlay active but not configured to persist"
+    EXIT_CODE=1
   else
     warn "Read-only mode is not persistent"
     EXIT_CODE=1
@@ -438,10 +454,12 @@ if [[ $VERBOSE -eq 1 ]]; then
   echo "UDC state: ${UDC_STATE_VALUE:-<unknown>}"
   echo "Readonly mode: ${READONLY_MODE}"
   echo "OverlayFS configured: ${OVERLAY_STATUS}"
+  echo "Allow non-Pi overlay bypass: ${ALLOW_NON_PI}"
   echo "Root filesystem type: ${ROOT_FILESYSTEM_TYPE}"
   echo "Root overlay active: ${ROOT_OVERLAY_ACTIVE}"
   echo "Root mount: $(root_overlay_report)"
   echo "Bluetooth state persistent: ${BLUETOOTH_STATE_PERSISTENT}"
+  echo "Smoketest post-reboot mode: ${SMOKETEST_POST_REBOOT}"
   echo "Relayable device count: ${RELAYABLE_COUNT:-unknown}"
   echo "Paired Bluetooth device count: ${PAIRED_COUNT:-unknown}"
   echo "Non-fatal warning count: ${SOFT_WARNINGS}"

--- a/scripts/smoketest.sh
+++ b/scripts/smoketest.sh
@@ -75,7 +75,7 @@ UDC_STATE_PATH=""
 UDC_STATE_VALUE=""
 DWC2_MODE="$(dwc2_mode)"
 IFS=',' read -r -a REQUIRED_MODULES <<<"$(required_boot_modules_csv)"
-EXPECTED_OVERLAY_LINE="$(expected_dwc2_overlay_line)"
+EXPECTED_OVERLAY_LINE="$(expected_dwc2_overlay_line 2>/dev/null || true)"
 OVERLAY_STATUS="$(overlay_status)"
 ROOT_OVERLAY_ACTIVE="unknown"
 ROOT_FILESYSTEM_TYPE="unknown"
@@ -91,8 +91,14 @@ if ROOT_FILESYSTEM_TYPE="$(current_root_filesystem_type)"; then
     ROOT_OVERLAY_ACTIVE="no"
   fi
 else
-  warn "Could not determine the live root filesystem type"
-  EXIT_CODE=1
+  if [[ "$ALLOW_NON_PI" == "1" ]]; then
+    soft_warn "Could not determine the live root filesystem type"
+  elif [[ "$OVERLAY_STATUS" == "enabled" && "$SMOKETEST_POST_REBOOT" != "1" ]]; then
+    soft_warn "Could not determine the live root filesystem type before reboot"
+  else
+    warn "Could not determine the live root filesystem type"
+    EXIT_CODE=1
+  fi
 fi
 
 if bluetooth_state_persistent; then
@@ -150,7 +156,14 @@ print_verbose_section_header() {
   echo "## $1"
 }
 
-if grep -qxF "$EXPECTED_OVERLAY_LINE" "$CONFIG_TXT"; then
+if [[ -z "$EXPECTED_OVERLAY_LINE" ]]; then
+  if [[ "$ALLOW_NON_PI" == "1" ]]; then
+    soft_warn "Could not determine expected Raspberry Pi overlay line"
+  else
+    warn "Could not determine expected Raspberry Pi overlay line"
+    EXIT_CODE=1
+  fi
+elif grep -qxF "$EXPECTED_OVERLAY_LINE" "$CONFIG_TXT"; then
   ok "config.txt contains expected overlay (${EXPECTED_OVERLAY_LINE})"
 else
   warn "config.txt is missing expected overlay (${EXPECTED_OVERLAY_LINE})"
@@ -345,19 +358,29 @@ esac
 if [[ "$ROOT_OVERLAY_ACTIVE" == "yes" ]]; then
   ok "Root overlay is active"
 elif [[ "$ROOT_OVERLAY_ACTIVE" == "unknown" ]]; then
-  warn "Could not determine whether the root overlay is active"
+  if [[ "$ALLOW_NON_PI" == "1" ]]; then
+    soft_warn "Could not determine whether the root overlay is active"
+  elif [[ "$OVERLAY_STATUS" == "enabled" && "$SMOKETEST_POST_REBOOT" != "1" ]]; then
+    soft_warn "Could not determine whether the root overlay is active before reboot"
+  else
+    warn "Could not determine whether the root overlay is active"
+    EXIT_CODE=1
+  fi
   ROOT_MOUNT_REPORT="$(root_overlay_report)"
   if [[ -n "$ROOT_MOUNT_REPORT" ]]; then
     printf '%s\n' "$ROOT_MOUNT_REPORT"
   fi
-  EXIT_CODE=1
 elif [[ "$OVERLAY_STATUS" == "enabled" ]]; then
-  warn "Root overlay is not active"
+  if [[ "$SMOKETEST_POST_REBOOT" == "1" ]]; then
+    warn "Root overlay is not active"
+    EXIT_CODE=1
+  else
+    soft_warn "Root overlay is not active; reboot may still be pending"
+  fi
   ROOT_MOUNT_REPORT="$(root_overlay_report)"
   if [[ -n "$ROOT_MOUNT_REPORT" ]]; then
     printf '%s\n' "$ROOT_MOUNT_REPORT"
   fi
-  EXIT_CODE=1
 else
   ok "Root overlay is inactive"
 fi
@@ -426,6 +449,13 @@ else
     warn "Read-only mode is not persistent"
     if [[ "$SMOKETEST_POST_REBOOT" == "1" ]]; then
       EXIT_CODE=1
+    fi
+  elif [[ "$OVERLAY_STATUS" == "enabled" && "$ROOT_OVERLAY_ACTIVE" == "unknown" ]]; then
+    if [[ "$SMOKETEST_POST_REBOOT" == "1" ]]; then
+      warn "Read-only mode could not be confirmed after reboot"
+      EXIT_CODE=1
+    else
+      soft_warn "Read-only mode could not be confirmed yet; reboot may still be pending"
     fi
   elif [[ "$OVERLAY_STATUS" == "disabled" && "$ROOT_OVERLAY_ACTIVE" == "yes" ]]; then
     warn "Read-only mode config drift: overlay active but not configured to persist"


### PR DESCRIPTION
## Summary
- automate boot initramfs preparation for the active kernel when enabling persistent read-only mode
- switch read-only detection to the live root mount state and tighten smoketest reporting/output
- update the read-only and remote-wakeup docs to reflect the intended initramfs and validation flow

## Validation
- `bash -n` on the changed shell scripts
- `shellcheck` on the changed shell scripts
- Pi validation on `pi4b` after installing this branch into `/opt/bluetooth_2_usb`
- `sudo ./scripts/install.sh`
- `sudo ./scripts/smoketest.sh --verbose` on writable root
- `sudo ./scripts/debug.sh --duration 1` on writable root
- `sudo ./scripts/readonly-enable.sh` and reboot to live overlay root
- `sudo ./scripts/smoketest.sh --verbose` on live overlay root
- `sudo ./scripts/debug.sh --duration 1` on live overlay root
- `sudo ./scripts/readonly-enable.sh` idempotence check on live overlay root
- delete-and-reboot regression under active read-only mode, followed by another `sudo ./scripts/smoketest.sh --verbose`
- `sudo bluetoothctl show`
- `sudo btmgmt info`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Post-reboot smoketest mode adds a reboot flag, emits extra boot/root diagnostics, and requires initramfs readiness before enabling persistent read-only.

* **Documentation**
  * Expanded target/build matrix, per-board kernel/initramfs guidance, and updated persistent read-only and custom-kernel checklists (including kernel-module/config preservation notes).

* **Bug Fixes**
  * More robust overlay/rootfs detection and gating, clearer smoketest verdicts, improved timeout handling and reporting, refined Bluetooth checks, and stricter device-model validation.

* **Chores**
  * Disabled automatic CodeRabbit auto-review in configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->