### PR TITLE
feat: add extended HID loopback support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,9 @@ Branch and commit naming:
   `test/`, `chore/`
 - use matching conventional commit prefixes such as `feat:`, `fix:`, `docs:`,
   `refactor:`, `test:`, `chore:`
+- keep branch names, commit messages, PR titles, and PR bodies focused on the
+  project change; do not include assistant, automation, or tool branding in
+  those Git artifacts
 - do not push directly to `main`
 
 ## Review and CI

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ healthy.
 | Argument | Meaning |
 | --- | --- |
 | `--verbose` | Print fuller diagnostics, including the collected summary data. |
+| `--allow-non-pi` | Suppress hard failures for non-Pi OverlayFS and root filesystem detection uncertainty. |
 
 ### `debug.sh`
 
@@ -240,6 +241,12 @@ harness.
 ### `loopback-capture.ps1`
 
 Windows PowerShell wrapper for the same host-capture flow.
+
+### `capture-device.sh`
+
+Capture redacted input-device inventory and optional live evdev samples for
+hardware support work, such as gamepads, trackpads, drawing tablets, mouse pan,
+and keyboard LED behavior.
 
 ### `install-hid-udev-rule.sh`
 
@@ -279,6 +286,7 @@ Bluetooth-state configuration available.
 - Contributor workflow: [CONTRIBUTING.md](CONTRIBUTING.md)
 - Pi validation flow: [docs/cli-service-test.md](docs/cli-service-test.md)
 - Loopback inject/capture harness: [docs/host-relay-loopback.md](docs/host-relay-loopback.md)
+- Device capture workflow: [docs/device-capture.md](docs/device-capture.md)
 - Persistent read-only workflow: [docs/persistent-readonly.md](docs/persistent-readonly.md)
 - Doc consistency review: [docs/doc-consistency-review.md](docs/doc-consistency-review.md)
 - Release tagging and versioning: [docs/release-versioning-policy.md](docs/release-versioning-policy.md)

--- a/docs/cli-service-test.md
+++ b/docs/cli-service-test.md
@@ -72,6 +72,7 @@ ssh <pi-host> '
   bash /opt/bluetooth_2_usb/scripts/uninstall.sh --help >/dev/null
   bash /opt/bluetooth_2_usb/scripts/smoketest.sh --help >/dev/null
   bash /opt/bluetooth_2_usb/scripts/debug.sh --help >/dev/null
+  bash /opt/bluetooth_2_usb/scripts/capture-device.sh --help >/dev/null
   bash /opt/bluetooth_2_usb/scripts/loopback-inject.sh --help >/dev/null
   bash /opt/bluetooth_2_usb/scripts/readonly-enable.sh --help >/dev/null
   bash /opt/bluetooth_2_usb/scripts/readonly-disable.sh --help >/dev/null

--- a/docs/device-capture.md
+++ b/docs/device-capture.md
@@ -1,0 +1,68 @@
+# Device Capture
+
+Use this guide when a gamepad, trackpad, drawing tablet, mouse wheel, or
+keyboard LED behavior needs real-device data before support can be completed.
+
+The capture helper prints redacted JSON by default:
+
+```bash
+sudo /opt/bluetooth_2_usb/scripts/capture-device.sh
+```
+
+To capture live events from one device, first list devices:
+
+```bash
+bluetooth_2_usb --list_devices --output json
+```
+
+Then sample the matching event node while using the controls you care about:
+
+```bash
+sudo /opt/bluetooth_2_usb/scripts/capture-device.sh \
+  --device /dev/input/event4 \
+  --duration 15 \
+  --output json
+```
+
+The output includes:
+
+- current Bluetooth-2-USB inventory metadata
+- event types such as `EV_KEY`, `EV_REL`, `EV_ABS`, and `EV_FF`
+- input properties such as pointer/buttonpad hints
+- absolute axis ranges, fuzz, flat, and resolution
+- detected relay classes
+- live evdev events grouped by `SYN_REPORT`
+
+MAC-address-like values are redacted.
+
+## Suggested Samples
+
+For an Apple Magic Trackpad, capture:
+
+- one-finger movement
+- physical click
+- two-finger vertical scroll
+- two-finger horizontal scroll
+- three or more fingers moving together
+
+For a DualSense or Xbox controller, capture:
+
+- every face button
+- shoulders and triggers
+- both sticks, including center release
+- D-pad in each direction
+- home/guide/share/options buttons where available
+- a short host-side rumble test if possible
+
+For a drawing tablet, capture:
+
+- hover movement
+- tip down/up
+- pressure ramp
+- tilt in both axes
+- barrel buttons
+- eraser, if present
+- touch surface gestures, if the tablet exposes a separate touch node
+
+For keyboard LED issues, capture inventory and then run a live relay session while
+toggling Caps Lock, Num Lock, and Scroll Lock from the target host.

--- a/docs/host-relay-loopback.md
+++ b/docs/host-relay-loopback.md
@@ -86,7 +86,7 @@ From the repository checkout on the host:
 Default behavior:
 
 - detects the gadget HID device by product name and HID usage
-- waits up to `5` seconds for the complete sequence
+- waits up to `10` seconds for the complete sequence
 - may temporarily claim the gadget HID interfaces while the capture runs, so do
   not assume the local desktop will process the same inputs during that window
 - uses a single harness lock file; do not run multiple inject/capture sessions
@@ -129,8 +129,8 @@ and emits this deterministic sequence:
 - keyboard: `KEY_F13`, `KEY_F14`, `KEY_F15` down/up
 - mouse: `REL_X +1`, `REL_X -1`, `REL_Y +1`, `REL_Y -1`,
   `REL_WHEEL +1`, `REL_WHEEL -1`, `REL_HWHEEL +1`, `REL_HWHEEL -1`, one coalesced `REL_X +2` /
-  `REL_Y -3` / `REL_HWHEEL +1` frame, then `BTN_FORWARD`, `BTN_BACK`, and
-  `BTN_TASK` press/release
+  `REL_Y -3` / `REL_HWHEEL +1` frame, then mouse buttons 1 through 8
+  press/release (`BTN_LEFT` through `BTN_TASK`)
 
 The mouse gadget report uses one button byte, signed 16-bit relative X/Y, and
 signed 8-bit wheel/pan.

--- a/docs/host-relay-loopback.md
+++ b/docs/host-relay-loopback.md
@@ -127,7 +127,13 @@ The injector creates temporary virtual devices named:
 and emits this deterministic sequence:
 
 - keyboard: `KEY_F13`, `KEY_F14`, `KEY_F15` down/up
-- mouse: `REL_X +1`, `REL_X -1`, `REL_Y +1`, `REL_Y -1`
+- mouse: `REL_X +1`, `REL_X -1`, `REL_Y +1`, `REL_Y -1`,
+  `REL_HWHEEL +1`, `REL_HWHEEL -1`, one coalesced `REL_X +2` /
+  `REL_Y -3` / `REL_HWHEEL +1` frame, then `BTN_FORWARD`, `BTN_BACK`, and
+  `BTN_TASK` press/release
+
+The mouse gadget report uses one button byte, signed 16-bit relative X/Y, and
+signed 8-bit wheel/pan.
 
 ## 4. Success criteria
 
@@ -235,9 +241,9 @@ run is active, clear the stale lock file and retry.
 
 Lock paths:
 
-- host Windows: `%TEMP%\bluetooth_2_usb_test_harness.lock`
-- host Linux/macOS: `/tmp/bluetooth_2_usb_test_harness.lock`
-- Pi: `/tmp/bluetooth_2_usb_test_harness.lock`
+- host Windows: `%TEMP%\bluetooth_2_usb_loopback_harness.lock`
+- host Linux/macOS: `/tmp/bluetooth_2_usb_loopback_harness.lock`
+- Pi: `/tmp/bluetooth_2_usb_loopback_harness.lock`
 
 ## 7. CI scope
 

--- a/docs/host-relay-loopback.md
+++ b/docs/host-relay-loopback.md
@@ -128,7 +128,7 @@ and emits this deterministic sequence:
 
 - keyboard: `KEY_F13`, `KEY_F14`, `KEY_F15` down/up
 - mouse: `REL_X +1`, `REL_X -1`, `REL_Y +1`, `REL_Y -1`,
-  `REL_HWHEEL +1`, `REL_HWHEEL -1`, one coalesced `REL_X +2` /
+  `REL_WHEEL +1`, `REL_WHEEL -1`, `REL_HWHEEL +1`, `REL_HWHEEL -1`, one coalesced `REL_X +2` /
   `REL_Y -3` / `REL_HWHEEL +1` frame, then `BTN_FORWARD`, `BTN_BACK`, and
   `BTN_TASK` press/release
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # which conflicts with the patched quax-Blinka fork used for built-in dwc2.
 adafruit-circuitpython-typing==1.2.0
 Adafruit-Blinka @ git+https://github.com/quaxalber/Adafruit_Blinka.git@aa687e03ec98a6a647e546e4180ece8f0c87e4e9
-adafruit-circuitpython-hid @ git+https://github.com/quaxalber/Adafruit_CircuitPython_HID.git@bbe2617ef257a74933e23f5b2a44d8162ac2aec5
+adafruit-circuitpython-hid @ git+https://github.com/quaxalber/Adafruit_CircuitPython_HID.git@247c0f670a376c10304a47b40d3e4d41418007bd
 Adafruit-PlatformDetect==3.88.0
 Adafruit-PureIO==1.1.11
 evdev==1.9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Newer releases currently depend on the upstream Adafruit-Blinka package,
 # which conflicts with the patched quax-Blinka fork used for built-in dwc2.
 adafruit-circuitpython-typing==1.2.0
-Adafruit-Blinka @ git+https://github.com/quaxalber/Adafruit_Blinka.git@aa687e03ec98a6a647e546e4180ece8f0c87e4e9
+Adafruit-Blinka @ git+https://github.com/quaxalber/Adafruit_Blinka.git@15f027f10ba9955bac16573a6e6930324f8dd082
 adafruit-circuitpython-hid @ git+https://github.com/quaxalber/Adafruit_CircuitPython_HID.git@247c0f670a376c10304a47b40d3e4d41418007bd
 Adafruit-PlatformDetect==3.88.0
 Adafruit-PureIO==1.1.11

--- a/scripts/capture-device.sh
+++ b/scripts/capture-device.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+PYTHON_BIN="${REPO_ROOT}/venv/bin/python"
+
+if [[ ! -x "$PYTHON_BIN" ]]; then
+  PYTHON_BIN="python3"
+fi
+
+exec "$PYTHON_BIN" -m bluetooth_2_usb.capture_device "$@"

--- a/scripts/capture-device.sh
+++ b/scripts/capture-device.sh
@@ -6,7 +6,9 @@ REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
 PYTHON_BIN="${REPO_ROOT}/venv/bin/python"
 
 if [[ ! -x "$PYTHON_BIN" ]]; then
-  PYTHON_BIN="python3"
+  printf 'Missing repository virtualenv Python: %s\n' "$PYTHON_BIN" >&2
+  printf 'Run the installer or create the repo venv before capturing device data.\n' >&2
+  exit 3
 fi
 
 export PYTHONPATH="${REPO_ROOT}/src${PYTHONPATH:+:${PYTHONPATH}}"

--- a/scripts/capture-device.sh
+++ b/scripts/capture-device.sh
@@ -9,4 +9,6 @@ if [[ ! -x "$PYTHON_BIN" ]]; then
   PYTHON_BIN="python3"
 fi
 
+export PYTHONPATH="${REPO_ROOT}/src${PYTHONPATH:+:${PYTHONPATH}}"
+
 exec "$PYTHON_BIN" -m bluetooth_2_usb.capture_device "$@"

--- a/scripts/loopback-capture.ps1
+++ b/scripts/loopback-capture.ps1
@@ -41,9 +41,9 @@ if (-not $PythonBin) {
 $env:PYTHONPATH = "$RepoRoot\src" + $(if ($env:PYTHONPATH) { ";$env:PYTHONPATH" } else { "" })
 
 if ($PythonBin -eq "py -3") {
-  & py -3 -m bluetooth_2_usb.test_harness capture @args
+  & py -3 -m bluetooth_2_usb.loopback_harness capture @args
 } else {
-  & $PythonBin -m bluetooth_2_usb.test_harness capture @args
+  & $PythonBin -m bluetooth_2_usb.loopback_harness capture @args
 }
 
 exit $LASTEXITCODE

--- a/scripts/loopback-capture.sh
+++ b/scripts/loopback-capture.sh
@@ -11,7 +11,7 @@ source "${SCRIPTS_DIR}/lib/common.sh"
 
 usage() {
   cat <<EOF
-Usage: ./scripts/loopback-capture.sh [test_harness capture options]
+Usage: ./scripts/loopback-capture.sh [loopback_harness capture options]
 
 Capture relay reports from the host-side gadget HID devices.
 On Linux, install the host hidapi udev rule first if unprivileged access fails.
@@ -40,4 +40,4 @@ else
 fi
 
 export PYTHONPATH="${REPO_ROOT}/src${PYTHONPATH:+:${PYTHONPATH}}"
-exec "${PYTHON_BIN}" -m bluetooth_2_usb.test_harness capture "$@"
+exec "${PYTHON_BIN}" -m bluetooth_2_usb.loopback_harness capture "$@"

--- a/scripts/loopback-inject.sh
+++ b/scripts/loopback-inject.sh
@@ -13,7 +13,7 @@ PYTHON_BIN="${B2U_INSTALL_DIR}/venv/bin/python"
 
 usage() {
   cat <<EOF
-Usage: sudo ${B2U_INSTALL_DIR}/scripts/loopback-inject.sh [test_harness inject options]
+Usage: sudo ${B2U_INSTALL_DIR}/scripts/loopback-inject.sh [loopback_harness inject options]
 
 Run the Pi-side loopback injector using the managed virtual environment.
 Example:
@@ -30,4 +30,4 @@ esac
 
 [[ -x "${PYTHON_BIN}" ]] || fail "Managed Python not found: ${PYTHON_BIN}"
 
-exec "${PYTHON_BIN}" -m bluetooth_2_usb.test_harness inject "$@"
+exec "${PYTHON_BIN}" -m bluetooth_2_usb.loopback_harness inject "$@"

--- a/src/bluetooth_2_usb/capture_device.py
+++ b/src/bluetooth_2_usb/capture_device.py
@@ -58,6 +58,8 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def capture(device_path: str | None = None, duration: float = 10.0) -> dict[str, Any]:
+    if duration < 0:
+        raise ValueError("duration must be >= 0")
     result: dict[str, Any] = {
         "inventory": [device.to_dict() for device in describe_input_devices()],
         "sample": None,

--- a/src/bluetooth_2_usb/capture_device.py
+++ b/src/bluetooth_2_usb/capture_device.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import select
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+try:
+    from evdev import InputDevice, categorize
+except ModuleNotFoundError as exc:
+    InputDevice = None  # type: ignore[assignment]
+    categorize = None  # type: ignore[assignment]
+    _EVDEV_IMPORT_ERROR: ModuleNotFoundError | None = exc
+else:
+    _EVDEV_IMPORT_ERROR = None
+
+from .device_classification import describe_capabilities
+from .inventory import describe_input_devices
+
+MAC_RE = re.compile(r"\b(?:[0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}\b")
+
+
+@dataclass(slots=True)
+class CapturedFrame:
+    events: list[str] = field(default_factory=list)
+
+
+def redact(value: str) -> str:
+    return MAC_RE.sub("<redacted-mac>", value)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Capture redacted input-device details for Bluetooth-2-USB support."
+    )
+    parser.add_argument(
+        "--device",
+        "-d",
+        default=None,
+        help="Input event path to sample, for example /dev/input/event4.",
+    )
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=10.0,
+        help="Seconds to collect live events when --device is set. Default: 10.",
+    )
+    parser.add_argument(
+        "--output",
+        choices=["json", "text"],
+        default="json",
+        help="Output format. Default: json.",
+    )
+    return parser
+
+
+def capture(device_path: str | None = None, duration: float = 10.0) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "inventory": [device.to_dict() for device in describe_input_devices()],
+        "sample": None,
+    }
+    if device_path is None:
+        return _redact_jsonable(result)
+
+    if _EVDEV_IMPORT_ERROR is not None or InputDevice is None:
+        raise RuntimeError("python-evdev is required to capture live input events")
+
+    device = InputDevice(device_path)
+    try:
+        result["sample"] = _capture_device_sample(device, duration)
+    finally:
+        device.close()
+    return _redact_jsonable(result)
+
+
+def _capture_device_sample(device: InputDevice, duration: float) -> dict[str, Any]:
+    capabilities = describe_capabilities(device)
+    frames: list[CapturedFrame] = []
+    current = CapturedFrame()
+    deadline = time.monotonic() + max(duration, 0.0)
+
+    while time.monotonic() < deadline:
+        timeout = max(0.0, deadline - time.monotonic())
+        readable, _, _ = select.select([device.fd], [], [], timeout)
+        if not readable:
+            break
+        for event in device.read():
+            if time.monotonic() >= deadline:
+                break
+            categorized = categorize(event) if categorize is not None else event
+            current.events.append(redact(str(categorized)))
+            if event.type == 0 and event.code == 0:
+                frames.append(current)
+                current = CapturedFrame()
+            if len(frames) >= 200:
+                break
+        if len(frames) >= 200:
+            break
+
+    if current.events:
+        frames.append(current)
+
+    return {
+        "path": device.path,
+        "name": redact(device.name or ""),
+        "phys": redact(device.phys or ""),
+        "uniq": redact(device.uniq or ""),
+        "capabilities": {
+            "event_types": list(capabilities.event_types),
+            "properties": list(capabilities.properties),
+            "abs_axes": [
+                {
+                    "code": axis.code,
+                    "name": axis.name,
+                    "minimum": axis.minimum,
+                    "maximum": axis.maximum,
+                    "fuzz": axis.fuzz,
+                    "flat": axis.flat,
+                    "resolution": axis.resolution,
+                }
+                for axis in capabilities.abs_axes
+            ],
+            "relay_classes": list(capabilities.relay_classes),
+        },
+        "frames": [{"events": frame.events} for frame in frames],
+    }
+
+
+def _redact_jsonable(value: Any) -> Any:
+    if isinstance(value, str):
+        return redact(value)
+    if isinstance(value, list):
+        return [_redact_jsonable(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _redact_jsonable(item) for key, item in value.items()}
+    return value
+
+
+def _print_text(result: dict[str, Any]) -> None:
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.duration < 0:
+        parser.error("--duration must be >= 0")
+
+    result = capture(args.device, args.duration)
+    if args.output == "json":
+        print(json.dumps(result, sort_keys=True))
+    else:
+        _print_text(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/bluetooth_2_usb/capture_device.py
+++ b/src/bluetooth_2_usb/capture_device.py
@@ -149,7 +149,11 @@ def main(argv: list[str] | None = None) -> int:
     if args.duration < 0:
         parser.error("--duration must be >= 0")
 
-    result = capture(args.device, args.duration)
+    try:
+        result = capture(args.device, args.duration)
+    except Exception as exc:
+        target = args.device or "inventory"
+        parser.exit(2, f"Failed to capture input device data from {target}: {exc}\n")
     if args.output == "json":
         print(json.dumps(result, sort_keys=True))
     else:

--- a/src/bluetooth_2_usb/cli.py
+++ b/src/bluetooth_2_usb/cli.py
@@ -233,6 +233,7 @@ async def async_run(args: Arguments) -> int:
 
     from .relay import (
         GadgetManager,
+        KeyboardLedSync,
         RelayController,
         RuntimeMonitor,
         ShortcutToggler,
@@ -251,6 +252,7 @@ async def async_run(args: Arguments) -> int:
             gadget_manager=gadget_manager,
         )
 
+    led_sync = KeyboardLedSync(gadget_manager)
     relay_controller = RelayController(
         gadget_manager=gadget_manager,
         device_identifiers=args.device_ids,
@@ -258,6 +260,7 @@ async def async_run(args: Arguments) -> int:
         grab_devices=args.grab_devices,
         relaying_active=relaying_active,
         shortcut_toggler=shortcut_toggler,
+        led_sync=led_sync,
     )
 
     logger.debug(f"Detected UDC state file: {env_status.udc_path}")
@@ -267,10 +270,13 @@ async def async_run(args: Arguments) -> int:
     )
 
     try:
-        async with RuntimeMonitor(
-            relay_controller=relay_controller,
-            relaying_active=relaying_active,
-            udc_path=env_status.udc_path,
+        async with (
+            led_sync,
+            RuntimeMonitor(
+                relay_controller=relay_controller,
+                relaying_active=relaying_active,
+                udc_path=env_status.udc_path,
+            ),
         ):
             relay_task = asyncio.create_task(relay_controller.async_relay_devices())
             shutdown_task = asyncio.create_task(shutdown_event.wait())

--- a/src/bluetooth_2_usb/device_classification.py
+++ b/src/bluetooth_2_usb/device_classification.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+try:
+    from evdev import ecodes
+except ModuleNotFoundError:
+    from .evdev import ecodes  # type: ignore[assignment]
+
+
+@dataclass(frozen=True, slots=True)
+class AbsAxisInfo:
+    code: int
+    name: str
+    minimum: int | None
+    maximum: int | None
+    fuzz: int | None
+    flat: int | None
+    resolution: int | None
+
+
+@dataclass(frozen=True, slots=True)
+class DeviceCapabilities:
+    event_types: tuple[str, ...]
+    properties: tuple[str, ...]
+    abs_axes: tuple[AbsAxisInfo, ...]
+    relay_classes: tuple[str, ...]
+
+
+GAMEPAD_KEYS = {
+    ecodes.BTN_SOUTH,
+    ecodes.BTN_EAST,
+    ecodes.BTN_NORTH,
+    ecodes.BTN_WEST,
+    ecodes.BTN_TL,
+    ecodes.BTN_TR,
+    ecodes.BTN_TL2,
+    ecodes.BTN_TR2,
+    ecodes.BTN_SELECT,
+    ecodes.BTN_START,
+    ecodes.BTN_MODE,
+    getattr(ecodes, "BTN_THUMBL", 0x13D),
+    getattr(ecodes, "BTN_THUMBR", 0x13E),
+}
+
+GAMEPAD_ABS = {
+    ecodes.ABS_X,
+    ecodes.ABS_Y,
+    ecodes.ABS_RX,
+    ecodes.ABS_RY,
+    ecodes.ABS_Z,
+    ecodes.ABS_RZ,
+    ecodes.ABS_GAS,
+    ecodes.ABS_BRAKE,
+    ecodes.ABS_HAT0X,
+    ecodes.ABS_HAT0Y,
+}
+
+TOUCHPAD_KEYS = {
+    ecodes.BTN_TOUCH,
+    ecodes.BTN_TOOL_FINGER,
+    ecodes.BTN_TOOL_DOUBLETAP,
+    ecodes.BTN_TOOL_TRIPLETAP,
+    ecodes.BTN_TOOL_QUADTAP,
+    ecodes.BTN_TOOL_QUINTTAP,
+}
+
+TOUCHPAD_ABS = {
+    ecodes.ABS_X,
+    ecodes.ABS_Y,
+    ecodes.ABS_MT_SLOT,
+    ecodes.ABS_MT_POSITION_X,
+    ecodes.ABS_MT_POSITION_Y,
+    ecodes.ABS_MT_TRACKING_ID,
+}
+
+TABLET_KEYS = {
+    ecodes.BTN_TOOL_PEN,
+    ecodes.BTN_TOOL_RUBBER,
+    ecodes.BTN_STYLUS,
+    ecodes.BTN_STYLUS2,
+    ecodes.BTN_STYLUS3,
+}
+
+TABLET_ABS = {
+    ecodes.ABS_X,
+    ecodes.ABS_Y,
+    ecodes.ABS_PRESSURE,
+    ecodes.ABS_DISTANCE,
+    ecodes.ABS_TILT_X,
+    ecodes.ABS_TILT_Y,
+}
+
+
+def describe_capabilities(device: Any) -> DeviceCapabilities:
+    capabilities = device.capabilities(verbose=False)
+    props = _device_properties(device)
+    event_types = tuple(
+        sorted(_event_type_name(event_type) for event_type in capabilities)
+    )
+    abs_axes = tuple(
+        _abs_axis_info(device, code) for code in _codes(capabilities, ecodes.EV_ABS)
+    )
+    relay_classes = tuple(sorted(_relay_classes(capabilities, props)))
+    return DeviceCapabilities(
+        event_types=event_types,
+        properties=tuple(sorted(_property_name(prop) for prop in props)),
+        abs_axes=abs_axes,
+        relay_classes=relay_classes,
+    )
+
+
+def _relay_classes(capabilities: dict[int, list[int]], props: set[int]) -> set[str]:
+    classes: set[str] = set()
+    keys = set(_codes(capabilities, ecodes.EV_KEY))
+    rels = set(_codes(capabilities, ecodes.EV_REL))
+    abs_axes = set(_codes(capabilities, ecodes.EV_ABS))
+
+    if keys:
+        classes.add("keyboard")
+    if rels or keys.intersection(
+        {ecodes.BTN_LEFT, ecodes.BTN_RIGHT, ecodes.BTN_MIDDLE}
+    ):
+        classes.add("mouse")
+    if abs_axes.intersection(GAMEPAD_ABS) and keys.intersection(GAMEPAD_KEYS):
+        classes.add("gamepad")
+    if _looks_like_touchpad(keys, abs_axes, props):
+        classes.add("touchpad")
+    if keys.intersection(TABLET_KEYS) or (
+        ecodes.ABS_PRESSURE in abs_axes and abs_axes.intersection(TABLET_ABS)
+    ):
+        classes.add("tablet_pen")
+    if ecodes.EV_FF in capabilities:
+        classes.add("feedback")
+    return classes
+
+
+def _looks_like_touchpad(keys: set[int], abs_axes: set[int], props: set[int]) -> bool:
+    has_touch = bool(keys.intersection(TOUCHPAD_KEYS))
+    has_position = {
+        ecodes.ABS_MT_POSITION_X,
+        ecodes.ABS_MT_POSITION_Y,
+    }.issubset(
+        abs_axes
+    ) or {ecodes.ABS_X, ecodes.ABS_Y}.issubset(abs_axes)
+    has_pointer_property = bool(
+        props.intersection(
+            {
+                ecodes.INPUT_PROP_POINTER,
+                ecodes.INPUT_PROP_BUTTONPAD,
+            }
+        )
+    )
+    return has_touch and has_position and has_pointer_property
+
+
+def _codes(capabilities: dict[int, list[int]], event_type: int) -> list[int]:
+    return list(capabilities.get(event_type, ()))
+
+
+def _device_properties(device: Any) -> set[int]:
+    try:
+        return set(device.input_props())
+    except (AttributeError, OSError):
+        return set()
+
+
+def _abs_axis_info(device: Any, code: int) -> AbsAxisInfo:
+    try:
+        info = device.absinfo(code)
+    except (AttributeError, OSError):
+        info = None
+    return AbsAxisInfo(
+        code=code,
+        name=_code_name("ABS_", code),
+        minimum=getattr(info, "min", None),
+        maximum=getattr(info, "max", None),
+        fuzz=getattr(info, "fuzz", None),
+        flat=getattr(info, "flat", None),
+        resolution=getattr(info, "resolution", None),
+    )
+
+
+def _event_type_name(event_type: int) -> str:
+    return _code_name("EV_", event_type)
+
+
+def _property_name(prop: int) -> str:
+    return _code_name("INPUT_PROP_", prop)
+
+
+def _code_name(prefix: str, value: int) -> str:
+    for name in dir(ecodes):
+        if name.startswith(prefix) and getattr(ecodes, name) == value:
+            return name
+    return str(value)

--- a/src/bluetooth_2_usb/device_classification.py
+++ b/src/bluetooth_2_usb/device_classification.py
@@ -94,7 +94,7 @@ TABLET_ABS = {
 
 
 def describe_capabilities(device: Any) -> DeviceCapabilities:
-    capabilities = device.capabilities(verbose=False)
+    capabilities = device.capabilities(verbose=False, absinfo=False)
     props = _device_properties(device)
     event_types = tuple(
         sorted(_event_type_name(event_type) for event_type in capabilities)
@@ -117,7 +117,7 @@ def _relay_classes(capabilities: dict[int, list[int]], props: set[int]) -> set[s
     rels = set(_codes(capabilities, ecodes.EV_REL))
     abs_axes = set(_codes(capabilities, ecodes.EV_ABS))
 
-    if keys:
+    if any(code < ecodes.BTN_MISC for code in keys):
         classes.add("keyboard")
     if rels or keys.intersection(
         {ecodes.BTN_LEFT, ecodes.BTN_RIGHT, ecodes.BTN_MIDDLE}

--- a/src/bluetooth_2_usb/evdev.py
+++ b/src/bluetooth_2_usb/evdev.py
@@ -1206,6 +1206,11 @@ _MOUSE_BUTTONS = set(
         ecodes.BTN_LEFT,
         ecodes.BTN_RIGHT,
         ecodes.BTN_MIDDLE,
+        ecodes.BTN_SIDE,
+        ecodes.BTN_EXTRA,
+        ecodes.BTN_FORWARD,
+        ecodes.BTN_BACK,
+        ecodes.BTN_TASK,
     )
 )
 """Mouse button ecodes"""
@@ -1273,16 +1278,24 @@ def is_consumer_key(event: KeyEvent) -> bool:
     return event.scancode in _CONSUMER_KEYS
 
 
-def get_mouse_movement(event: RelEvent) -> tuple[int, int, int]:
+def get_mouse_movement(event: RelEvent) -> tuple[int, int, int, int]:
     input_event: InputEvent = event.event
-    x, y, mwheel = 0, 0, 0
+    x, y, mwheel, pan = 0, 0, 0, 0
     if input_event.code == ecodes.REL_X:
         x = input_event.value
     elif input_event.code == ecodes.REL_Y:
         y = input_event.value
     elif input_event.code == ecodes.REL_WHEEL:
         mwheel = input_event.value
-    return x, y, mwheel
+    elif input_event.code == ecodes.REL_HWHEEL:
+        pan = input_event.value
+    elif input_event.code == ecodes.REL_HWHEEL_HI_RES:
+        # Linux reports high-resolution wheel values in multiples/fractions of
+        # 120. Preserve the sign and round toward zero; stateful accumulation is
+        # handled in the relay frame accumulator when multiple events arrive
+        # before SYN_REPORT.
+        pan = int(input_event.value / 120)
+    return x, y, mwheel, pan
 
 
 @lru_cache(maxsize=1)
@@ -1429,6 +1442,11 @@ def _evdev_to_usb_hid_map() -> dict[int, int]:
         ecodes.BTN_LEFT: MouseButton.LEFT,
         ecodes.BTN_RIGHT: MouseButton.RIGHT,
         ecodes.BTN_MIDDLE: MouseButton.MIDDLE,
+        ecodes.BTN_SIDE: 0x08,
+        ecodes.BTN_EXTRA: 0x10,
+        ecodes.BTN_FORWARD: 0x20,
+        ecodes.BTN_BACK: 0x40,
+        ecodes.BTN_TASK: 0x80,
         ecodes.KEY_POWER: ConsumerControlCode.POWER,
         ecodes.KEY_RESTART: ConsumerControlCode.RESET,
         ecodes.KEY_SLEEP: ConsumerControlCode.SLEEP,

--- a/src/bluetooth_2_usb/evdev.py
+++ b/src/bluetooth_2_usb/evdev.py
@@ -1278,9 +1278,9 @@ def is_consumer_key(event: KeyEvent) -> bool:
     return event.scancode in _CONSUMER_KEYS
 
 
-def get_mouse_movement(event: RelEvent) -> tuple[int, int, int, int]:
+def get_mouse_movement(event: RelEvent) -> tuple[int, int, int, float]:
     input_event: InputEvent = event.event
-    x, y, mwheel, pan = 0, 0, 0, 0
+    x, y, mwheel, pan = 0, 0, 0, 0.0
     if input_event.code == ecodes.REL_X:
         x = input_event.value
     elif input_event.code == ecodes.REL_Y:
@@ -1291,10 +1291,9 @@ def get_mouse_movement(event: RelEvent) -> tuple[int, int, int, int]:
         pan = input_event.value
     elif input_event.code == ecodes.REL_HWHEEL_HI_RES:
         # Linux reports high-resolution wheel values in multiples/fractions of
-        # 120. Preserve the sign and round toward zero; stateful accumulation is
-        # handled in the relay frame accumulator when multiple events arrive
-        # before SYN_REPORT.
-        pan = int(input_event.value / 120)
+        # 120. Keep fractional steps so the relay frame accumulator can combine
+        # multiple events before quantizing the HID pan report.
+        pan = input_event.value / 120
     return x, y, mwheel, pan
 
 

--- a/src/bluetooth_2_usb/hid_layout.py
+++ b/src/bluetooth_2_usb/hid_layout.py
@@ -6,97 +6,89 @@ from pathlib import Path
 
 import usb_hid
 
-DEFAULT_KEYBOARD_DESCRIPTOR = bytes.fromhex(
-    "05010906a101050719e029e715002501750195088102950175088101"
-    "95037501050819012903910295057501910195067508150026ff0005"
-    "0719002aff008100c0"
+# Keep descriptor bytes in two-byte rows to match the Adafruit HID descriptor
+# style and make HID item boundaries easier to review.
+# fmt: off
+DEFAULT_KEYBOARD_DESCRIPTOR = bytes(
+    (
+        0x05, 0x01,  # Usage Page (Generic Desktop)
+        0x09, 0x06,  # Usage (Keyboard)
+        0xA1, 0x01,  # Collection (Application)
+        0x05, 0x07,  # Usage Page (Keyboard)
+        0x19, 0xE0,  # Usage Minimum (Keyboard LeftControl)
+        0x29, 0xE7,  # Usage Maximum (Keyboard Right GUI)
+        0x15, 0x00,  # Logical Minimum (0)
+        0x25, 0x01,  # Logical Maximum (1)
+        0x75, 0x01,  # Report Size (1)
+        0x95, 0x08,  # Report Count (8)
+        0x81, 0x02,  # Input (Data, Variable, Absolute)
+        0x95, 0x01,  # Report Count (1)
+        0x75, 0x08,  # Report Size (8)
+        0x81, 0x01,  # Input (Constant)
+        0x95, 0x03,  # Report Count (3)
+        0x75, 0x01,  # Report Size (1)
+        0x05, 0x08,  # Usage Page (LEDs)
+        0x19, 0x01,  # Usage Minimum (Num Lock)
+        0x29, 0x03,  # Usage Maximum (Scroll Lock)
+        0x91, 0x02,  # Output (Data, Variable, Absolute)
+        0x95, 0x05,  # Report Count (5)
+        0x75, 0x01,  # Report Size (1)
+        0x91, 0x01,  # Output (Constant)
+        0x95, 0x06,  # Report Count (6)
+        0x75, 0x08,  # Report Size (8)
+        0x15, 0x00,  # Logical Minimum (0)
+        0x26, 0xFF,  # Logical Maximum (255)
+        0x00, 0x05,  # Logical Maximum continuation, Usage Page
+        0x07, 0x19,  # Usage Page continuation, Usage Minimum
+        0x00, 0x2A,  # Usage Minimum continuation, Usage Maximum
+        0xFF, 0x00,  # Usage Maximum continuation
+        0x81, 0x00,  # Input (Data, Array)
+        0xC0,  # End Collection
+    )
 )
 
 DEFAULT_MOUSE_DESCRIPTOR = bytes(
     (
-        # Usage Page (Generic Desktop), Usage (Mouse), Collection (Application)
-        0x05,
-        0x01,
-        0x09,
-        0x02,
-        0xA1,
-        0x01,
-        # Usage (Pointer), Collection (Physical)
-        0x09,
-        0x01,
-        0xA1,
-        0x00,
-        # 8 buttons
-        0x05,
-        0x09,
-        0x19,
-        0x01,
-        0x29,
-        0x08,
-        0x15,
-        0x00,
-        0x25,
-        0x01,
-        0x95,
-        0x08,
-        0x75,
-        0x01,
-        0x81,
-        0x02,
-        # X/Y use signed 16-bit relative motion. Wheel and pan remain 8-bit.
-        0x05,
-        0x01,
-        0x09,
-        0x30,
-        0x09,
-        0x31,
-        0x16,
-        0x01,
-        0x80,
-        0x26,
-        0xFF,
-        0x7F,
-        0x75,
-        0x10,
-        0x95,
-        0x02,
-        0x81,
-        0x06,
-        # Vertical wheel
-        0x09,
-        0x38,
-        0x15,
-        0x81,
-        0x25,
-        0x7F,
-        0x75,
-        0x08,
-        0x95,
-        0x01,
-        0x81,
-        0x06,
-        # AC Pan lives on the Consumer page but is commonly used in mouse
-        # descriptors for horizontal wheel/pan.
-        0x05,
-        0x0C,
-        0x0A,
-        0x38,
-        0x02,
-        0x15,
-        0x81,
-        0x25,
-        0x7F,
-        0x75,
-        0x08,
-        0x95,
-        0x01,
-        0x81,
-        0x06,
-        # End Physical, End Application
-        0xC0,
-        0xC0,
+        0x05, 0x01,  # Usage Page (Generic Desktop)
+        0x09, 0x02,  # Usage (Mouse)
+        0xA1, 0x01,  # Collection (Application)
+        0x09, 0x01,  # Usage (Pointer)
+        0xA1, 0x00,  # Collection (Physical)
+        0x05, 0x09,  # Usage Page (Button)
+        0x19, 0x01,  # Usage Minimum (Button 1)
+        0x29, 0x08,  # Usage Maximum (Button 8)
+        0x15, 0x00,  # Logical Minimum (0)
+        0x25, 0x01,  # Logical Maximum (1)
+        0x95, 0x08,  # Report Count (8)
+        0x75, 0x01,  # Report Size (1)
+        0x81, 0x02,  # Input (Data, Variable, Absolute)
+        0x05, 0x01,  # Usage Page (Generic Desktop)
+        0x09, 0x30,  # Usage (X)
+        0x09, 0x31,  # Usage (Y)
+        0x16, 0x01,  # Logical Minimum (-32767)
+        0x80, 0x26,  # Logical Minimum continuation, Logical Maximum
+        0xFF, 0x7F,  # Logical Maximum continuation (32767)
+        0x75, 0x10,  # Report Size (16)
+        0x95, 0x02,  # Report Count (2)
+        0x81, 0x06,  # Input (Data, Variable, Relative)
+        0x09, 0x38,  # Usage (Wheel)
+        0x15, 0x81,  # Logical Minimum (-127)
+        0x25, 0x7F,  # Logical Maximum (127)
+        0x75, 0x08,  # Report Size (8)
+        0x95, 0x01,  # Report Count (1)
+        0x81, 0x06,  # Input (Data, Variable, Relative)
+        0x05, 0x0C,  # Usage Page (Consumer)
+        0x0A, 0x38,  # Usage (AC Pan)
+        0x02, 0x15,  # Usage continuation, Logical Minimum
+        0x81, 0x25,  # Logical Minimum continuation, Logical Maximum
+        0x7F, 0x75,  # Logical Maximum continuation, Report Size
+        0x08, 0x95,  # Report Size continuation, Report Count
+        0x01, 0x81,  # Report Count continuation, Input
+        0x06, 0xC0,  # Input continuation, End Collection
+        0xC0,  # End Collection
     )
 )
+# fmt: on
 
 
 class GadgetHidDevice(usb_hid.Device):

--- a/src/bluetooth_2_usb/hid_layout.py
+++ b/src/bluetooth_2_usb/hid_layout.py
@@ -12,6 +12,92 @@ DEFAULT_KEYBOARD_DESCRIPTOR = bytes.fromhex(
     "0719002aff008100c0"
 )
 
+DEFAULT_MOUSE_DESCRIPTOR = bytes(
+    (
+        # Usage Page (Generic Desktop), Usage (Mouse), Collection (Application)
+        0x05,
+        0x01,
+        0x09,
+        0x02,
+        0xA1,
+        0x01,
+        # Usage (Pointer), Collection (Physical)
+        0x09,
+        0x01,
+        0xA1,
+        0x00,
+        # 8 buttons
+        0x05,
+        0x09,
+        0x19,
+        0x01,
+        0x29,
+        0x08,
+        0x15,
+        0x00,
+        0x25,
+        0x01,
+        0x95,
+        0x08,
+        0x75,
+        0x01,
+        0x81,
+        0x02,
+        # X/Y use signed 16-bit relative motion. Wheel and pan remain 8-bit.
+        0x05,
+        0x01,
+        0x09,
+        0x30,
+        0x09,
+        0x31,
+        0x16,
+        0x01,
+        0x80,
+        0x26,
+        0xFF,
+        0x7F,
+        0x75,
+        0x10,
+        0x95,
+        0x02,
+        0x81,
+        0x06,
+        # Vertical wheel
+        0x09,
+        0x38,
+        0x15,
+        0x81,
+        0x25,
+        0x7F,
+        0x75,
+        0x08,
+        0x95,
+        0x01,
+        0x81,
+        0x06,
+        # AC Pan lives on the Consumer page but is commonly used in mouse
+        # descriptors for horizontal wheel/pan.
+        0x05,
+        0x0C,
+        0x0A,
+        0x38,
+        0x02,
+        0x15,
+        0x81,
+        0x25,
+        0x7F,
+        0x75,
+        0x08,
+        0x95,
+        0x01,
+        0x81,
+        0x06,
+        # End Physical, End Application
+        0xC0,
+        0xC0,
+    )
+)
+
 
 class GadgetHidDevice(usb_hid.Device):
     def __init__(
@@ -63,6 +149,9 @@ class GadgetHidDevice(usb_hid.Device):
         subclass: int,
         descriptor: bytes | None = None,
         name: str | None = None,
+        report_ids: Sequence[int] | None = None,
+        in_report_lengths: Sequence[int] | None = None,
+        out_report_lengths: Sequence[int] | None = None,
         wakeup_on_write: bool | None = None,
     ) -> GadgetHidDevice:
         return cls(
@@ -71,9 +160,21 @@ class GadgetHidDevice(usb_hid.Device):
             ),
             usage_page=base_device.usage_page,
             usage=base_device.usage,
-            report_ids=tuple(base_device.report_ids),
-            in_report_lengths=tuple(base_device.in_report_lengths),
-            out_report_lengths=tuple(base_device.out_report_lengths),
+            report_ids=(
+                tuple(base_device.report_ids)
+                if report_ids is None
+                else tuple(report_ids)
+            ),
+            in_report_lengths=(
+                tuple(base_device.in_report_lengths)
+                if in_report_lengths is None
+                else tuple(in_report_lengths)
+            ),
+            out_report_lengths=(
+                tuple(base_device.out_report_lengths)
+                if out_report_lengths is None
+                else tuple(out_report_lengths)
+            ),
             name=base_device.name if name is None else name,
             function_index=function_index,
             protocol=protocol,
@@ -121,6 +222,11 @@ def build_default_layout() -> GadgetLayout:
                 function_index=1,
                 protocol=0,
                 subclass=0,
+                descriptor=DEFAULT_MOUSE_DESCRIPTOR,
+                name="mouse gadget",
+                report_ids=(0,),
+                in_report_lengths=(7,),
+                out_report_lengths=(0,),
             ),
             GadgetHidDevice.from_existing(
                 usb_hid.Device.CONSUMER_CONTROL,

--- a/src/bluetooth_2_usb/inventory.py
+++ b/src/bluetooth_2_usb/inventory.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import io
 import shutil
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from types import SimpleNamespace
 from typing import Any
 
@@ -10,6 +10,7 @@ from rich import box
 from rich.console import Console
 from rich.table import Table
 
+from .device_classification import AbsAxisInfo, describe_capabilities
 from .logging import get_logger
 
 _logger = get_logger()
@@ -33,7 +34,7 @@ try:
 except ModuleNotFoundError as exc:
     InputDevice = Any  # type: ignore[assignment]
     list_devices = None  # type: ignore[assignment]
-    native_ecodes = SimpleNamespace(EV_KEY=0x01, EV_REL=0x02)
+    native_ecodes = SimpleNamespace(EV_KEY=0x01, EV_REL=0x02, EV_ABS=0x03, EV_FF=0x15)
     _EVDEV_IMPORT_ERROR: ModuleNotFoundError | None = exc
 else:
     _EVDEV_IMPORT_ERROR = None
@@ -42,6 +43,8 @@ else:
 EVENT_TYPE_NAMES = {
     native_ecodes.EV_KEY: "EV_KEY",
     native_ecodes.EV_REL: "EV_REL",
+    native_ecodes.EV_ABS: "EV_ABS",
+    native_ecodes.EV_FF: "EV_FF",
 }
 
 
@@ -54,6 +57,9 @@ class InputDeviceMetadata:
     capabilities: list[str]
     relay_candidate: bool
     exclusion_reason: str | None
+    properties: list[str] = field(default_factory=list)
+    abs_axes: list[dict[str, object]] = field(default_factory=list)
+    relay_classes: list[str] = field(default_factory=list)
 
     @property
     def identity(self) -> str:
@@ -78,8 +84,11 @@ def auto_discover_exclusion_reason(
     except OSError as exc:
         return f"failed to read capabilities ({exc})"
 
-    if not any(code in capabilities for code in EVENT_TYPE_NAMES):
-        return "missing EV_KEY/EV_REL capabilities"
+    if not any(
+        code in capabilities
+        for code in (native_ecodes.EV_KEY, native_ecodes.EV_REL, native_ecodes.EV_ABS)
+    ):
+        return "missing supported input capabilities"
 
     return None
 
@@ -115,13 +124,16 @@ def describe_input_devices(
     metadata: list[InputDeviceMetadata] = []
     for device in list_input_devices():
         try:
-            capabilities = sorted(
-                EVENT_TYPE_NAMES[code]
-                for code in device.capabilities(verbose=False)
-                if code in EVENT_TYPE_NAMES
-            )
+            rich_capabilities = describe_capabilities(device)
+            capabilities = list(rich_capabilities.event_types)
+            properties = list(rich_capabilities.properties)
+            abs_axes = [_abs_axis_to_dict(axis) for axis in rich_capabilities.abs_axes]
+            relay_classes = list(rich_capabilities.relay_classes)
         except OSError as exc:
             capabilities = []
+            properties = []
+            abs_axes = []
+            relay_classes = []
             exclusion_reason = f"failed to read capabilities ({exc})"
         else:
             exclusion_reason = auto_discover_exclusion_reason(
@@ -135,12 +147,27 @@ def describe_input_devices(
                 phys=device.phys,
                 uniq=device.uniq or "",
                 capabilities=capabilities,
+                properties=properties,
+                abs_axes=abs_axes,
+                relay_classes=relay_classes,
                 relay_candidate=exclusion_reason is None,
                 exclusion_reason=exclusion_reason,
             )
         )
         device.close()
     return metadata
+
+
+def _abs_axis_to_dict(axis: AbsAxisInfo) -> dict[str, object]:
+    return {
+        "code": axis.code,
+        "name": axis.name,
+        "minimum": axis.minimum,
+        "maximum": axis.maximum,
+        "fuzz": axis.fuzz,
+        "flat": axis.flat,
+        "resolution": axis.resolution,
+    }
 
 
 def inventory_to_text(devices: list[InputDeviceMetadata]) -> str:
@@ -155,6 +182,7 @@ def inventory_to_text(devices: list[InputDeviceMetadata]) -> str:
     table.add_column("Device", min_width=18, overflow="fold")
     table.add_column("Identity", min_width=16, overflow="fold")
     table.add_column("Path", min_width=18, overflow="fold")
+    table.add_column("Classes", min_width=16, overflow="fold")
     table.add_column("Exclusion Reason", min_width=20, overflow="fold")
 
     for device in devices:
@@ -164,6 +192,7 @@ def inventory_to_text(devices: list[InputDeviceMetadata]) -> str:
             device.name or "-",
             device.identity,
             device.path,
+            ",".join(device.relay_classes) or "-",
             device.exclusion_reason or "",
         )
 

--- a/src/bluetooth_2_usb/inventory.py
+++ b/src/bluetooth_2_usb/inventory.py
@@ -10,7 +10,11 @@ from rich import box
 from rich.console import Console
 from rich.table import Table
 
-from .device_classification import AbsAxisInfo, describe_capabilities
+from .device_classification import (
+    AbsAxisInfo,
+    DeviceCapabilities,
+    describe_capabilities,
+)
 from .logging import get_logger
 
 _logger = get_logger()
@@ -72,6 +76,7 @@ class InputDeviceMetadata:
 def auto_discover_exclusion_reason(
     device: InputDevice,
     skip_name_prefixes: tuple[str, ...] = DEFAULT_SKIP_NAME_PREFIXES,
+    rich_capabilities: DeviceCapabilities | None = None,
 ) -> str | None:
     name = (device.name or "").strip()
     name_lower = name.lower()
@@ -80,15 +85,17 @@ def auto_discover_exclusion_reason(
             return f"name prefix {prefix}"
 
     try:
-        capabilities = device.capabilities(verbose=False)
+        rich_capabilities = rich_capabilities or describe_capabilities(device)
     except OSError as exc:
         return f"failed to read capabilities ({exc})"
 
     if not any(
-        code in capabilities
-        for code in (native_ecodes.EV_KEY, native_ecodes.EV_REL, native_ecodes.EV_ABS)
+        event_type in rich_capabilities.event_types
+        for event_type in ("EV_KEY", "EV_REL", "EV_ABS")
     ):
         return "missing supported input capabilities"
+    if not rich_capabilities.relay_classes:
+        return "missing supported relay classes"
 
     return None
 
@@ -137,10 +144,8 @@ def describe_input_devices(
             exclusion_reason = f"failed to read capabilities ({exc})"
         else:
             exclusion_reason = auto_discover_exclusion_reason(
-                device, skip_name_prefixes
+                device, skip_name_prefixes, rich_capabilities
             )
-            if exclusion_reason is None and not relay_classes:
-                exclusion_reason = "missing supported relay classes"
 
         metadata.append(
             InputDeviceMetadata(

--- a/src/bluetooth_2_usb/inventory.py
+++ b/src/bluetooth_2_usb/inventory.py
@@ -139,6 +139,8 @@ def describe_input_devices(
             exclusion_reason = auto_discover_exclusion_reason(
                 device, skip_name_prefixes
             )
+            if exclusion_reason is None and not relay_classes:
+                exclusion_reason = "missing supported relay classes"
 
         metadata.append(
             InputDeviceMetadata(
@@ -150,7 +152,7 @@ def describe_input_devices(
                 properties=properties,
                 abs_axes=abs_axes,
                 relay_classes=relay_classes,
-                relay_candidate=exclusion_reason is None,
+                relay_candidate=exclusion_reason is None and bool(relay_classes),
                 exclusion_reason=exclusion_reason,
             )
         )

--- a/src/bluetooth_2_usb/loopback_capture.py
+++ b/src/bluetooth_2_usb/loopback_capture.py
@@ -14,7 +14,12 @@ from adafruit_hid.keycode import Keycode
 from .evdev import evdev_to_usb_hid
 from .loopback_common import (
     BTN_BACK,
+    BTN_EXTRA,
     BTN_FORWARD,
+    BTN_LEFT,
+    BTN_MIDDLE,
+    BTN_RIGHT,
+    BTN_SIDE,
     BTN_TASK,
     DEFAULT_DEVICE_SUBSTRING,
     EXIT_ACCESS,
@@ -56,6 +61,11 @@ REL_NAMES = {
 }
 
 MOUSE_BUTTON_BITS = {
+    BTN_LEFT: 0x01,
+    BTN_RIGHT: 0x02,
+    BTN_MIDDLE: 0x04,
+    BTN_SIDE: 0x08,
+    BTN_EXTRA: 0x10,
     BTN_FORWARD: 0x20,
     BTN_BACK: 0x40,
     BTN_TASK: 0x80,
@@ -1037,7 +1047,7 @@ def _capture_once_linux_hidraw(
 
 def run_capture(
     scenario_name: str,
-    timeout_sec: float = 5.0,
+    timeout_sec: float = 10.0,
     device_substring: str = DEFAULT_DEVICE_SUBSTRING,
     keyboard_node: str | None = None,
     mouse_node: str | None = None,

--- a/src/bluetooth_2_usb/loopback_capture.py
+++ b/src/bluetooth_2_usb/loopback_capture.py
@@ -789,6 +789,12 @@ def _resolve_hidraw_node(
     sys_usb_root: Path = Path("/sys/bus/usb/devices"),
     dev_root: Path = Path("/dev"),
 ) -> str | None:
+    node_path = Path(info.node)
+    if node_path.is_absolute() and node_path.name.startswith("hidraw"):
+        return str(node_path)
+    if node_path.parent == Path(".") and node_path.name.startswith("hidraw"):
+        return str(dev_root / node_path.name)
+
     interface_root = sys_usb_root / info.node
     for hidraw_path in sorted(interface_root.glob("*/hidraw/hidraw*")):
         return str(dev_root / hidraw_path.name)

--- a/src/bluetooth_2_usb/loopback_capture.py
+++ b/src/bluetooth_2_usb/loopback_capture.py
@@ -1,15 +1,21 @@
 from __future__ import annotations
 
+import os
+import select
 import sys
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
 from adafruit_hid.keycode import Keycode
 
 from .evdev import evdev_to_usb_hid
-from .test_harness_common import (
+from .loopback_common import (
+    BTN_BACK,
+    BTN_FORWARD,
+    BTN_TASK,
     DEFAULT_DEVICE_SUBSTRING,
     EXIT_ACCESS,
     EXIT_MISMATCH,
@@ -18,6 +24,7 @@ from .test_harness_common import (
     EXIT_TIMEOUT,
     KEY_VOLUMEDOWN,
     KEY_VOLUMEUP,
+    REL_HWHEEL,
     REL_X,
     REL_Y,
     GadgetNodes,
@@ -43,6 +50,13 @@ CONSUMER_USAGES = {
 REL_NAMES = {
     REL_X: "REL_X",
     REL_Y: "REL_Y",
+    REL_HWHEEL: "REL_HWHEEL",
+}
+
+MOUSE_BUTTON_BITS = {
+    BTN_FORWARD: 0x20,
+    BTN_BACK: 0x40,
+    BTN_TASK: 0x80,
 }
 
 
@@ -168,6 +182,7 @@ class MouseSequenceMatcher:
     expected_button_steps: tuple
     rel_index: int = 0
     button_index: int = 0
+    _button_state: int = 0
 
     @classmethod
     def create(cls, expected_rel_steps: tuple, expected_button_steps: tuple):
@@ -184,7 +199,7 @@ class MouseSequenceMatcher:
             raise CaptureMismatchError(
                 f"Unexpected mouse report format: {report.hex(sep=' ')}"
             )
-        buttons, rel_x, rel_y, wheel = parsed
+        buttons, rel_x, rel_y, wheel, pan = parsed
         if wheel != 0:
             raise CaptureMismatchError(
                 f"Unexpected mouse wheel movement in report {report.hex(sep=' ')}"
@@ -198,13 +213,10 @@ class MouseSequenceMatcher:
             self._apply_rel(REL_X, rel_x)
         if rel_y:
             self._apply_rel(REL_Y, rel_y)
+        if pan:
+            self._apply_rel(REL_HWHEEL, pan)
 
-        if buttons not in (0, 1, 2):
-            raise CaptureMismatchError(
-                f"Unexpected mouse button bits in report {report.hex(sep=' ')}"
-            )
-
-        if rel_x == 0 and rel_y == 0:
+        if rel_x == 0 and rel_y == 0 and pan == 0:
             if self.button_index >= len(self.expected_button_steps):
                 if buttons == 0:
                     return
@@ -220,11 +232,24 @@ class MouseSequenceMatcher:
                 return
 
             expected = self.expected_button_steps[self.button_index]
-            if buttons != expected.value:
+            expected_buttons = self._apply_button_step(expected)
+            if buttons != expected_buttons:
                 raise CaptureMismatchError(
                     f"Unexpected mouse button report {report.hex(sep=' ')}; expected {expected.describe()}"
                 )
             self.button_index += 1
+
+    def _apply_button_step(self, expected) -> int:
+        button_bit = MOUSE_BUTTON_BITS.get(expected.code)
+        if button_bit is None:
+            raise CaptureMismatchError(
+                f"Expected mouse button step {expected.describe()} is not mappable to HID"
+            )
+        if expected.value == 1:
+            self._button_state |= button_bit
+        elif expected.value == 0:
+            self._button_state &= ~button_bit
+        return self._button_state
 
     def _apply_rel(self, code: int, value: int) -> None:
         if self.rel_index >= len(self.expected_rel_steps):
@@ -286,6 +311,8 @@ class _CandidateMatcher:
     device: Any
     matcher: KeyboardSequenceMatcher | MouseSequenceMatcher | ConsumerSequenceMatcher
     failed_message: str | None = None
+    capture_node: str | None = None
+    matched_reports: list[str] = field(default_factory=list)
 
     @property
     def node(self) -> str:
@@ -299,6 +326,11 @@ class _CandidateMatcher:
     def failed(self) -> bool:
         return self.failed_message is not None
 
+    def note_report(self, report: bytes) -> None:
+        if len(self.matched_reports) >= 12:
+            return
+        self.matched_reports.append(report.hex(" "))
+
 
 def _normalize_keyboard_report(report: bytes) -> bytes | None:
     if len(report) == 8:
@@ -308,13 +340,22 @@ def _normalize_keyboard_report(report: bytes) -> bytes | None:
     return None
 
 
-def _normalize_mouse_report(report: bytes) -> tuple[int, int, int, int] | None:
+def _normalize_mouse_report(report: bytes) -> tuple[int, int, int, int, int] | None:
     payload = report
     wheel = 0
-    if len(report) == 5 and report[0] == 0x02:
+    pan = 0
+    if len(report) == 8 and report[0] == 0x02:
+        payload = report[1:]
+    elif len(report) == 7:
+        payload = report
+    elif len(report) == 6 and report[0] == 0x02:
+        payload = report[1:]
+    elif len(report) == 5 and report[0] == 0x02:
         payload = report[1:]
     elif len(report) == 4 and report[0] == 0x02:
         payload = report[1:]
+    elif len(report) == 5:
+        payload = report
     elif len(report) == 4:
         payload = report
     elif len(report) == 3:
@@ -323,11 +364,20 @@ def _normalize_mouse_report(report: bytes) -> tuple[int, int, int, int] | None:
         return None
 
     buttons = payload[0]
+    if len(payload) == 7:
+        rel_x = int.from_bytes(payload[1:3], "little", signed=True)
+        rel_y = int.from_bytes(payload[3:5], "little", signed=True)
+        wheel = int.from_bytes(payload[5:6], "little", signed=True)
+        pan = int.from_bytes(payload[6:7], "little", signed=True)
+        return buttons, rel_x, rel_y, wheel, pan
+
     rel_x = int.from_bytes(payload[1:2], "little", signed=True)
     rel_y = int.from_bytes(payload[2:3], "little", signed=True)
     if len(payload) >= 4:
         wheel = int.from_bytes(payload[3:4], "little", signed=True)
-    return buttons, rel_x, rel_y, wheel
+    if len(payload) >= 5:
+        pan = int.from_bytes(payload[4:5], "little", signed=True)
+    return buttons, rel_x, rel_y, wheel, pan
 
 
 def _normalize_consumer_report(report: bytes) -> int | None:
@@ -668,6 +718,7 @@ def _capture_once(
 
                 progress = True
                 report = bytes(report_values)
+                candidate.note_report(report)
                 try:
                     candidate.matcher.handle(report)
                 except CaptureMismatchError as exc:
@@ -713,11 +764,14 @@ def _capture_once(
     }
     if keyboard_matcher is not None:
         details["keyboard_steps_seen"] = keyboard_matcher.matcher.index
+        details["keyboard_reports_seen"] = list(keyboard_matcher.matched_reports)
     if mouse_matcher is not None:
         details["mouse_rel_steps_seen"] = mouse_matcher.matcher.rel_index
         details["mouse_button_steps_seen"] = mouse_matcher.matcher.button_index
+        details["mouse_reports_seen"] = list(mouse_matcher.matched_reports)
     if consumer_matcher is not None:
         details["consumer_steps_seen"] = consumer_matcher.matcher.index
+        details["consumer_reports_seen"] = list(consumer_matcher.matched_reports)
 
     return HarnessResult(
         command="capture",
@@ -725,6 +779,252 @@ def _capture_once(
         success=True,
         exit_code=EXIT_OK,
         message="Observed expected relay reports on gadget HID devices",
+        details=details,
+    )
+
+
+def _resolve_hidraw_node(
+    info: HidDeviceInfo,
+    *,
+    sys_usb_root: Path = Path("/sys/bus/usb/devices"),
+    dev_root: Path = Path("/dev"),
+) -> str | None:
+    interface_root = sys_usb_root / info.node
+    for hidraw_path in sorted(interface_root.glob("*/hidraw/hidraw*")):
+        return str(dev_root / hidraw_path.name)
+    for hidraw_path in sorted(interface_root.glob("hidraw/hidraw*")):
+        return str(dev_root / hidraw_path.name)
+    return None
+
+
+def _open_hidraw_node(path: str, info: HidDeviceInfo) -> int:
+    try:
+        return os.open(path, os.O_RDONLY | os.O_NONBLOCK)
+    except PermissionError as exc:
+        raise CaptureError(
+            f"Failed opening HID raw device {path} for {info.node}: {exc}. "
+            "On Linux, run sudo ./scripts/install-hid-udev-rule.sh "
+            "and ensure the user is in the input group."
+        ) from exc
+    except OSError as exc:
+        raise CaptureError(
+            f"Failed opening HID raw device {path} for {info.node}: {exc}"
+        ) from exc
+
+
+def _candidate_metadata(candidates: list[_CandidateMatcher]) -> list[dict[str, object]]:
+    return [
+        {
+            "role": candidate.role,
+            "node": candidate.node,
+            "capture_node": candidate.capture_node,
+            "interface_number": candidate.info.interface_number,
+            "serial": candidate.info.serial,
+            "reports_seen": list(candidate.matched_reports),
+            "failed_message": candidate.failed_message,
+        }
+        for candidate in candidates
+    ]
+
+
+def _capture_once_linux_hidraw(
+    scenario_name: str,
+    timeout_sec: float,
+    candidate_nodes: GadgetNodeCandidates,
+) -> HarnessResult:
+    scenario = get_scenario(scenario_name)
+    candidates: list[_CandidateMatcher] = []
+    fd_to_candidate: dict[int, _CandidateMatcher] = {}
+
+    def _completed_candidate(role: str) -> _CandidateMatcher | None:
+        for candidate in candidates:
+            if candidate.role == role and candidate.complete:
+                return candidate
+        return None
+
+    def _required_role_done(role: str) -> bool:
+        if role == "keyboard":
+            return (
+                not scenario.keyboard_enabled or _completed_candidate(role) is not None
+            )
+        if role == "mouse":
+            return not scenario.mouse_enabled or _completed_candidate(role) is not None
+        if role == "consumer":
+            return (
+                not scenario.consumer_enabled or _completed_candidate(role) is not None
+            )
+        raise AssertionError(f"Unexpected role: {role}")
+
+    def _active_candidates(role: str) -> list[_CandidateMatcher]:
+        return [
+            candidate
+            for candidate in candidates
+            if candidate.role == role and not candidate.failed
+        ]
+
+    def _register_candidate(
+        role: str,
+        info: HidDeviceInfo,
+        matcher: (
+            KeyboardSequenceMatcher | MouseSequenceMatcher | ConsumerSequenceMatcher
+        ),
+    ) -> None:
+        hidraw_node = _resolve_hidraw_node(info)
+        if hidraw_node is None:
+            raise MissingNodeError(f"No hidraw device found for {info.node}")
+        fd = _open_hidraw_node(hidraw_node, info)
+        candidate = _CandidateMatcher(
+            role=role,
+            info=info,
+            device=fd,
+            matcher=matcher,
+            capture_node=hidraw_node,
+        )
+        candidates.append(candidate)
+        fd_to_candidate[fd] = candidate
+
+    try:
+        if scenario.keyboard_enabled:
+            if not candidate_nodes.keyboard_nodes:
+                raise MissingNodeError("Keyboard HID device was not found")
+            for info in candidate_nodes.keyboard_nodes:
+                _register_candidate(
+                    "keyboard", info, KeyboardSequenceMatcher(scenario.keyboard_steps)
+                )
+
+        if scenario.mouse_enabled:
+            if not candidate_nodes.mouse_nodes:
+                raise MissingNodeError("Mouse HID device was not found")
+            for info in candidate_nodes.mouse_nodes:
+                _register_candidate(
+                    "mouse",
+                    info,
+                    MouseSequenceMatcher.create(
+                        scenario.mouse_rel_steps, scenario.mouse_button_steps
+                    ),
+                )
+
+        if scenario.consumer_enabled:
+            if not candidate_nodes.consumer_nodes:
+                raise MissingNodeError("Consumer-control HID device was not found")
+            for info in candidate_nodes.consumer_nodes:
+                _register_candidate(
+                    "consumer", info, ConsumerSequenceMatcher(scenario.consumer_steps)
+                )
+
+        deadline = time.monotonic() + timeout_sec
+        while True:
+            if (
+                _required_role_done("keyboard")
+                and _required_role_done("mouse")
+                and _required_role_done("consumer")
+            ):
+                break
+
+            for role, enabled in (
+                ("keyboard", scenario.keyboard_enabled),
+                ("mouse", scenario.mouse_enabled),
+                ("consumer", scenario.consumer_enabled),
+            ):
+                if not enabled or _active_candidates(role):
+                    continue
+                messages = [
+                    candidate.failed_message
+                    for candidate in candidates
+                    if candidate.role == role and candidate.failed_message
+                ]
+                raise CaptureMismatchError(
+                    f"All {role} HID candidates mismatched: " + "; ".join(messages)
+                )
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise CaptureTimeoutError(
+                    f"Timed out waiting for {scenario.name} reports after {timeout_sec}s"
+                )
+
+            active_fds = [
+                candidate.device
+                for candidate in candidates
+                if not candidate.failed and not candidate.complete
+            ]
+            if not active_fds:
+                time.sleep(POLL_INTERVAL_SEC)
+                continue
+
+            readable, _, _ = select.select(
+                active_fds, [], [], min(POLL_INTERVAL_SEC, max(0.0, remaining))
+            )
+            for fd in readable:
+                candidate = fd_to_candidate[fd]
+                try:
+                    report = os.read(fd, REPORT_READ_SIZE)
+                except OSError as exc:
+                    raise CaptureError(
+                        f"Failed reading HID raw reports from {candidate.capture_node}: {exc}"
+                    ) from exc
+                if not report:
+                    continue
+                candidate.note_report(report)
+                try:
+                    candidate.matcher.handle(report)
+                except CaptureMismatchError as exc:
+                    candidate.failed_message = f"{candidate.node}: {exc}"
+
+    except CaptureError as exc:
+        return HarnessResult(
+            command="capture",
+            scenario=scenario.name,
+            success=False,
+            exit_code=exc.exit_code,
+            message=str(exc),
+            details={
+                "capture_backend": "linux_hidraw",
+                "candidates": candidate_nodes.to_dict(),
+                "candidate_details": _candidate_metadata(candidates),
+                "nodes": GadgetNodes(None, None, None).to_dict(),
+                "timeout_sec": timeout_sec,
+            },
+        )
+    finally:
+        for fd in tuple(fd_to_candidate):
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+    keyboard_matcher = _completed_candidate("keyboard")
+    mouse_matcher = _completed_candidate("mouse")
+    consumer_matcher = _completed_candidate("consumer")
+    matched_nodes = candidate_nodes.matched_nodes(
+        keyboard_node=keyboard_matcher.node if keyboard_matcher else None,
+        mouse_node=mouse_matcher.node if mouse_matcher else None,
+        consumer_node=consumer_matcher.node if consumer_matcher else None,
+    )
+    details: dict[str, object] = {
+        "capture_backend": "linux_hidraw",
+        "candidates": candidate_nodes.to_dict(),
+        "candidate_details": _candidate_metadata(candidates),
+        "nodes": matched_nodes.to_dict(),
+        "timeout_sec": timeout_sec,
+    }
+    if keyboard_matcher is not None:
+        details["keyboard_steps_seen"] = keyboard_matcher.matcher.index
+        details["keyboard_reports_seen"] = list(keyboard_matcher.matched_reports)
+    if mouse_matcher is not None:
+        details["mouse_rel_steps_seen"] = mouse_matcher.matcher.rel_index
+        details["mouse_button_steps_seen"] = mouse_matcher.matcher.button_index
+        details["mouse_reports_seen"] = list(mouse_matcher.matched_reports)
+    if consumer_matcher is not None:
+        details["consumer_steps_seen"] = consumer_matcher.matcher.index
+        details["consumer_reports_seen"] = list(consumer_matcher.matched_reports)
+
+    return HarnessResult(
+        command="capture",
+        scenario=scenario.name,
+        success=True,
+        exit_code=EXIT_OK,
+        message="Observed expected relay reports on gadget HID raw devices",
         details=details,
     )
 
@@ -763,9 +1063,17 @@ def run_capture(
         )
 
     if sys.platform == "win32":
-        from .test_harness_capture_windows import run_windows_raw_input_capture
+        from .loopback_capture_windows import run_windows_raw_input_capture
 
         result = run_windows_raw_input_capture(
+            scenario_name=scenario_name,
+            timeout_sec=timeout_sec,
+            candidate_nodes=candidate_nodes,
+        )
+        result.details["candidates"] = candidate_nodes.to_dict()
+        return result
+    if sys.platform.startswith("linux"):
+        result = _capture_once_linux_hidraw(
             scenario_name=scenario_name,
             timeout_sec=timeout_sec,
             candidate_nodes=candidate_nodes,

--- a/src/bluetooth_2_usb/loopback_capture.py
+++ b/src/bluetooth_2_usb/loopback_capture.py
@@ -25,6 +25,7 @@ from .loopback_common import (
     KEY_VOLUMEDOWN,
     KEY_VOLUMEUP,
     REL_HWHEEL,
+    REL_WHEEL,
     REL_X,
     REL_Y,
     GadgetNodes,
@@ -51,6 +52,7 @@ REL_NAMES = {
     REL_X: "REL_X",
     REL_Y: "REL_Y",
     REL_HWHEEL: "REL_HWHEEL",
+    REL_WHEEL: "REL_WHEEL",
 }
 
 MOUSE_BUTTON_BITS = {
@@ -200,10 +202,6 @@ class MouseSequenceMatcher:
                 f"Unexpected mouse report format: {report.hex(sep=' ')}"
             )
         buttons, rel_x, rel_y, wheel, pan = parsed
-        if wheel != 0:
-            raise CaptureMismatchError(
-                f"Unexpected mouse wheel movement in report {report.hex(sep=' ')}"
-            )
         if not self.expected_button_steps and buttons != 0:
             raise CaptureMismatchError(
                 f"Unexpected mouse button bits in report {report.hex(sep=' ')}"
@@ -213,10 +211,12 @@ class MouseSequenceMatcher:
             self._apply_rel(REL_X, rel_x)
         if rel_y:
             self._apply_rel(REL_Y, rel_y)
+        if wheel:
+            self._apply_rel(REL_WHEEL, wheel)
         if pan:
             self._apply_rel(REL_HWHEEL, pan)
 
-        if rel_x == 0 and rel_y == 0 and pan == 0:
+        if rel_x == 0 and rel_y == 0 and wheel == 0 and pan == 0:
             if self.button_index >= len(self.expected_button_steps):
                 if buttons == 0:
                     return

--- a/src/bluetooth_2_usb/loopback_capture_windows.py
+++ b/src/bluetooth_2_usb/loopback_capture_windows.py
@@ -6,7 +6,7 @@ import time
 from ctypes import wintypes
 from dataclasses import dataclass, field
 
-from .test_harness_capture import (
+from .loopback_capture import (
     CaptureMismatchError,
     CaptureTimeoutError,
     ConsumerSequenceMatcher,
@@ -17,7 +17,7 @@ from .test_harness_capture import (
     MissingNodeError,
     MouseSequenceMatcher,
 )
-from .test_harness_common import EXIT_OK, get_scenario
+from .loopback_common import EXIT_OK, get_scenario
 
 IS_WINDOWS = sys.platform == "win32"
 
@@ -59,6 +59,7 @@ RIM_TYPEHID = 2
 PM_REMOVE = 0x0001
 RI_KEY_BREAK = 0x0001
 RI_MOUSE_WHEEL = 0x0400
+RI_MOUSE_HORIZONTAL_WHEEL = 0x0800
 CW_USEDEFAULT = -2147483648
 GENERIC_DESKTOP_USAGE_PAGE = 0x01
 KEYBOARD_USAGE = 0x06
@@ -384,6 +385,7 @@ class _RawInputDebug:
         is_key_up: bool | None = None,
         rel_x: int | None = None,
         rel_y: int | None = None,
+        rel_pan: int | None = None,
     ) -> None:
         self.total_messages_seen += 1
         if role == "keyboard":
@@ -419,6 +421,8 @@ class _RawInputDebug:
         if rel_x is not None or rel_y is not None:
             event["rel_x"] = rel_x
             event["rel_y"] = rel_y
+        if rel_pan is not None:
+            event["rel_pan"] = rel_pan
         self.sample_events.append(event)
 
     def to_dict(self) -> dict[str, object]:
@@ -486,6 +490,11 @@ def _mouse_event_to_reports(raw_mouse: RAWMOUSE) -> list[bytes]:
     reports: list[bytes] = []
     button_flags = raw_mouse.ulButtons & 0xFFFF
     if button_flags & RI_MOUSE_WHEEL:
+        return reports
+    if button_flags & RI_MOUSE_HORIZONTAL_WHEEL:
+        pan = ctypes.c_short((raw_mouse.ulButtons >> 16) & 0xFFFF).value
+        if pan:
+            reports.append(bytes([0x02, 0x00, 0x00, 0x00, 0x00, pan & 0xFF]))
         return reports
     if raw_mouse.lLastX:
         reports.append(bytes([0x02, 0x00, raw_mouse.lLastX & 0xFF, 0x00, 0x00]))
@@ -808,6 +817,13 @@ def _pump_raw_input(
                             matched=matched,
                             rel_x=raw.mouse.lLastX,
                             rel_y=raw.mouse.lLastY,
+                            rel_pan=(
+                                ctypes.c_short(
+                                    (raw.mouse.ulButtons >> 16) & 0xFFFF
+                                ).value
+                                if raw.mouse.ulButtons & RI_MOUSE_HORIZONTAL_WHEEL
+                                else None
+                            ),
                         )
                         if not matched:
                             continue

--- a/src/bluetooth_2_usb/loopback_capture_windows.py
+++ b/src/bluetooth_2_usb/loopback_capture_windows.py
@@ -486,6 +486,11 @@ def _keyboard_event_to_report(vkey: int, is_key_up: bool) -> bytes | None:
     return bytes([0x00, 0x00, hid_code, 0, 0, 0, 0, 0])
 
 
+def _mouse_i16_bytes(value: int) -> bytes:
+    clamped = min(32767, max(-32767, value))
+    return clamped.to_bytes(2, "little", signed=True)
+
+
 def _mouse_event_to_reports(raw_mouse: RAWMOUSE) -> list[bytes]:
     reports: list[bytes] = []
     button_flags = raw_mouse.ulButtons & 0xFFFF
@@ -497,9 +502,11 @@ def _mouse_event_to_reports(raw_mouse: RAWMOUSE) -> list[bytes]:
             reports.append(bytes([0x02, 0x00, 0x00, 0x00, 0x00, pan & 0xFF]))
         return reports
     if raw_mouse.lLastX:
-        reports.append(bytes([0x02, 0x00, raw_mouse.lLastX & 0xFF, 0x00, 0x00]))
+        x_bytes = _mouse_i16_bytes(raw_mouse.lLastX)
+        reports.append(bytes([0x02, 0x00, *x_bytes, 0x00, 0x00, 0x00, 0x00]))
     if raw_mouse.lLastY:
-        reports.append(bytes([0x02, 0x00, 0x00, raw_mouse.lLastY & 0xFF, 0x00]))
+        y_bytes = _mouse_i16_bytes(raw_mouse.lLastY)
+        reports.append(bytes([0x02, 0x00, 0x00, 0x00, *y_bytes, 0x00, 0x00]))
     return reports
 
 

--- a/src/bluetooth_2_usb/loopback_common.py
+++ b/src/bluetooth_2_usb/loopback_common.py
@@ -42,6 +42,7 @@ BTN_TASK = 279
 REL_X = 0
 REL_Y = 1
 REL_HWHEEL = 6
+REL_WHEEL = 8
 
 EVENT_TYPE_NAMES = {
     EV_KEY: "EV_KEY",
@@ -75,6 +76,7 @@ EVENT_CODE_NAMES = {
         REL_X: "REL_X",
         REL_Y: "REL_Y",
         REL_HWHEEL: "REL_HWHEEL",
+        REL_WHEEL: "REL_WHEEL",
     },
 }
 
@@ -269,6 +271,8 @@ MOUSE_SINGLE_REL_STEPS = (
     ExpectedEvent(EV_REL, REL_X, -1),
     ExpectedEvent(EV_REL, REL_Y, 1),
     ExpectedEvent(EV_REL, REL_Y, -1),
+    ExpectedEvent(EV_REL, REL_WHEEL, 1),
+    ExpectedEvent(EV_REL, REL_WHEEL, -1),
     ExpectedEvent(EV_REL, REL_HWHEEL, 1),
     ExpectedEvent(EV_REL, REL_HWHEEL, -1),
 )

--- a/src/bluetooth_2_usb/loopback_common.py
+++ b/src/bluetooth_2_usb/loopback_common.py
@@ -36,6 +36,11 @@ KEY_VOLUMEUP = 115
 KEY_VOLUMEDOWN = 114
 KEY_MINUS = 12
 KEY_SPACE = 57
+BTN_LEFT = 272
+BTN_RIGHT = 273
+BTN_MIDDLE = 274
+BTN_SIDE = 275
+BTN_EXTRA = 276
 BTN_FORWARD = 277
 BTN_BACK = 278
 BTN_TASK = 279
@@ -68,6 +73,11 @@ EVENT_CODE_NAMES = {
         KEY_VOLUMEDOWN: "KEY_VOLUMEDOWN",
         KEY_MINUS: "KEY_MINUS",
         KEY_SPACE: "KEY_SPACE",
+        BTN_LEFT: "BTN_LEFT",
+        BTN_RIGHT: "BTN_RIGHT",
+        BTN_MIDDLE: "BTN_MIDDLE",
+        BTN_SIDE: "BTN_SIDE",
+        BTN_EXTRA: "BTN_EXTRA",
         BTN_FORWARD: "BTN_FORWARD",
         BTN_BACK: "BTN_BACK",
         BTN_TASK: "BTN_TASK",
@@ -286,6 +296,16 @@ MOUSE_COALESCED_REL_STEPS = (
 MOUSE_REL_STEPS = MOUSE_SINGLE_REL_STEPS + MOUSE_COALESCED_REL_STEPS
 
 MOUSE_BUTTON_STEPS = (
+    ExpectedEvent(EV_KEY, BTN_LEFT, 1),
+    ExpectedEvent(EV_KEY, BTN_LEFT, 0),
+    ExpectedEvent(EV_KEY, BTN_RIGHT, 1),
+    ExpectedEvent(EV_KEY, BTN_RIGHT, 0),
+    ExpectedEvent(EV_KEY, BTN_MIDDLE, 1),
+    ExpectedEvent(EV_KEY, BTN_MIDDLE, 0),
+    ExpectedEvent(EV_KEY, BTN_SIDE, 1),
+    ExpectedEvent(EV_KEY, BTN_SIDE, 0),
+    ExpectedEvent(EV_KEY, BTN_EXTRA, 1),
+    ExpectedEvent(EV_KEY, BTN_EXTRA, 0),
     ExpectedEvent(EV_KEY, BTN_FORWARD, 1),
     ExpectedEvent(EV_KEY, BTN_FORWARD, 0),
     ExpectedEvent(EV_KEY, BTN_BACK, 1),

--- a/src/bluetooth_2_usb/loopback_common.py
+++ b/src/bluetooth_2_usb/loopback_common.py
@@ -36,8 +36,12 @@ KEY_VOLUMEUP = 115
 KEY_VOLUMEDOWN = 114
 KEY_MINUS = 12
 KEY_SPACE = 57
+BTN_FORWARD = 277
+BTN_BACK = 278
+BTN_TASK = 279
 REL_X = 0
 REL_Y = 1
+REL_HWHEEL = 6
 
 EVENT_TYPE_NAMES = {
     EV_KEY: "EV_KEY",
@@ -63,20 +67,32 @@ EVENT_CODE_NAMES = {
         KEY_VOLUMEDOWN: "KEY_VOLUMEDOWN",
         KEY_MINUS: "KEY_MINUS",
         KEY_SPACE: "KEY_SPACE",
+        BTN_FORWARD: "BTN_FORWARD",
+        BTN_BACK: "BTN_BACK",
+        BTN_TASK: "BTN_TASK",
     },
     EV_REL: {
         REL_X: "REL_X",
         REL_Y: "REL_Y",
+        REL_HWHEEL: "REL_HWHEEL",
     },
 }
 
-SCENARIO_NAMES = ("keyboard", "mouse", "combo", "consumer", "text_burst")
+SCENARIO_NAMES = (
+    "keyboard",
+    "mouse",
+    "combo",
+    "consumer",
+    "text_burst",
+)
 DEFAULT_DEVICE_SUBSTRING = "USB_Combo_Device"
 DEFAULT_KEYBOARD_NAME = "B2U Test Keyboard"
 DEFAULT_MOUSE_NAME = "B2U Test Mouse"
 DEFAULT_CONSUMER_NAME = "B2U Test Consumer"
 COMBO_MOUSE_DELAY_MS = 150
-HARNESS_LOCK_PATH = Path(tempfile.gettempdir()) / "bluetooth_2_usb_test_harness.lock"
+HARNESS_LOCK_PATH = (
+    Path(tempfile.gettempdir()) / "bluetooth_2_usb_loopback_harness.lock"
+)
 
 if os.name == "nt":
     import msvcrt
@@ -138,7 +154,7 @@ def harness_session(command: str, scenario: str):
             _lock_harness_file(lock_handle)
         except OSError as exc:
             raise HarnessBusyError(
-                "Another Bluetooth-2-USB test harness session is already running "
+                "Another Bluetooth-2-USB loopback harness session is already running "
                 f"(lock: {HARNESS_LOCK_PATH})"
             ) from exc
 
@@ -248,11 +264,30 @@ KEYBOARD_STEPS = (
     ExpectedEvent(EV_KEY, KEY_F15, 0),
 )
 
-MOUSE_REL_STEPS = (
+MOUSE_SINGLE_REL_STEPS = (
     ExpectedEvent(EV_REL, REL_X, 1),
     ExpectedEvent(EV_REL, REL_X, -1),
     ExpectedEvent(EV_REL, REL_Y, 1),
     ExpectedEvent(EV_REL, REL_Y, -1),
+    ExpectedEvent(EV_REL, REL_HWHEEL, 1),
+    ExpectedEvent(EV_REL, REL_HWHEEL, -1),
+)
+
+MOUSE_COALESCED_REL_STEPS = (
+    ExpectedEvent(EV_REL, REL_X, 2),
+    ExpectedEvent(EV_REL, REL_Y, -3),
+    ExpectedEvent(EV_REL, REL_HWHEEL, 1),
+)
+
+MOUSE_REL_STEPS = MOUSE_SINGLE_REL_STEPS + MOUSE_COALESCED_REL_STEPS
+
+MOUSE_BUTTON_STEPS = (
+    ExpectedEvent(EV_KEY, BTN_FORWARD, 1),
+    ExpectedEvent(EV_KEY, BTN_FORWARD, 0),
+    ExpectedEvent(EV_KEY, BTN_BACK, 1),
+    ExpectedEvent(EV_KEY, BTN_BACK, 0),
+    ExpectedEvent(EV_KEY, BTN_TASK, 1),
+    ExpectedEvent(EV_KEY, BTN_TASK, 0),
 )
 
 CONSUMER_STEPS = (
@@ -334,14 +369,14 @@ SCENARIOS = {
         name="mouse",
         keyboard_steps=(),
         mouse_rel_steps=MOUSE_REL_STEPS,
-        mouse_button_steps=(),
+        mouse_button_steps=MOUSE_BUTTON_STEPS,
         consumer_steps=(),
     ),
     "combo": ScenarioDefinition(
         name="combo",
         keyboard_steps=KEYBOARD_STEPS,
         mouse_rel_steps=MOUSE_REL_STEPS,
-        mouse_button_steps=(),
+        mouse_button_steps=MOUSE_BUTTON_STEPS,
         consumer_steps=(),
     ),
     "consumer": ScenarioDefinition(

--- a/src/bluetooth_2_usb/loopback_harness.py
+++ b/src/bluetooth_2_usb/loopback_harness.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 
-from .test_harness_common import (
+from .loopback_common import (
     DEFAULT_CONSUMER_NAME,
     DEFAULT_DEVICE_SUBSTRING,
     DEFAULT_KEYBOARD_NAME,
@@ -38,8 +38,8 @@ def _build_parser() -> argparse.ArgumentParser:
     inject.add_argument(
         "--pre-delay-ms",
         type=int,
-        default=1000,
-        help="Delay after virtual device creation before injection. Default: 1000",
+        default=6000,
+        help="Delay after virtual device creation before injection. Default: 6000",
     )
     inject.add_argument(
         "--event-gap-ms",
@@ -167,7 +167,7 @@ def run(argv: list[str] | None = None) -> int:
     try:
         with harness_session(args.command, args.scenario):
             if args.command == "inject":
-                from .test_harness_inject import run_inject
+                from .loopback_inject import run_inject
 
                 result = run_inject(
                     scenario_name=args.scenario,
@@ -178,7 +178,7 @@ def run(argv: list[str] | None = None) -> int:
                     consumer_name=args.consumer_name,
                 )
             else:
-                from .test_harness_capture import run_capture
+                from .loopback_capture import run_capture
 
                 result = run_capture(
                     scenario_name=args.scenario,

--- a/src/bluetooth_2_usb/loopback_harness.py
+++ b/src/bluetooth_2_usb/loopback_harness.py
@@ -82,8 +82,8 @@ def _build_parser() -> argparse.ArgumentParser:
     capture.add_argument(
         "--timeout-sec",
         type=float,
-        default=5.0,
-        help="Timeout waiting for relay events. Default: 5",
+        default=10.0,
+        help="Timeout waiting for relay events. Default: 10",
     )
     capture.add_argument(
         "--device-substring",

--- a/src/bluetooth_2_usb/loopback_inject.py
+++ b/src/bluetooth_2_usb/loopback_inject.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from evdev import UInput, ecodes
 
-from .test_harness_common import (
+from .loopback_common import (
     COMBO_MOUSE_DELAY_MS,
     DEFAULT_CONSUMER_NAME,
     DEFAULT_KEYBOARD_NAME,
@@ -13,6 +13,7 @@ from .test_harness_common import (
     EXIT_ACCESS,
     EXIT_OK,
     EXIT_PREREQUISITE,
+    MOUSE_COALESCED_REL_STEPS,
     SCENARIOS,
     HarnessResult,
     get_scenario,
@@ -26,6 +27,20 @@ def _send_step(device: UInput, step_event, event_gap_ms: int) -> None:
     device.write(step_event.event_type, step_event.code, step_event.value)
     device.syn()
     time.sleep(event_gap_ms / 1000.0)
+
+
+def _send_frame(device: UInput, step_events, event_gap_ms: int) -> None:
+    for step_event in step_events:
+        device.write(step_event.event_type, step_event.code, step_event.value)
+    device.syn()
+    time.sleep(event_gap_ms / 1000.0)
+
+
+def _mouse_rel_step_frames(scenario) -> tuple[tuple, tuple[tuple, ...]]:
+    coalesced = MOUSE_COALESCED_REL_STEPS
+    if scenario.mouse_rel_steps[-len(coalesced) :] == coalesced:
+        return scenario.mouse_rel_steps[: -len(coalesced)], (coalesced,)
+    return scenario.mouse_rel_steps, ()
 
 
 def _keyboard_capabilities() -> dict[int, list[int]]:
@@ -42,9 +57,26 @@ def _keyboard_capabilities() -> dict[int, list[int]]:
 
 
 def _mouse_capabilities() -> dict[int, list[int]]:
-    return {
-        ecodes.EV_REL: [ecodes.REL_X, ecodes.REL_Y],
-    }
+    rel_codes = sorted(
+        {
+            step.code
+            for scenario in SCENARIOS.values()
+            for step in scenario.mouse_rel_steps
+        }
+    )
+    button_codes = sorted(
+        {
+            step.code
+            for scenario in SCENARIOS.values()
+            for step in scenario.mouse_button_steps
+        }
+    )
+    capabilities: dict[int, list[int]] = {}
+    if rel_codes:
+        capabilities[ecodes.EV_REL] = rel_codes
+    if button_codes:
+        capabilities[ecodes.EV_KEY] = button_codes
+    return capabilities
 
 
 def _consumer_capabilities() -> dict[int, list[int]]:
@@ -55,7 +87,7 @@ def _consumer_capabilities() -> dict[int, list[int]]:
 
 def run_inject(
     scenario_name: str,
-    pre_delay_ms: int = 1000,
+    pre_delay_ms: int = 6000,
     event_gap_ms: int = 40,
     keyboard_name: str = DEFAULT_KEYBOARD_NAME,
     mouse_name: str = DEFAULT_MOUSE_NAME,
@@ -123,8 +155,11 @@ def run_inject(
             time.sleep(COMBO_MOUSE_DELAY_MS / 1000.0)
 
         if mouse is not None:
-            for step_event in scenario.mouse_rel_steps:
+            mouse_rel_steps, mouse_rel_frames = _mouse_rel_step_frames(scenario)
+            for step_event in mouse_rel_steps:
                 _send_step(mouse, step_event, event_gap_ms)
+            for frame in mouse_rel_frames:
+                _send_frame(mouse, frame, event_gap_ms)
             for step_event in scenario.mouse_button_steps:
                 _send_step(mouse, step_event, event_gap_ms)
 

--- a/src/bluetooth_2_usb/relay.py
+++ b/src/bluetooth_2_usb/relay.py
@@ -274,6 +274,9 @@ class InputFrameAccumulator:
         self._events = []
         return events
 
+    def clear(self) -> None:
+        self._events = []
+
     def _is_syn_report(self, event: InputEvent) -> bool:
         input_event = getattr(event, "event", event)
         event_type = getattr(input_event, "type", None)
@@ -929,6 +932,7 @@ class DeviceRelay:
         self._last_touch_x: int | None = None
         self._last_touch_y: int | None = None
         self._touch_x_scale, self._touch_y_scale = self._detect_touch_scale()
+        self._rel_pan_remainder = 0.0
 
     def __str__(self) -> str:
         return f"relay for {self._input_device}"
@@ -1050,6 +1054,7 @@ class DeviceRelay:
 
         :return: None
         """
+        device_disappeared = False
         try:
             async for input_event in self._input_device.async_read_loop():
                 event = categorize(input_event)
@@ -1067,6 +1072,7 @@ class DeviceRelay:
                 self._update_grab_state(active)
 
                 if not active:
+                    self._discard_pending_input_state()
                     continue
 
                 frame = self._frame_accumulator.add(event)
@@ -1079,9 +1085,12 @@ class DeviceRelay:
                 "Stopping relay loop for %s because the input device disappeared.",
                 self._input_device.path,
             )
-        pending_frame = self._frame_accumulator.flush()
-        if pending_frame is not None:
-            await self._process_frame_with_retry(pending_frame)
+            device_disappeared = True
+            self._discard_pending_input_state()
+        if not device_disappeared:
+            pending_frame = self._frame_accumulator.flush()
+            if pending_frame is not None:
+                await self._process_frame_with_retry(pending_frame)
         _logger.debug(
             "Relay stats for %s: hid_write_retries=%s hid_write_failures=%s",
             self._input_device.path,
@@ -1114,11 +1123,18 @@ class DeviceRelay:
             await self._process_event_with_retry(event)
 
         if rel_seen:
+            rel_pan = self._rel_pan_remainder + rel_pan
+            whole_pan = int(rel_pan)
+            self._rel_pan_remainder = rel_pan - whole_pan
             await self._process_mouse_delta_with_retry(
-                rel_x, rel_y, rel_wheel, int(rel_pan)
+                rel_x, rel_y, rel_wheel, whole_pan
             )
         if touch_seen:
             await self._process_touch_frame_with_retry()
+
+    def _discard_pending_input_state(self) -> None:
+        self._frame_accumulator.clear()
+        self._rel_pan_remainder = 0.0
 
     def _update_touch_abs(self, event: AbsEvent) -> None:
         input_event = event.event

--- a/src/bluetooth_2_usb/relay.py
+++ b/src/bluetooth_2_usb/relay.py
@@ -1090,7 +1090,8 @@ class DeviceRelay:
         )
 
     async def _process_frame_with_retry(self, frame: list[InputEvent]) -> None:
-        rel_x = rel_y = rel_wheel = rel_pan = 0
+        rel_x = rel_y = rel_wheel = 0
+        rel_pan = 0.0
         rel_seen = False
         touch_seen = False
 
@@ -1113,7 +1114,9 @@ class DeviceRelay:
             await self._process_event_with_retry(event)
 
         if rel_seen:
-            await self._process_mouse_delta_with_retry(rel_x, rel_y, rel_wheel, rel_pan)
+            await self._process_mouse_delta_with_retry(
+                rel_x, rel_y, rel_wheel, int(rel_pan)
+            )
         if touch_seen:
             await self._process_touch_frame_with_retry()
 
@@ -1329,12 +1332,12 @@ def move_mouse(event: RelEvent, gadget_manager: GadgetManager) -> None:
 
 
 def move_mouse_delta(
-    x: int, y: int, mwheel: int, pan: int, gadget_manager: GadgetManager
+    x: int, y: int, mwheel: int, pan: int | float, gadget_manager: GadgetManager
 ) -> None:
     mouse = gadget_manager.get_mouse()
     if mouse is None:
         raise RuntimeError("Mouse gadget not initialized or manager not enabled.")
-    mouse.move(x, y, mwheel, pan)
+    mouse.move(x, y, mwheel, int(pan))
 
 
 def send_key_event(event: KeyEvent, gadget_manager: GadgetManager) -> None:

--- a/src/bluetooth_2_usb/relay.py
+++ b/src/bluetooth_2_usb/relay.py
@@ -931,6 +931,10 @@ class DeviceRelay:
         self._touch_y: int | None = None
         self._last_touch_x: int | None = None
         self._last_touch_y: int | None = None
+        self._touch_motion_x_remainder = 0.0
+        self._touch_motion_y_remainder = 0.0
+        self._touch_pan_remainder = 0.0
+        self._touch_wheel_remainder = 0.0
         self._touch_x_scale, self._touch_y_scale = self._detect_touch_scale()
         self._rel_pan_remainder = 0.0
 
@@ -1135,6 +1139,19 @@ class DeviceRelay:
     def _discard_pending_input_state(self) -> None:
         self._frame_accumulator.clear()
         self._rel_pan_remainder = 0.0
+        self._reset_touch_state()
+
+    def _reset_touch_state(self) -> None:
+        self._touch_active = False
+        self._touch_contacts = 0
+        self._touch_x = None
+        self._touch_y = None
+        self._last_touch_x = None
+        self._last_touch_y = None
+        self._touch_motion_x_remainder = 0.0
+        self._touch_motion_y_remainder = 0.0
+        self._touch_pan_remainder = 0.0
+        self._touch_wheel_remainder = 0.0
 
     def _update_touch_abs(self, event: AbsEvent) -> None:
         input_event = event.event
@@ -1149,8 +1166,7 @@ class DeviceRelay:
         if scancode == ecodes.BTN_TOUCH:
             self._touch_active = is_down
             if not is_down:
-                self._last_touch_x = None
-                self._last_touch_y = None
+                self._reset_touch_state()
             return True
         contact_counts = {
             ecodes.BTN_TOOL_FINGER: 1,
@@ -1181,14 +1197,30 @@ class DeviceRelay:
         self._last_touch_y = self._touch_y
 
         if self._touch_contacts >= 2:
-            pan = int(delta_x / self._touch_x_scale)
-            wheel = -int(delta_y / self._touch_y_scale)
+            pan = self._accumulate_scaled_touch_delta(
+                delta_x, self._touch_x_scale, "_touch_pan_remainder"
+            )
+            wheel = -self._accumulate_scaled_touch_delta(
+                delta_y, self._touch_y_scale, "_touch_wheel_remainder"
+            )
             await self._process_mouse_delta_with_retry(0, 0, wheel, pan)
             return
 
-        x = int(delta_x / self._touch_x_scale)
-        y = int(delta_y / self._touch_y_scale)
+        x = self._accumulate_scaled_touch_delta(
+            delta_x, self._touch_x_scale, "_touch_motion_x_remainder"
+        )
+        y = self._accumulate_scaled_touch_delta(
+            delta_y, self._touch_y_scale, "_touch_motion_y_remainder"
+        )
         await self._process_mouse_delta_with_retry(x, y, 0, 0)
+
+    def _accumulate_scaled_touch_delta(
+        self, delta: int, scale: float, remainder_attr: str
+    ) -> int:
+        total = getattr(self, remainder_attr) + delta
+        steps = int(total / scale)
+        setattr(self, remainder_attr, total - (steps * scale))
+        return steps
 
     async def _process_mouse_delta_with_retry(
         self, x: int, y: int, wheel: int, pan: int

--- a/src/bluetooth_2_usb/relay.py
+++ b/src/bluetooth_2_usb/relay.py
@@ -12,7 +12,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 try:
-    from evdev import InputDevice, InputEvent, KeyEvent, RelEvent, categorize
+    from evdev import AbsEvent, InputDevice, InputEvent, KeyEvent, RelEvent, categorize
+    from evdev import ecodes as native_ecodes
 except ModuleNotFoundError:
     InputEvent = Any  # type: ignore[assignment]
 
@@ -38,11 +39,17 @@ except ModuleNotFoundError:
     class RelEvent:
         pass
 
+    class AbsEvent:
+        pass
+
+    native_ecodes = None  # type: ignore[assignment]
+
     def categorize(event):
         return event
 
 
 from .evdev import (
+    ecodes,
     evdev_to_usb_hid,
     find_key_name,
     get_mouse_movement,
@@ -93,7 +100,187 @@ except ModuleNotFoundError:
 if TYPE_CHECKING:
     from adafruit_hid.consumer_control import ConsumerControl
     from adafruit_hid.keyboard import Keyboard
-    from adafruit_hid.mouse import Mouse
+
+
+def _clamp_hid_i8(value: int) -> int:
+    return min(127, max(-127, value))
+
+
+def _clamp_hid_i16(value: int) -> int:
+    return min(32767, max(-32767, value))
+
+
+class ExtendedMouse:
+    """Small mouse report writer with horizontal pan support."""
+
+    LEFT_BUTTON = 1
+    RIGHT_BUTTON = 2
+    MIDDLE_BUTTON = 4
+    BACK_BUTTON = 8
+    FORWARD_BUTTON = 16
+    BUTTON_6 = 32
+    BUTTON_7 = 64
+    BUTTON_8 = 128
+
+    def __init__(self, devices) -> None:
+        from adafruit_hid import find_device
+
+        self._mouse_device = find_device(devices, usage_page=0x1, usage=0x02)
+        if not self._mouse_device:
+            raise ValueError("Could not find matching mouse HID device.")
+        self.report = bytearray(7)
+
+    def __str__(self):
+        return str(self._mouse_device)
+
+    def press(self, buttons: int) -> None:
+        self.report[0] |= buttons
+        self._send_no_move()
+
+    def release(self, buttons: int) -> None:
+        self.report[0] &= ~buttons
+        self._send_no_move()
+
+    def release_all(self) -> None:
+        self.report[0] = 0
+        self._send_no_move()
+
+    def move(self, x: int = 0, y: int = 0, wheel: int = 0, pan: int = 0) -> None:
+        while x != 0 or y != 0 or wheel != 0 or pan != 0:
+            partial_x = _clamp_hid_i16(x)
+            partial_y = _clamp_hid_i16(y)
+            partial_wheel = _clamp_hid_i8(wheel)
+            partial_pan = _clamp_hid_i8(pan)
+            self.report[1:3] = partial_x.to_bytes(2, "little", signed=True)
+            self.report[3:5] = partial_y.to_bytes(2, "little", signed=True)
+            self.report[5] = partial_wheel & 0xFF
+            self.report[6] = partial_pan & 0xFF
+            self._mouse_device.send_report(self.report)
+            x -= partial_x
+            y -= partial_y
+            wheel -= partial_wheel
+            pan -= partial_pan
+
+    def _send_no_move(self) -> None:
+        self.report[1:7] = b"\x00" * 6
+        self._mouse_device.send_report(self.report)
+
+
+class KeyboardLedSync:
+    """Best-effort propagation of host keyboard LED OUT reports to input devices."""
+
+    POLL_INTERVAL_SEC = 0.1
+    HID_TO_EVDEV_LED = (
+        (0x01, "LED_NUML"),
+        (0x02, "LED_CAPSL"),
+        (0x04, "LED_SCROLLL"),
+        (0x08, "LED_COMPOSE"),
+        (0x10, "LED_KANA"),
+    )
+
+    def __init__(self, gadget_manager: GadgetManager) -> None:
+        self._gadget_manager = gadget_manager
+        self._devices: dict[str, InputDevice] = {}
+        self._last_led_status = b"\x00"
+        self._task: asyncio.Task | None = None
+        self._stop_event = asyncio.Event()
+
+    def register_input_device(self, device: InputDevice) -> None:
+        if not self._supports_leds(device):
+            return
+        self._devices[device.path] = device
+        self._apply_led_status(device, self._last_led_status)
+
+    def unregister_input_device(self, device: InputDevice) -> None:
+        self._devices.pop(device.path, None)
+
+    async def __aenter__(self) -> KeyboardLedSync:
+        self._stop_event.clear()
+        self._task = asyncio.create_task(self._poll_loop())
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> bool:
+        self._stop_event.set()
+        if self._task is not None:
+            self._task.cancel()
+            await asyncio.gather(self._task, return_exceptions=True)
+        self._task = None
+        return False
+
+    async def _poll_loop(self) -> None:
+        while not self._stop_event.is_set():
+            self.poll_once()
+            try:
+                await asyncio.wait_for(
+                    self._stop_event.wait(), timeout=self.POLL_INTERVAL_SEC
+                )
+            except TimeoutError:
+                pass
+
+    def poll_once(self) -> None:
+        keyboard = self._gadget_manager.get_keyboard()
+        if keyboard is None or not hasattr(keyboard, "led_status"):
+            return
+        try:
+            led_status = bytes(keyboard.led_status)
+        except (BlockingIOError, OSError, ValueError):
+            return
+        if not led_status or led_status == self._last_led_status:
+            return
+        self._last_led_status = led_status[:1]
+        for device in tuple(self._devices.values()):
+            self._apply_led_status(device, self._last_led_status)
+
+    def _supports_leds(self, device: InputDevice) -> bool:
+        if not hasattr(device, "set_led"):
+            return False
+        try:
+            capabilities = device.capabilities(verbose=False)
+        except (AttributeError, OSError):
+            return False
+        ev_led = getattr(native_ecodes, "EV_LED", 0x11)
+        return ev_led in capabilities
+
+    def _apply_led_status(self, device: InputDevice, led_status: bytes) -> None:
+        if not led_status:
+            return
+        status = led_status[0]
+        for hid_mask, evdev_name in self.HID_TO_EVDEV_LED:
+            led_code = getattr(native_ecodes, evdev_name, None)
+            if led_code is None:
+                continue
+            try:
+                device.set_led(led_code, int(bool(status & hid_mask)))
+            except (AttributeError, OSError):
+                _logger.debug("Skipping LED update for %s", device.path)
+
+
+class InputFrameAccumulator:
+    """Collect evdev events until SYN_REPORT so stateful reports can be coalesced."""
+
+    def __init__(self) -> None:
+        self._events: list[InputEvent] = []
+
+    def add(self, event: InputEvent) -> list[InputEvent] | None:
+        if self._is_syn_report(event):
+            return self.flush()
+        self._events.append(event)
+        return None
+
+    def flush(self) -> list[InputEvent] | None:
+        if not self._events:
+            return None
+        events = self._events
+        self._events = []
+        return events
+
+    def _is_syn_report(self, event: InputEvent) -> bool:
+        input_event = getattr(event, "event", event)
+        event_type = getattr(input_event, "type", None)
+        event_code = getattr(input_event, "code", None)
+        ev_syn = getattr(native_ecodes, "EV_SYN", 0)
+        syn_report = getattr(native_ecodes, "SYN_REPORT", 0)
+        return event_type == ev_syn and event_code == syn_report
 
 
 class GadgetManager:
@@ -210,10 +397,9 @@ class GadgetManager:
 
         from adafruit_hid.consumer_control import ConsumerControl
         from adafruit_hid.keyboard import Keyboard
-        from adafruit_hid.mouse import Mouse
 
         self._gadgets["keyboard"] = Keyboard(enabled_devices)
-        self._gadgets["mouse"] = Mouse(enabled_devices)
+        self._gadgets["mouse"] = ExtendedMouse(enabled_devices)
         self._gadgets["consumer"] = ConsumerControl(enabled_devices)
         self._enabled = True
 
@@ -228,7 +414,7 @@ class GadgetManager:
         """
         return self._gadgets["keyboard"]
 
-    def get_mouse(self) -> Mouse | None:
+    def get_mouse(self) -> ExtendedMouse | None:
         """
         Get the Mouse gadget.
 
@@ -343,6 +529,7 @@ class RelayController:
         grab_devices: bool = False,
         relaying_active: asyncio.Event | None = None,
         shortcut_toggler: ShortcutToggler | None = None,
+        led_sync: KeyboardLedSync | None = None,
     ) -> None:
         """
         :param gadget_manager: Provides the USB HID gadget devices
@@ -364,6 +551,7 @@ class RelayController:
         self._grab_devices = grab_devices
         self._relaying_active = relaying_active
         self._shortcut_toggler = shortcut_toggler
+        self._led_sync = led_sync
 
         self._active_tasks: dict[str, Task] = {}
         self._active_devices: dict[str, InputDevice] = {}
@@ -660,6 +848,7 @@ class RelayController:
                 grab_device=self._grab_devices,
                 relaying_active=self._relaying_active,
                 shortcut_toggler=self._shortcut_toggler,
+                led_sync=self._led_sync,
             ) as relay:
                 _logger.info(f"Activated {relay}")
                 await relay.async_relay_events_loop()
@@ -713,6 +902,7 @@ class DeviceRelay:
         grab_device: bool = False,
         relaying_active: asyncio.Event | None = None,
         shortcut_toggler: ShortcutToggler | None = None,
+        led_sync: KeyboardLedSync | None = None,
     ) -> None:
         """
         :param input_device: The evdev input device
@@ -726,10 +916,19 @@ class DeviceRelay:
         self._grab_device = grab_device
         self._relaying_active = relaying_active
         self._shortcut_toggler = shortcut_toggler
+        self._led_sync = led_sync
 
         self._currently_grabbed = False
         self._hid_write_retries = 0
         self._hid_write_failures = 0
+        self._frame_accumulator = InputFrameAccumulator()
+        self._touch_active = False
+        self._touch_contacts = 0
+        self._touch_x: int | None = None
+        self._touch_y: int | None = None
+        self._last_touch_x: int | None = None
+        self._last_touch_y: int | None = None
+        self._touch_x_scale, self._touch_y_scale = self._detect_touch_scale()
 
     def __str__(self) -> str:
         return f"relay for {self._input_device}"
@@ -756,6 +955,8 @@ class DeviceRelay:
                 self._currently_grabbed = True
             except Exception as ex:
                 _logger.warning(f"Could not grab {self._input_device.path}: {ex}")
+        if self._led_sync is not None:
+            self._led_sync.register_input_device(self._input_device)
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> bool:
@@ -781,6 +982,8 @@ class DeviceRelay:
             self._release_gadget_states()
         except Exception:
             _logger.debug("Ignoring gadget state release failure for %s", self)
+        if self._led_sync is not None:
+            self._led_sync.unregister_input_device(self._input_device)
         try:
             self._input_device.close()
         except Exception:
@@ -789,6 +992,25 @@ class DeviceRelay:
 
     def _should_ignore_ungrab_error(self, ex: Exception) -> bool:
         return isinstance(ex, OSError) and ex.errno in (errno.ENODEV, errno.EBADF)
+
+    def _detect_touch_scale(self) -> tuple[float, float]:
+        return (
+            self._axis_scale(ecodes.ABS_MT_POSITION_X, ecodes.ABS_X),
+            self._axis_scale(ecodes.ABS_MT_POSITION_Y, ecodes.ABS_Y),
+        )
+
+    def _axis_scale(self, preferred_code: int, fallback_code: int) -> float:
+        for code in (preferred_code, fallback_code):
+            try:
+                info = self._input_device.absinfo(code)
+            except (AttributeError, OSError):
+                continue
+            minimum = getattr(info, "min", 0)
+            maximum = getattr(info, "max", 0)
+            axis_range = maximum - minimum
+            if axis_range > 0:
+                return max(axis_range / 1024.0, 1.0)
+        return 16.0
 
     def _release_gadget_states(self) -> None:
         keyboard = self._gadget_manager.get_keyboard()
@@ -847,7 +1069,9 @@ class DeviceRelay:
                 if not active:
                     continue
 
-                await self._process_event_with_retry(event)
+                frame = self._frame_accumulator.add(event)
+                if frame is not None:
+                    await self._process_frame_with_retry(frame)
         except OSError as ex:
             if ex.errno != errno.ENODEV:
                 raise
@@ -855,12 +1079,131 @@ class DeviceRelay:
                 "Stopping relay loop for %s because the input device disappeared.",
                 self._input_device.path,
             )
+        pending_frame = self._frame_accumulator.flush()
+        if pending_frame is not None:
+            await self._process_frame_with_retry(pending_frame)
         _logger.debug(
             "Relay stats for %s: hid_write_retries=%s hid_write_failures=%s",
             self._input_device.path,
             self._hid_write_retries,
             self._hid_write_failures,
         )
+
+    async def _process_frame_with_retry(self, frame: list[InputEvent]) -> None:
+        rel_x = rel_y = rel_wheel = rel_pan = 0
+        rel_seen = False
+        touch_seen = False
+
+        for event in frame:
+            if isinstance(event, RelEvent):
+                x, y, wheel, pan = get_mouse_movement(event)
+                rel_x += x
+                rel_y += y
+                rel_wheel += wheel
+                rel_pan += pan
+                rel_seen = True
+                continue
+            if isinstance(event, AbsEvent):
+                self._update_touch_abs(event)
+                touch_seen = True
+                continue
+            if isinstance(event, KeyEvent) and self._update_touch_key(event):
+                touch_seen = True
+                continue
+            await self._process_event_with_retry(event)
+
+        if rel_seen:
+            await self._process_mouse_delta_with_retry(rel_x, rel_y, rel_wheel, rel_pan)
+        if touch_seen:
+            await self._process_touch_frame_with_retry()
+
+    def _update_touch_abs(self, event: AbsEvent) -> None:
+        input_event = event.event
+        if input_event.code in (ecodes.ABS_X, ecodes.ABS_MT_POSITION_X):
+            self._touch_x = input_event.value
+        elif input_event.code in (ecodes.ABS_Y, ecodes.ABS_MT_POSITION_Y):
+            self._touch_y = input_event.value
+
+    def _update_touch_key(self, event: KeyEvent) -> bool:
+        scancode = event.scancode
+        is_down = event.keystate in (KeyEvent.key_down, KeyEvent.key_hold)
+        if scancode == ecodes.BTN_TOUCH:
+            self._touch_active = is_down
+            if not is_down:
+                self._last_touch_x = None
+                self._last_touch_y = None
+            return True
+        contact_counts = {
+            ecodes.BTN_TOOL_FINGER: 1,
+            ecodes.BTN_TOOL_DOUBLETAP: 2,
+            ecodes.BTN_TOOL_TRIPLETAP: 3,
+            ecodes.BTN_TOOL_QUADTAP: 4,
+            ecodes.BTN_TOOL_QUINTTAP: 5,
+        }
+        contact_count = contact_counts.get(scancode)
+        if contact_count is None:
+            return False
+        self._touch_contacts = (
+            contact_count if is_down else min(self._touch_contacts, contact_count - 1)
+        )
+        return True
+
+    async def _process_touch_frame_with_retry(self) -> None:
+        if not self._touch_active or self._touch_x is None or self._touch_y is None:
+            return
+        if self._last_touch_x is None or self._last_touch_y is None:
+            self._last_touch_x = self._touch_x
+            self._last_touch_y = self._touch_y
+            return
+
+        delta_x = self._touch_x - self._last_touch_x
+        delta_y = self._touch_y - self._last_touch_y
+        self._last_touch_x = self._touch_x
+        self._last_touch_y = self._touch_y
+
+        if self._touch_contacts >= 2:
+            pan = int(delta_x / self._touch_x_scale)
+            wheel = -int(delta_y / self._touch_y_scale)
+            await self._process_mouse_delta_with_retry(0, 0, wheel, pan)
+            return
+
+        x = int(delta_x / self._touch_x_scale)
+        y = int(delta_y / self._touch_y_scale)
+        await self._process_mouse_delta_with_retry(x, y, 0, 0)
+
+    async def _process_mouse_delta_with_retry(
+        self, x: int, y: int, wheel: int, pan: int
+    ) -> None:
+        if x == 0 and y == 0 and wheel == 0 and pan == 0:
+            return
+        max_tries = self.HID_WRITE_MAX_TRIES
+        retry_delay = self.HID_WRITE_RETRY_DELAY_SEC
+        for attempt in range(1, max_tries + 1):
+            try:
+                move_mouse_delta(x, y, wheel, pan, self._gadget_manager)
+                return
+            except BlockingIOError:
+                if attempt < max_tries:
+                    self._hid_write_retries += 1
+                    _logger.debug(f"HID write blocked ({attempt}/{max_tries})")
+                    await asyncio.sleep(retry_delay)
+                else:
+                    self._hid_write_failures += 1
+                    _logger.warning(f"HID write blocked ({attempt}/{max_tries})")
+            except BrokenPipeError:
+                self._hid_write_failures += 1
+                _logger.warning(
+                    "BrokenPipeError: USB cable likely disconnected or power-only. "
+                    "Pausing relay.\nSee: "
+                    "https://github.com/quaxalber/bluetooth_2_usb/blob/main/TROUBLESHOOTING.md"
+                )
+                if self._relaying_active:
+                    self._relaying_active.clear()
+                return
+            except Exception:
+                self._hid_write_failures += 1
+                _logger.exception("Error processing mouse frame")
+                return
 
     async def _process_event_with_retry(self, event: InputEvent) -> None:
         """
@@ -981,8 +1324,17 @@ def move_mouse(event: RelEvent, gadget_manager: GadgetManager) -> None:
     if mouse is None:
         raise RuntimeError("Mouse gadget not initialized or manager not enabled.")
 
-    x, y, mwheel = get_mouse_movement(event)
-    mouse.move(x, y, mwheel)
+    x, y, mwheel, pan = get_mouse_movement(event)
+    move_mouse_delta(x, y, mwheel, pan, gadget_manager)
+
+
+def move_mouse_delta(
+    x: int, y: int, mwheel: int, pan: int, gadget_manager: GadgetManager
+) -> None:
+    mouse = gadget_manager.get_mouse()
+    if mouse is None:
+        raise RuntimeError("Mouse gadget not initialized or manager not enabled.")
+    mouse.move(x, y, mwheel, pan)
 
 
 def send_key_event(event: KeyEvent, gadget_manager: GadgetManager) -> None:
@@ -1011,7 +1363,7 @@ def send_key_event(event: KeyEvent, gadget_manager: GadgetManager) -> None:
 
 def get_output_device(
     event: KeyEvent, gadget_manager: GadgetManager
-) -> ConsumerControl | Keyboard | Mouse | None:
+) -> ConsumerControl | Keyboard | ExtendedMouse | None:
     """
     Determine which HID gadget to target for the given key event.
 

--- a/tests/test_capture_device.py
+++ b/tests/test_capture_device.py
@@ -1,0 +1,27 @@
+import io
+import unittest
+from contextlib import redirect_stderr
+from unittest.mock import patch
+
+from bluetooth_2_usb import capture_device
+
+
+class CaptureDeviceCliTest(unittest.TestCase):
+    def test_capture_failures_are_reported_without_traceback(self) -> None:
+        stderr = io.StringIO()
+
+        with patch(
+            "bluetooth_2_usb.capture_device.capture",
+            side_effect=OSError("permission denied"),
+        ):
+            with redirect_stderr(stderr):
+                with self.assertRaises(SystemExit) as raised:
+                    capture_device.main(["--device", "/dev/input/missing"])
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("Failed to capture input device data", stderr.getvalue())
+        self.assertNotIn("Traceback", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_capture_device.py
+++ b/tests/test_capture_device.py
@@ -7,6 +7,10 @@ from bluetooth_2_usb import capture_device
 
 
 class CaptureDeviceCliTest(unittest.TestCase):
+    def test_capture_rejects_negative_duration(self) -> None:
+        with self.assertRaisesRegex(ValueError, "duration must be >= 0"):
+            capture_device.capture(duration=-1)
+
     def test_capture_failures_are_reported_without_traceback(self) -> None:
         stderr = io.StringIO()
 

--- a/tests/test_device_classification.py
+++ b/tests/test_device_classification.py
@@ -1,0 +1,65 @@
+import unittest
+from types import SimpleNamespace
+
+from bluetooth_2_usb.device_classification import describe_capabilities, ecodes
+
+
+class _FakeDevice:
+    def __init__(self, capabilities, props=()) -> None:
+        self._capabilities = capabilities
+        self._props = set(props)
+        self.absinfo_calls = []
+        self.capabilities_kwargs = []
+
+    def capabilities(self, **kwargs):
+        self.capabilities_kwargs.append(kwargs)
+        return self._capabilities
+
+    def input_props(self):
+        return self._props
+
+    def absinfo(self, code):
+        self.absinfo_calls.append(code)
+        return SimpleNamespace(min=0, max=1024, fuzz=1, flat=2, resolution=3)
+
+
+class DeviceClassificationTest(unittest.TestCase):
+    def test_abs_capabilities_are_requested_without_absinfo_tuples(self) -> None:
+        device = _FakeDevice(
+            {
+                ecodes.EV_ABS: [ecodes.ABS_X, ecodes.ABS_Y],
+                ecodes.EV_KEY: [ecodes.BTN_SOUTH],
+            }
+        )
+
+        capabilities = describe_capabilities(device)
+
+        self.assertEqual(
+            device.capabilities_kwargs, [{"verbose": False, "absinfo": False}]
+        )
+        self.assertEqual(device.absinfo_calls, [ecodes.ABS_X, ecodes.ABS_Y])
+        self.assertEqual([axis.code for axis in capabilities.abs_axes], [0, 1])
+
+    def test_button_only_devices_are_not_classified_as_keyboards(self) -> None:
+        device = _FakeDevice(
+            {
+                ecodes.EV_ABS: [ecodes.ABS_X, ecodes.ABS_Y],
+                ecodes.EV_KEY: [ecodes.BTN_SOUTH, ecodes.BTN_EAST],
+            }
+        )
+
+        capabilities = describe_capabilities(device)
+
+        self.assertIn("gamepad", capabilities.relay_classes)
+        self.assertNotIn("keyboard", capabilities.relay_classes)
+
+    def test_real_key_codes_are_classified_as_keyboard(self) -> None:
+        device = _FakeDevice({ecodes.EV_KEY: [ecodes.KEY_A]})
+
+        capabilities = describe_capabilities(device)
+
+        self.assertIn("keyboard", capabilities.relay_classes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -1,0 +1,50 @@
+import unittest
+from unittest.mock import patch
+
+from bluetooth_2_usb import inventory
+from bluetooth_2_usb.device_classification import DeviceCapabilities
+
+
+class _FakeDevice:
+    path = "/dev/input/event-abs"
+    name = "Generic ABS"
+    phys = "phys"
+    uniq = ""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def capabilities(self, verbose=False):
+        del verbose
+        return {inventory.native_ecodes.EV_ABS: [0]}
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class InventoryTest(unittest.TestCase):
+    def test_classless_abs_devices_are_not_relay_candidates(self) -> None:
+        device = _FakeDevice()
+        capabilities = DeviceCapabilities(
+            event_types=("EV_ABS",),
+            properties=(),
+            abs_axes=(),
+            relay_classes=(),
+        )
+
+        with patch(
+            "bluetooth_2_usb.inventory.list_input_devices", return_value=[device]
+        ):
+            with patch(
+                "bluetooth_2_usb.inventory.describe_capabilities",
+                return_value=capabilities,
+            ):
+                devices = inventory.describe_input_devices()
+
+        self.assertFalse(devices[0].relay_candidate)
+        self.assertEqual(devices[0].exclusion_reason, "missing supported relay classes")
+        self.assertTrue(device.closed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -14,8 +14,8 @@ class _FakeDevice:
     def __init__(self) -> None:
         self.closed = False
 
-    def capabilities(self, verbose=False):
-        del verbose
+    def capabilities(self, **kwargs):
+        del kwargs
         return {inventory.native_ecodes.EV_ABS: [0]}
 
     def close(self) -> None:
@@ -44,6 +44,13 @@ class InventoryTest(unittest.TestCase):
         self.assertFalse(devices[0].relay_candidate)
         self.assertEqual(devices[0].exclusion_reason, "missing supported relay classes")
         self.assertTrue(device.closed)
+
+    def test_auto_discovery_rejects_classless_abs_devices(self) -> None:
+        device = _FakeDevice()
+
+        exclusion_reason = inventory.auto_discover_exclusion_reason(device)
+
+        self.assertEqual(exclusion_reason, "missing supported relay classes")
 
 
 if __name__ == "__main__":

--- a/tests/test_loopback_harness.py
+++ b/tests/test_loopback_harness.py
@@ -233,6 +233,22 @@ class GadgetNodeDiscoveryTest(unittest.TestCase):
 
         self.assertEqual(resolved, str(dev_root / "hidraw7"))
 
+    def test_linux_hidraw_node_accepts_absolute_hidraw_path(self) -> None:
+        info = SimpleNamespace(node="/dev/hidraw3")
+
+        resolved = _resolve_hidraw_node(info)
+
+        self.assertEqual(resolved, "/dev/hidraw3")
+
+    def test_linux_hidraw_node_accepts_hidraw_device_name(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            dev_root = Path(tmp) / "dev"
+            info = SimpleNamespace(node="hidraw4")
+
+            resolved = _resolve_hidraw_node(info, dev_root=dev_root)
+
+        self.assertEqual(resolved, str(dev_root / "hidraw4"))
+
     def test_discovery_accepts_linux_gadget_signature_without_product_strings(
         self,
     ) -> None:

--- a/tests/test_loopback_harness.py
+++ b/tests/test_loopback_harness.py
@@ -105,7 +105,7 @@ class ScenarioDefinitionTest(unittest.TestCase):
         )
         self.assertEqual(
             [step.value for step in scenario.mouse_button_steps],
-            [1, 0, 1, 0, 1, 0],
+            [1, 0] * 8,
         )
 
     def test_mouse_injector_groups_coalesced_suffix_into_one_frame(self) -> None:
@@ -518,6 +518,16 @@ class MouseSequenceMatcherTest(unittest.TestCase):
     def test_mouse_matcher_accepts_extended_button_reports(self) -> None:
         matcher = MouseSequenceMatcher.create((), MOUSE_BUTTON_STEPS)
 
+        matcher.handle(bytes([0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
+        matcher.handle(bytes([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
+        matcher.handle(bytes([0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
+        matcher.handle(bytes([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
+        matcher.handle(bytes([0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
+        matcher.handle(bytes([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
+        matcher.handle(bytes([0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
+        matcher.handle(bytes([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
+        matcher.handle(bytes([0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
+        matcher.handle(bytes([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
         matcher.handle(bytes([0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
         matcher.handle(bytes([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
         matcher.handle(bytes([0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
@@ -723,11 +733,14 @@ class LoopbackHarnessCliTest(unittest.TestCase):
             to_text=lambda: "ignored",
         )
 
-        with patch("bluetooth_2_usb.loopback_capture.run_capture", return_value=result):
+        with patch(
+            "bluetooth_2_usb.loopback_capture.run_capture", return_value=result
+        ) as run_capture:
             with redirect_stdout(stdout):
                 exit_code = run_harness(["capture", "--output", "json"])
 
         self.assertEqual(exit_code, 0)
+        self.assertEqual(run_capture.call_args.kwargs["timeout_sec"], 10.0)
         self.assertEqual(
             json.loads(stdout.getvalue())["details"]["keyboard_steps_seen"], 6
         )

--- a/tests/test_loopback_harness.py
+++ b/tests/test_loopback_harness.py
@@ -36,6 +36,7 @@ from bluetooth_2_usb.loopback_common import (
     MOUSE_REL_STEPS,
     MOUSE_SINGLE_REL_STEPS,
     REL_HWHEEL,
+    REL_WHEEL,
     SCENARIOS,
     TEXT_BURST_STEPS,
     HarnessBusyError,
@@ -95,8 +96,8 @@ class ScenarioDefinitionTest(unittest.TestCase):
         self.assertEqual(scenario.mouse_rel_steps, MOUSE_REL_STEPS)
         self.assertEqual(scenario.mouse_button_steps, MOUSE_BUTTON_STEPS)
         self.assertEqual(
-            [step.code for step in MOUSE_SINGLE_REL_STEPS[-2:]],
-            [REL_HWHEEL, REL_HWHEEL],
+            [step.code for step in MOUSE_SINGLE_REL_STEPS[-4:]],
+            [REL_WHEEL, REL_WHEEL, REL_HWHEEL, REL_HWHEEL],
         )
         self.assertEqual(
             [(step.code, step.value) for step in scenario.mouse_rel_steps[-3:]],
@@ -487,6 +488,14 @@ class MouseSequenceMatcherTest(unittest.TestCase):
 
         matcher.handle(bytes([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]))
         matcher.handle(bytes([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF]))
+
+        self.assertTrue(matcher.complete)
+
+    def test_mouse_matcher_accepts_vertical_wheel_reports(self) -> None:
+        matcher = MouseSequenceMatcher.create(MOUSE_SINGLE_REL_STEPS[-4:-2], ())
+
+        matcher.handle(bytes([0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00]))
+        matcher.handle(bytes([0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0x00]))
 
         self.assertTrue(matcher.complete)
 

--- a/tests/test_loopback_harness.py
+++ b/tests/test_loopback_harness.py
@@ -233,6 +233,7 @@ class GadgetNodeDiscoveryTest(unittest.TestCase):
 
         self.assertEqual(resolved, str(dev_root / "hidraw7"))
 
+    @unittest.skipUnless(sys.platform.startswith("linux"), "Linux hidraw tests")
     def test_linux_hidraw_node_accepts_absolute_hidraw_path(self) -> None:
         info = SimpleNamespace(node="/dev/hidraw3")
 
@@ -240,6 +241,7 @@ class GadgetNodeDiscoveryTest(unittest.TestCase):
 
         self.assertEqual(resolved, "/dev/hidraw3")
 
+    @unittest.skipUnless(sys.platform.startswith("linux"), "Linux hidraw tests")
     def test_linux_hidraw_node_accepts_hidraw_device_name(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             dev_root = Path(tmp) / "dev"
@@ -660,6 +662,19 @@ class WindowsRawInputHelpersTest(unittest.TestCase):
         self.assertEqual(
             _mouse_event_to_reports(raw_mouse),
             [bytes([0x02, 0x00, 0x00, 0x00, 0x00, 0xFF])],
+        )
+
+    def test_mouse_event_to_reports_builds_16_bit_xy_reports(self) -> None:
+        raw_mouse = loopback_capture_windows.RAWMOUSE()
+        raw_mouse.lLastX = 300
+        raw_mouse.lLastY = -300
+
+        self.assertEqual(
+            _mouse_event_to_reports(raw_mouse),
+            [
+                bytes([0x02, 0x00, 0x2C, 0x01, 0x00, 0x00, 0x00, 0x00]),
+                bytes([0x02, 0x00, 0x00, 0x00, 0xD4, 0xFE, 0x00, 0x00]),
+            ],
         )
 
     def test_windows_backend_refuses_non_windows_runtime(self) -> None:

--- a/tests/test_loopback_harness.py
+++ b/tests/test_loopback_harness.py
@@ -2,39 +2,48 @@ import importlib
 import io
 import json
 import sys
+import tempfile
 import unittest
 from contextlib import redirect_stdout
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
-from bluetooth_2_usb import test_harness_capture_windows
-from bluetooth_2_usb.test_harness import run as run_harness
-from bluetooth_2_usb.test_harness_capture import (
+from bluetooth_2_usb import loopback_capture_windows
+from bluetooth_2_usb.loopback_capture import (
     CaptureMismatchError,
     ConsumerSequenceMatcher,
     KeyboardSequenceMatcher,
     MouseSequenceMatcher,
+    _resolve_hidraw_node,
     discover_gadget_node_candidates,
     discover_gadget_nodes,
 )
-from bluetooth_2_usb.test_harness_capture_windows import (
+from bluetooth_2_usb.loopback_capture_windows import (
     _device_matches_candidate,
     _extract_device_identities,
     _keyboard_event_to_report,
+    _mouse_event_to_reports,
     _stable_device_identity,
 )
-from bluetooth_2_usb.test_harness_common import (
+from bluetooth_2_usb.loopback_common import (
     CONSUMER_STEPS,
     EXIT_INTERRUPTED,
     EXIT_PREREQUISITE,
     EXIT_USAGE,
+    MOUSE_BUTTON_STEPS,
+    MOUSE_COALESCED_REL_STEPS,
     MOUSE_REL_STEPS,
+    MOUSE_SINGLE_REL_STEPS,
+    REL_HWHEEL,
     SCENARIOS,
     TEXT_BURST_STEPS,
     HarnessBusyError,
     HarnessResult,
     get_scenario,
 )
+from bluetooth_2_usb.loopback_harness import run as run_harness
+from bluetooth_2_usb.loopback_inject import _mouse_rel_step_frames
 
 
 def _hid_entry(
@@ -76,8 +85,33 @@ class ScenarioDefinitionTest(unittest.TestCase):
 
         self.assertEqual(combo.required_nodes, ("keyboard", "mouse"))
         self.assertEqual(len(combo.keyboard_steps), 6)
-        self.assertEqual(len(combo.mouse_rel_steps), 4)
-        self.assertEqual(len(combo.mouse_button_steps), 0)
+        self.assertEqual(combo.mouse_rel_steps, MOUSE_REL_STEPS)
+        self.assertEqual(combo.mouse_button_steps, MOUSE_BUTTON_STEPS)
+
+    def test_mouse_scenario_contains_motion_pan_and_extended_buttons(self) -> None:
+        scenario = SCENARIOS["mouse"]
+
+        self.assertEqual(scenario.required_nodes, ("mouse",))
+        self.assertEqual(scenario.mouse_rel_steps, MOUSE_REL_STEPS)
+        self.assertEqual(scenario.mouse_button_steps, MOUSE_BUTTON_STEPS)
+        self.assertEqual(
+            [step.code for step in MOUSE_SINGLE_REL_STEPS[-2:]],
+            [REL_HWHEEL, REL_HWHEEL],
+        )
+        self.assertEqual(
+            [(step.code, step.value) for step in scenario.mouse_rel_steps[-3:]],
+            [(0, 2), (1, -3), (REL_HWHEEL, 1)],
+        )
+        self.assertEqual(
+            [step.value for step in scenario.mouse_button_steps],
+            [1, 0, 1, 0, 1, 0],
+        )
+
+    def test_mouse_injector_groups_coalesced_suffix_into_one_frame(self) -> None:
+        individual_steps, grouped_frames = _mouse_rel_step_frames(SCENARIOS["mouse"])
+
+        self.assertEqual(individual_steps, MOUSE_SINGLE_REL_STEPS)
+        self.assertEqual(grouped_frames, (MOUSE_COALESCED_REL_STEPS,))
 
     def test_consumer_scenario_contains_volume_sequence(self) -> None:
         consumer = SCENARIOS["consumer"]
@@ -175,6 +209,28 @@ class GadgetNodeDiscoveryTest(unittest.TestCase):
         self.assertEqual(nodes.keyboard_node, "kbd-a")
         self.assertEqual(nodes.mouse_node, "mouse-a")
         self.assertEqual(nodes.consumer_node, "consumer-a")
+
+    def test_linux_hidraw_node_resolves_from_usb_interface_sysfs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            sys_usb_root = root / "sys" / "bus" / "usb" / "devices"
+            dev_root = root / "dev"
+            (sys_usb_root / "1-1:1.1" / "0003:0000:0000.0001" / "hidraw").mkdir(
+                parents=True
+            )
+            (dev_root).mkdir()
+            (
+                sys_usb_root / "1-1:1.1" / "0003:0000:0000.0001" / "hidraw" / "hidraw7"
+            ).touch()
+            info = SimpleNamespace(node="1-1:1.1")
+
+            resolved = _resolve_hidraw_node(
+                info,
+                sys_usb_root=sys_usb_root,
+                dev_root=dev_root,
+            )
+
+        self.assertEqual(resolved, str(dev_root / "hidraw7"))
 
     def test_discovery_accepts_linux_gadget_signature_without_product_strings(
         self,
@@ -392,39 +448,59 @@ class KeyboardSequenceMatcherTest(unittest.TestCase):
 
 class MouseSequenceMatcherTest(unittest.TestCase):
     def test_mouse_matcher_accepts_small_relative_motion_only(self) -> None:
-        matcher = MouseSequenceMatcher.create(MOUSE_REL_STEPS, ())
+        matcher = MouseSequenceMatcher.create(MOUSE_REL_STEPS[:4], ())
 
-        matcher.handle(bytes([0x02, 0x00, 0x01, 0x00, 0x00]))
-        matcher.handle(bytes([0x02, 0x00, 0xFF, 0x00, 0x00]))
-        matcher.handle(bytes([0x02, 0x00, 0x00, 0x01, 0x00]))
-        matcher.handle(bytes([0x02, 0x00, 0x00, 0xFF, 0x00]))
+        matcher.handle(bytes([0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00]))
+        matcher.handle(bytes([0x00, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00]))
+        matcher.handle(bytes([0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00]))
+        matcher.handle(bytes([0x00, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00]))
 
         self.assertTrue(matcher.complete)
 
-    def test_mouse_matcher_accepts_compact_report_id_format(self) -> None:
-        matcher = MouseSequenceMatcher.create(MOUSE_REL_STEPS, ())
+    def test_mouse_matcher_accepts_report_id_format(self) -> None:
+        matcher = MouseSequenceMatcher.create(MOUSE_REL_STEPS[:4], ())
 
-        matcher.handle(bytes([0x02, 0x00, 0x01, 0x00]))
+        matcher.handle(bytes([0x02, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00]))
         matcher.handle(bytes([0x00]))
-        matcher.handle(bytes([0x02, 0x00, 0xFF, 0x00]))
+        matcher.handle(bytes([0x02, 0x00, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00]))
         matcher.handle(bytes([0x00]))
-        matcher.handle(bytes([0x02, 0x00, 0x00, 0x01]))
+        matcher.handle(bytes([0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00]))
         matcher.handle(bytes([0x00]))
-        matcher.handle(bytes([0x02, 0x00, 0x00, 0xFF]))
+        matcher.handle(bytes([0x02, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00]))
 
         self.assertTrue(matcher.complete)
 
     def test_mouse_matcher_rejects_unexpected_button_bits(self) -> None:
-        matcher = MouseSequenceMatcher.create(MOUSE_REL_STEPS, ())
+        matcher = MouseSequenceMatcher.create(MOUSE_REL_STEPS[:4], ())
 
         with self.assertRaisesRegex(CaptureMismatchError, "button bits"):
-            matcher.handle(bytes([0x02, 0x02, 0, 0, 0]))
+            matcher.handle(bytes([0x02, 0, 0, 0, 0, 0, 0]))
 
     def test_mouse_matcher_rejects_unexpected_motion_order(self) -> None:
-        matcher = MouseSequenceMatcher.create(MOUSE_REL_STEPS, ())
+        matcher = MouseSequenceMatcher.create(MOUSE_REL_STEPS[:4], ())
 
         with self.assertRaisesRegex(CaptureMismatchError, "expected EV_REL/REL_X=1"):
-            matcher.handle(bytes([0x02, 0x00, 0xFF, 0x00, 0x00]))
+            matcher.handle(bytes([0x00, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00]))
+
+    def test_mouse_matcher_accepts_horizontal_pan_reports(self) -> None:
+        matcher = MouseSequenceMatcher.create(MOUSE_SINGLE_REL_STEPS[-2:], ())
+
+        matcher.handle(bytes([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]))
+        matcher.handle(bytes([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF]))
+
+        self.assertTrue(matcher.complete)
+
+    def test_mouse_matcher_accepts_extended_button_reports(self) -> None:
+        matcher = MouseSequenceMatcher.create((), MOUSE_BUTTON_STEPS)
+
+        matcher.handle(bytes([0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
+        matcher.handle(bytes([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
+        matcher.handle(bytes([0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
+        matcher.handle(bytes([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
+        matcher.handle(bytes([0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
+        matcher.handle(bytes([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
+
+        self.assertTrue(matcher.complete)
 
 
 class ConsumerSequenceMatcherTest(unittest.TestCase):
@@ -542,15 +618,24 @@ class WindowsRawInputHelpersTest(unittest.TestCase):
     def test_keyboard_event_to_report_ignores_unexpected_keys(self) -> None:
         self.assertIsNone(_keyboard_event_to_report(0x41, is_key_up=False))
 
+    def test_mouse_event_to_reports_builds_horizontal_pan_reports(self) -> None:
+        raw_mouse = loopback_capture_windows.RAWMOUSE()
+        raw_mouse.ulButtons = 0x0800 | (0xFFFF << 16)
+
+        self.assertEqual(
+            _mouse_event_to_reports(raw_mouse),
+            [bytes([0x02, 0x00, 0x00, 0x00, 0x00, 0xFF])],
+        )
+
     def test_windows_backend_refuses_non_windows_runtime(self) -> None:
         if sys.platform == "win32":
             self.skipTest("Non-Windows runtime guard is not exercised on Windows")
 
         with self.assertRaisesRegex(RuntimeError, "only available on Windows"):
-            test_harness_capture_windows.run_windows_raw_input_capture(
+            loopback_capture_windows.run_windows_raw_input_capture(
                 scenario_name="keyboard",
                 timeout_sec=1.0,
-                candidate_nodes=test_harness_capture_windows.GadgetNodeCandidates(
+                candidate_nodes=loopback_capture_windows.GadgetNodeCandidates(
                     keyboard_nodes=(),
                     mouse_nodes=(),
                     consumer_nodes=(),
@@ -565,30 +650,30 @@ class WindowsRawInputHelpersTest(unittest.TestCase):
 
         missing_names = ("HCURSOR", "HICON", "HBRUSH")
         original_values = {
-            name: getattr(test_harness_capture_windows.wintypes, name)
+            name: getattr(loopback_capture_windows.wintypes, name)
             for name in missing_names
-            if hasattr(test_harness_capture_windows.wintypes, name)
+            if hasattr(loopback_capture_windows.wintypes, name)
         }
         try:
             for name in missing_names:
-                if hasattr(test_harness_capture_windows.wintypes, name):
-                    delattr(test_harness_capture_windows.wintypes, name)
+                if hasattr(loopback_capture_windows.wintypes, name):
+                    delattr(loopback_capture_windows.wintypes, name)
 
-            reloaded = importlib.reload(test_harness_capture_windows)
+            reloaded = importlib.reload(loopback_capture_windows)
 
             self.assertIs(reloaded.wintypes.HCURSOR, reloaded.ctypes.c_void_p)
             self.assertIs(reloaded.wintypes.HICON, reloaded.ctypes.c_void_p)
             self.assertIs(reloaded.wintypes.HBRUSH, reloaded.ctypes.c_void_p)
         finally:
             for name in missing_names:
-                if hasattr(test_harness_capture_windows.wintypes, name):
-                    delattr(test_harness_capture_windows.wintypes, name)
+                if hasattr(loopback_capture_windows.wintypes, name):
+                    delattr(loopback_capture_windows.wintypes, name)
             for name, value in original_values.items():
-                setattr(test_harness_capture_windows.wintypes, name, value)
-            importlib.reload(test_harness_capture_windows)
+                setattr(loopback_capture_windows.wintypes, name, value)
+            importlib.reload(loopback_capture_windows)
 
 
-class TestHarnessCliTest(unittest.TestCase):
+class LoopbackHarnessCliTest(unittest.TestCase):
     def test_inject_usage_error_returns_exit_usage(self) -> None:
         stdout = io.StringIO()
 
@@ -613,9 +698,7 @@ class TestHarnessCliTest(unittest.TestCase):
             to_text=lambda: "ignored",
         )
 
-        with patch(
-            "bluetooth_2_usb.test_harness_capture.run_capture", return_value=result
-        ):
+        with patch("bluetooth_2_usb.loopback_capture.run_capture", return_value=result):
             with redirect_stdout(stdout):
                 exit_code = run_harness(["capture", "--output", "json"])
 
@@ -629,7 +712,7 @@ class TestHarnessCliTest(unittest.TestCase):
         hid_module = _FakeHidModule([])
 
         with patch(
-            "bluetooth_2_usb.test_harness_capture._load_hidapi",
+            "bluetooth_2_usb.loopback_capture._load_hidapi",
             return_value=hid_module,
         ):
             with redirect_stdout(stdout):
@@ -640,11 +723,11 @@ class TestHarnessCliTest(unittest.TestCase):
         self.assertEqual(exit_code, EXIT_PREREQUISITE)
         self.assertIn("Keyboard HID device was not found", stdout.getvalue())
 
-    def test_harness_reports_busy_lock_cleanly(self) -> None:
+    def test_loopback_harness_reports_busy_lock_cleanly(self) -> None:
         stdout = io.StringIO()
 
         with patch(
-            "bluetooth_2_usb.test_harness.harness_session",
+            "bluetooth_2_usb.loopback_harness.harness_session",
             side_effect=HarnessBusyError("busy"),
         ):
             with redirect_stdout(stdout):
@@ -654,7 +737,7 @@ class TestHarnessCliTest(unittest.TestCase):
         self.assertIn("busy", stdout.getvalue())
         self.assertIn("lock_path", stdout.getvalue())
 
-    def test_harness_reports_interrupt_cleanly(self) -> None:
+    def test_loopback_harness_reports_interrupt_cleanly(self) -> None:
         stdout = io.StringIO()
         fake_inject_module = SimpleNamespace(
             run_inject=Mock(side_effect=KeyboardInterrupt)
@@ -662,7 +745,7 @@ class TestHarnessCliTest(unittest.TestCase):
 
         with patch.dict(
             "sys.modules",
-            {"bluetooth_2_usb.test_harness_inject": fake_inject_module},
+            {"bluetooth_2_usb.loopback_inject": fake_inject_module},
         ):
             with redirect_stdout(stdout):
                 exit_code = run_harness(["inject"])
@@ -698,9 +781,9 @@ class TestHarnessCliTest(unittest.TestCase):
             ),
         )
 
-        with patch("bluetooth_2_usb.test_harness_capture.sys.platform", "win32"):
+        with patch("bluetooth_2_usb.loopback_capture.sys.platform", "win32"):
             with patch(
-                "bluetooth_2_usb.test_harness_capture._load_hidapi",
+                "bluetooth_2_usb.loopback_capture._load_hidapi",
                 return_value=_FakeHidModule(
                     [
                         _hid_entry(
@@ -723,7 +806,7 @@ class TestHarnessCliTest(unittest.TestCase):
                 ),
             ):
                 with patch(
-                    "bluetooth_2_usb.test_harness_capture_windows.run_windows_raw_input_capture",
+                    "bluetooth_2_usb.loopback_capture_windows.run_windows_raw_input_capture",
                     return_value=HarnessResult(
                         command="capture",
                         scenario="combo",
@@ -754,13 +837,13 @@ class TestHarnessCliTest(unittest.TestCase):
             ]
         )
 
-        with patch("bluetooth_2_usb.test_harness_capture.sys.platform", "win32"):
+        with patch("bluetooth_2_usb.loopback_capture.sys.platform", "win32"):
             with patch(
-                "bluetooth_2_usb.test_harness_capture._load_hidapi",
+                "bluetooth_2_usb.loopback_capture._load_hidapi",
                 return_value=consumer_hid,
             ):
                 with patch(
-                    "bluetooth_2_usb.test_harness_capture_windows.run_windows_raw_input_capture",
+                    "bluetooth_2_usb.loopback_capture_windows.run_windows_raw_input_capture",
                     return_value=HarnessResult(
                         command="capture",
                         scenario="consumer",
@@ -771,7 +854,7 @@ class TestHarnessCliTest(unittest.TestCase):
                     ),
                 ) as run_backend:
                     with patch(
-                        "bluetooth_2_usb.test_harness_capture._capture_once"
+                        "bluetooth_2_usb.loopback_capture._capture_once"
                     ) as capture_once:
                         exit_code = run_harness(["capture", "--scenario", "consumer"])
 

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -25,6 +25,7 @@ from bluetooth_2_usb.relay import (
     RelayController,
     RuntimeMonitor,
     ShortcutToggler,
+    ecodes,
     send_key_event,
 )
 
@@ -724,6 +725,34 @@ class DeviceRelayTest(unittest.IsolatedAsyncioTestCase):
                     await relay.async_relay_events_loop()
 
         self.assertEqual(manager.mouse.moves, [(5, -3, 0, 2)])
+
+    async def test_frame_aggregates_high_resolution_horizontal_wheel(self) -> None:
+        relaying_active = asyncio.Event()
+        relaying_active.set()
+
+        def make_rel(code: int, value: int):
+            return SimpleNamespace(
+                event=SimpleNamespace(type=2, code=code, value=value)
+            )
+
+        input_device = _TestInputDevice(
+            [
+                make_rel(ecodes.REL_HWHEEL_HI_RES, 60),
+                make_rel(ecodes.REL_HWHEEL_HI_RES, 60),
+                SimpleNamespace(event=SimpleNamespace(type=0, code=0, value=0)),
+            ]
+        )
+        manager = _FakeGadgetManager()
+        relay = DeviceRelay(input_device, manager, relaying_active=relaying_active)
+
+        with patch("bluetooth_2_usb.relay.RelEvent", SimpleNamespace):
+            with patch(
+                "bluetooth_2_usb.relay.categorize", side_effect=lambda event: event
+            ):
+                async with relay:
+                    await relay.async_relay_events_loop()
+
+        self.assertEqual(manager.mouse.moves, [(0, 0, 0, 1)])
 
     async def test_touchpad_absolute_motion_falls_back_to_mouse_motion(self) -> None:
         relaying_active = asyncio.Event()

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -209,6 +209,19 @@ class _TestInputDevice:
         return SimpleNamespace(min=0, max=1024)
 
 
+class _SequenceActive:
+    def __init__(self, states: list[bool]) -> None:
+        self._states = list(states)
+        self._index = 0
+
+    def is_set(self) -> bool:
+        if self._index >= len(self._states):
+            return self._states[-1]
+        value = self._states[self._index]
+        self._index += 1
+        return value
+
+
 class _FakeLedInputDevice:
     def __init__(self) -> None:
         self.path = "/dev/input/event-led"
@@ -637,7 +650,7 @@ class DeviceRelayTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(input_device.close_calls, 1)
         self.assertFalse(relay._currently_grabbed)
 
-    async def test_input_device_removal_stops_reader_without_failing_task_group(
+    async def test_input_device_removal_discards_pending_frame_without_failing(
         self,
     ) -> None:
         relaying_active = asyncio.Event()
@@ -669,7 +682,7 @@ class DeviceRelayTest(unittest.IsolatedAsyncioTestCase):
                     async with relay:
                         await relay.async_relay_events_loop()
 
-        self.assertEqual(seen, [(183, 1), (183, 0)])
+        self.assertEqual(seen, [])
 
     async def test_broken_pipe_clears_relaying_active_when_hid_write_fails(
         self,
@@ -753,6 +766,82 @@ class DeviceRelayTest(unittest.IsolatedAsyncioTestCase):
                     await relay.async_relay_events_loop()
 
         self.assertEqual(manager.mouse.moves, [(0, 0, 0, 1)])
+
+    async def test_high_resolution_horizontal_wheel_accumulates_across_frames(
+        self,
+    ) -> None:
+        relaying_active = asyncio.Event()
+        relaying_active.set()
+        syn = SimpleNamespace(event=SimpleNamespace(type=0, code=0, value=0))
+
+        def make_rel(code: int, value: int):
+            return SimpleNamespace(
+                event=SimpleNamespace(type=2, code=code, value=value)
+            )
+
+        input_device = _TestInputDevice(
+            [
+                make_rel(ecodes.REL_HWHEEL_HI_RES, 60),
+                syn,
+                make_rel(ecodes.REL_HWHEEL_HI_RES, 60),
+                syn,
+            ]
+        )
+        manager = _FakeGadgetManager()
+        relay = DeviceRelay(input_device, manager, relaying_active=relaying_active)
+
+        with patch("bluetooth_2_usb.relay.RelEvent", SimpleNamespace):
+            with patch(
+                "bluetooth_2_usb.relay.categorize", side_effect=lambda event: event
+            ):
+                async with relay:
+                    await relay.async_relay_events_loop()
+
+        self.assertEqual(manager.mouse.moves, [(0, 0, 0, 1)])
+
+    async def test_inactive_relay_discards_pending_mouse_frame(self) -> None:
+        syn = SimpleNamespace(event=SimpleNamespace(type=0, code=0, value=0))
+        input_device = _TestInputDevice(
+            [
+                SimpleNamespace(event=SimpleNamespace(type=2, code=0, value=5)),
+                syn,
+                syn,
+            ]
+        )
+        manager = _FakeGadgetManager()
+        relay = DeviceRelay(
+            input_device,
+            manager,
+            relaying_active=_SequenceActive([True, False, True]),
+        )
+
+        with patch("bluetooth_2_usb.relay.RelEvent", SimpleNamespace):
+            with patch(
+                "bluetooth_2_usb.relay.categorize", side_effect=lambda event: event
+            ):
+                async with relay:
+                    await relay.async_relay_events_loop()
+
+        self.assertEqual(manager.mouse.moves, [])
+
+    async def test_disappearing_device_discards_pending_mouse_frame(self) -> None:
+        relaying_active = asyncio.Event()
+        relaying_active.set()
+        input_device = _TestInputDevice(
+            [SimpleNamespace(event=SimpleNamespace(type=2, code=0, value=5))],
+            removal_errno=errno.ENODEV,
+        )
+        manager = _FakeGadgetManager()
+        relay = DeviceRelay(input_device, manager, relaying_active=relaying_active)
+
+        with patch("bluetooth_2_usb.relay.RelEvent", SimpleNamespace):
+            with patch(
+                "bluetooth_2_usb.relay.categorize", side_effect=lambda event: event
+            ):
+                async with relay:
+                    await relay.async_relay_events_loop()
+
+        self.assertEqual(manager.mouse.moves, [])
 
     async def test_touchpad_absolute_motion_falls_back_to_mouse_motion(self) -> None:
         relaying_active = asyncio.Event()

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -13,21 +13,33 @@ import usb_hid
 from bluetooth_2_usb.gadget_config import rebuild_gadget
 from bluetooth_2_usb.hid_layout import (
     DEFAULT_KEYBOARD_DESCRIPTOR,
+    DEFAULT_MOUSE_DESCRIPTOR,
     GadgetHidDevice,
     build_default_layout,
 )
 from bluetooth_2_usb.relay import (
     DeviceRelay,
+    ExtendedMouse,
     GadgetManager,
+    KeyboardLedSync,
     RelayController,
     RuntimeMonitor,
     ShortcutToggler,
+    send_key_event,
 )
 
 
 class _FakeKeyboard:
     def __init__(self) -> None:
         self.release_all_calls = 0
+        self.presses = []
+        self.releases = []
+
+    def press(self, key_id: int) -> None:
+        self.presses.append(key_id)
+
+    def release(self, key_id: int) -> None:
+        self.releases.append(key_id)
 
     def release_all(self) -> None:
         self.release_all_calls += 1
@@ -36,21 +48,49 @@ class _FakeKeyboard:
 class _FakeMouse:
     def __init__(self) -> None:
         self.release_all_calls = 0
+        self.moves = []
+        self.presses = []
+        self.releases = []
+
+    def press(self, buttons: int) -> None:
+        self.presses.append(buttons)
+
+    def release(self, buttons: int) -> None:
+        self.releases.append(buttons)
 
     def release_all(self) -> None:
         self.release_all_calls += 1
+
+    def move(self, x=0, y=0, wheel=0, pan=0) -> None:
+        self.moves.append((x, y, wheel, pan))
+
+
+class _FakeConsumer:
+    def __init__(self) -> None:
+        self.presses = []
+        self.releases = []
+
+    def press(self, usage: int) -> None:
+        self.presses.append(usage)
+
+    def release(self, usage: int) -> None:
+        self.releases.append(usage)
 
 
 class _FakeGadgetManager:
     def __init__(self) -> None:
         self.keyboard = _FakeKeyboard()
         self.mouse = _FakeMouse()
+        self.consumer = _FakeConsumer()
 
     def get_keyboard(self):
         return self.keyboard
 
     def get_mouse(self):
         return self.mouse
+
+    def get_consumer(self):
+        return self.consumer
 
 
 class _FakeRelayController:
@@ -143,6 +183,11 @@ class _TestKeyEvent:
         self.keystate = keystate
 
 
+class _TestAbsEvent:
+    def __init__(self, code: int, value: int) -> None:
+        self.event = SimpleNamespace(type=3, code=code, value=value)
+
+
 class _TestInputDevice:
     def __init__(self, events, *, removal_errno: int | None = None) -> None:
         self.path = "/dev/input/event-test"
@@ -158,6 +203,22 @@ class _TestInputDevice:
 
     def close(self) -> None:
         return None
+
+    def absinfo(self, _code: int):
+        return SimpleNamespace(min=0, max=1024)
+
+
+class _FakeLedInputDevice:
+    def __init__(self) -> None:
+        self.path = "/dev/input/event-led"
+        self.leds = []
+
+    def capabilities(self, verbose=False):
+        del verbose
+        return {17: [0, 1, 2]}
+
+    def set_led(self, led_code: int, value: int) -> None:
+        self.leds.append((led_code, value))
 
 
 class ShortcutTogglerTest(unittest.TestCase):
@@ -185,6 +246,84 @@ class ShortcutTogglerTest(unittest.TestCase):
         self.assertFalse(toggler.handle_key_event(make_event(42, 1)))
         self.assertTrue(toggler.handle_key_event(make_event(88, 1)))
         self.assertFalse(event_state.is_set())
+
+    def test_shortcut_hold_events_do_not_retrigger_toggle(self) -> None:
+        event_state = asyncio.Event()
+        toggler = ShortcutToggler(
+            shortcut_keys={"KEY_LEFTCTRL", "KEY_LEFTSHIFT", "KEY_F12"},
+            relaying_active=event_state,
+            gadget_manager=_FakeGadgetManager(),
+        )
+
+        make_event = lambda scancode, keystate: SimpleNamespace(
+            scancode=scancode, keystate=keystate
+        )
+
+        self.assertFalse(toggler.handle_key_event(make_event(29, 1)))
+        self.assertFalse(toggler.handle_key_event(make_event(42, 1)))
+        self.assertTrue(toggler.handle_key_event(make_event(88, 1)))
+        self.assertTrue(event_state.is_set())
+
+        self.assertTrue(toggler.handle_key_event(make_event(88, 2)))
+        self.assertTrue(event_state.is_set())
+
+
+class SendKeyEventTest(unittest.TestCase):
+    def test_hold_events_are_ignored_for_keyboard_mouse_and_consumer(self) -> None:
+        manager = _FakeGadgetManager()
+
+        with patch("bluetooth_2_usb.relay.KeyEvent", _TestKeyEvent):
+            send_key_event(_TestKeyEvent(183, _TestKeyEvent.key_hold), manager)
+            send_key_event(_TestKeyEvent(115, _TestKeyEvent.key_hold), manager)
+            send_key_event(_TestKeyEvent(277, _TestKeyEvent.key_hold), manager)
+
+        self.assertEqual(manager.keyboard.presses, [])
+        self.assertEqual(manager.keyboard.releases, [])
+        self.assertEqual(manager.consumer.presses, [])
+        self.assertEqual(manager.consumer.releases, [])
+        self.assertEqual(manager.mouse.presses, [])
+        self.assertEqual(manager.mouse.releases, [])
+
+
+class ExtendedMouseTest(unittest.TestCase):
+    def test_move_uses_16_bit_xy_and_8_bit_wheel_pan(self) -> None:
+        device = SimpleNamespace(sent=[])
+
+        def send_report(report) -> None:
+            device.sent.append(bytes(report))
+
+        device.send_report = send_report
+
+        with patch("adafruit_hid.find_device", return_value=device):
+            mouse = ExtendedMouse(devices=[])
+            mouse.move(x=300, y=-300, wheel=1, pan=-1)
+
+        self.assertEqual(
+            device.sent,
+            [
+                bytes([0x00, 0x2C, 0x01, 0xD4, 0xFE, 0x01, 0xFF]),
+            ],
+        )
+
+    def test_move_splits_large_xy_without_widening_wheel_pan(self) -> None:
+        device = SimpleNamespace(sent=[])
+
+        def send_report(report) -> None:
+            device.sent.append(bytes(report))
+
+        device.send_report = send_report
+
+        with patch("adafruit_hid.find_device", return_value=device):
+            mouse = ExtendedMouse(devices=[])
+            mouse.move(x=40000, y=-40000, wheel=200, pan=-200)
+
+        self.assertEqual(
+            device.sent,
+            [
+                bytes([0x00, 0xFF, 0x7F, 0x01, 0x80, 0x7F, 0x81]),
+                bytes([0x00, 0x41, 0x1C, 0xBF, 0xE3, 0x49, 0xB7]),
+            ],
+        )
 
 
 class RuntimeMonitorTest(unittest.TestCase):
@@ -242,9 +381,8 @@ class GadgetManagerLayoutTest(unittest.TestCase):
         self.assertEqual(
             bytes(layout.devices[0].descriptor), DEFAULT_KEYBOARD_DESCRIPTOR
         )
-        self.assertEqual(
-            bytes(layout.devices[1].descriptor), bytes(usb_hid.Device.MOUSE.descriptor)
-        )
+        self.assertEqual(bytes(layout.devices[1].descriptor), DEFAULT_MOUSE_DESCRIPTOR)
+        self.assertEqual(tuple(layout.devices[1].in_report_lengths), (7,))
         self.assertEqual(
             bytes(layout.devices[2].descriptor),
             bytes(usb_hid.Device.CONSUMER_CONTROL.descriptor),
@@ -557,6 +695,79 @@ class DeviceRelayTest(unittest.IsolatedAsyncioTestCase):
 
         self.assertFalse(relaying_active.is_set())
         self.assertEqual(relay._hid_write_failures, 1)
+
+    async def test_frame_aggregates_relative_mouse_events(self) -> None:
+        relaying_active = asyncio.Event()
+        relaying_active.set()
+
+        def make_rel(code: int, value: int):
+            return SimpleNamespace(
+                event=SimpleNamespace(type=2, code=code, value=value)
+            )
+
+        input_device = _TestInputDevice(
+            [
+                make_rel(0, 5),
+                make_rel(1, -3),
+                make_rel(6, 2),
+                SimpleNamespace(event=SimpleNamespace(type=0, code=0, value=0)),
+            ]
+        )
+        manager = _FakeGadgetManager()
+        relay = DeviceRelay(input_device, manager, relaying_active=relaying_active)
+
+        with patch("bluetooth_2_usb.relay.RelEvent", SimpleNamespace):
+            with patch(
+                "bluetooth_2_usb.relay.categorize", side_effect=lambda event: event
+            ):
+                async with relay:
+                    await relay.async_relay_events_loop()
+
+        self.assertEqual(manager.mouse.moves, [(5, -3, 0, 2)])
+
+    async def test_touchpad_absolute_motion_falls_back_to_mouse_motion(self) -> None:
+        relaying_active = asyncio.Event()
+        relaying_active.set()
+        syn = SimpleNamespace(event=SimpleNamespace(type=0, code=0, value=0))
+        input_device = _TestInputDevice(
+            [
+                _TestKeyEvent(330, _TestKeyEvent.key_down),
+                _TestKeyEvent(325, _TestKeyEvent.key_down),
+                _TestAbsEvent(53, 100),
+                _TestAbsEvent(54, 100),
+                syn,
+                _TestAbsEvent(53, 110),
+                _TestAbsEvent(54, 95),
+                syn,
+            ]
+        )
+        manager = _FakeGadgetManager()
+        relay = DeviceRelay(input_device, manager, relaying_active=relaying_active)
+
+        with patch("bluetooth_2_usb.relay.KeyEvent", _TestKeyEvent):
+            with patch("bluetooth_2_usb.relay.AbsEvent", _TestAbsEvent):
+                with patch(
+                    "bluetooth_2_usb.relay.categorize", side_effect=lambda event: event
+                ):
+                    async with relay:
+                        await relay.async_relay_events_loop()
+
+        self.assertEqual(manager.mouse.moves, [(10, -5, 0, 0)])
+
+
+class KeyboardLedSyncTest(unittest.IsolatedAsyncioTestCase):
+    def test_poll_once_applies_host_led_report_to_led_devices(self) -> None:
+        keyboard = SimpleNamespace(led_status=b"\x03")
+        manager = SimpleNamespace(get_keyboard=lambda: keyboard)
+        led_sync = KeyboardLedSync(manager)
+        device = _FakeLedInputDevice()
+
+        led_sync.register_input_device(device)
+        led_sync.poll_once()
+
+        self.assertIn((0, 1), device.leds)
+        self.assertIn((1, 1), device.leds)
+        self.assertIn((2, 0), device.leds)
 
 
 class RelayControllerHotplugTest(unittest.TestCase):

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -190,11 +190,14 @@ class _TestAbsEvent:
 
 
 class _TestInputDevice:
-    def __init__(self, events, *, removal_errno: int | None = None) -> None:
+    def __init__(
+        self, events, *, removal_errno: int | None = None, abs_max: int = 1024
+    ) -> None:
         self.path = "/dev/input/event-test"
         self.name = "test-input-device"
         self._events = list(events)
         self._removal_errno = removal_errno
+        self._abs_max = abs_max
 
     async def async_read_loop(self):
         for event in self._events:
@@ -206,7 +209,7 @@ class _TestInputDevice:
         return None
 
     def absinfo(self, _code: int):
-        return SimpleNamespace(min=0, max=1024)
+        return SimpleNamespace(min=0, max=self._abs_max)
 
 
 class _SequenceActive:
@@ -871,6 +874,102 @@ class DeviceRelayTest(unittest.IsolatedAsyncioTestCase):
                         await relay.async_relay_events_loop()
 
         self.assertEqual(manager.mouse.moves, [(10, -5, 0, 0)])
+
+    def test_discard_pending_input_state_clears_touch_tracking(self) -> None:
+        relay = DeviceRelay(
+            _TestInputDevice([]),
+            _FakeGadgetManager(),
+            relaying_active=asyncio.Event(),
+        )
+        relay._touch_active = True
+        relay._touch_contacts = 2
+        relay._touch_x = 100
+        relay._touch_y = 200
+        relay._last_touch_x = 90
+        relay._last_touch_y = 190
+        relay._touch_motion_x_remainder = 0.5
+        relay._touch_motion_y_remainder = -0.5
+        relay._touch_pan_remainder = 0.5
+        relay._touch_wheel_remainder = -0.5
+
+        relay._discard_pending_input_state()
+
+        self.assertFalse(relay._touch_active)
+        self.assertEqual(relay._touch_contacts, 0)
+        self.assertIsNone(relay._touch_x)
+        self.assertIsNone(relay._touch_y)
+        self.assertIsNone(relay._last_touch_x)
+        self.assertIsNone(relay._last_touch_y)
+        self.assertEqual(relay._touch_motion_x_remainder, 0.0)
+        self.assertEqual(relay._touch_motion_y_remainder, 0.0)
+        self.assertEqual(relay._touch_pan_remainder, 0.0)
+        self.assertEqual(relay._touch_wheel_remainder, 0.0)
+
+    async def test_touchpad_motion_accumulates_sub_step_deltas(self) -> None:
+        relaying_active = asyncio.Event()
+        relaying_active.set()
+        syn = SimpleNamespace(event=SimpleNamespace(type=0, code=0, value=0))
+        input_device = _TestInputDevice(
+            [
+                _TestKeyEvent(ecodes.BTN_TOUCH, _TestKeyEvent.key_down),
+                _TestKeyEvent(ecodes.BTN_TOOL_FINGER, _TestKeyEvent.key_down),
+                _TestAbsEvent(ecodes.ABS_MT_POSITION_X, 100),
+                _TestAbsEvent(ecodes.ABS_MT_POSITION_Y, 100),
+                syn,
+                _TestAbsEvent(ecodes.ABS_MT_POSITION_X, 101),
+                _TestAbsEvent(ecodes.ABS_MT_POSITION_Y, 100),
+                syn,
+                _TestAbsEvent(ecodes.ABS_MT_POSITION_X, 102),
+                _TestAbsEvent(ecodes.ABS_MT_POSITION_Y, 100),
+                syn,
+            ],
+            abs_max=2048,
+        )
+        manager = _FakeGadgetManager()
+        relay = DeviceRelay(input_device, manager, relaying_active=relaying_active)
+
+        with patch("bluetooth_2_usb.relay.KeyEvent", _TestKeyEvent):
+            with patch("bluetooth_2_usb.relay.AbsEvent", _TestAbsEvent):
+                with patch(
+                    "bluetooth_2_usb.relay.categorize", side_effect=lambda event: event
+                ):
+                    async with relay:
+                        await relay.async_relay_events_loop()
+
+        self.assertEqual(manager.mouse.moves, [(1, 0, 0, 0)])
+
+    async def test_touchpad_scroll_accumulates_sub_step_deltas(self) -> None:
+        relaying_active = asyncio.Event()
+        relaying_active.set()
+        syn = SimpleNamespace(event=SimpleNamespace(type=0, code=0, value=0))
+        input_device = _TestInputDevice(
+            [
+                _TestKeyEvent(ecodes.BTN_TOUCH, _TestKeyEvent.key_down),
+                _TestKeyEvent(ecodes.BTN_TOOL_DOUBLETAP, _TestKeyEvent.key_down),
+                _TestAbsEvent(ecodes.ABS_MT_POSITION_X, 100),
+                _TestAbsEvent(ecodes.ABS_MT_POSITION_Y, 100),
+                syn,
+                _TestAbsEvent(ecodes.ABS_MT_POSITION_X, 101),
+                _TestAbsEvent(ecodes.ABS_MT_POSITION_Y, 99),
+                syn,
+                _TestAbsEvent(ecodes.ABS_MT_POSITION_X, 102),
+                _TestAbsEvent(ecodes.ABS_MT_POSITION_Y, 98),
+                syn,
+            ],
+            abs_max=2048,
+        )
+        manager = _FakeGadgetManager()
+        relay = DeviceRelay(input_device, manager, relaying_active=relaying_active)
+
+        with patch("bluetooth_2_usb.relay.KeyEvent", _TestKeyEvent):
+            with patch("bluetooth_2_usb.relay.AbsEvent", _TestAbsEvent):
+                with patch(
+                    "bluetooth_2_usb.relay.categorize", side_effect=lambda event: event
+                ):
+                    async with relay:
+                        await relay.async_relay_events_loop()
+
+        self.assertEqual(manager.mouse.moves, [(0, 0, 1, 1)])
 
 
 class KeyboardLedSyncTest(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary

- expand the mouse gadget to one button byte, signed 16-bit X/Y, signed 8-bit wheel and horizontal pan
- add frame aggregation, touchpad fallback, best-effort keyboard LED sync, and extended mouse button mapping
- rename shipped loopback harness modules from `test_harness*` to `loopback_*` without keeping the old module path
- add Linux hidraw loopback capture, collapsed mouse scenario coverage, device capture tooling, and documentation updates
- document project-focused Git artifact naming for branches, commit messages, PR titles, and PR bodies
- pin cleaned Adafruit HID and Blinka forks after removing experimental gamepad and digitizer helpers

## Affected Issues

- Closes #11 by adding horizontal mouse pan support.
- Closes #111 by adding best-effort keyboard LED synchronization for LED-capable input devices.
- Addresses #137 by adding touchpad fallback behavior and capture workflow support for real Magic Trackpad data.
- Refs #120 by adding gamepad/device capture and classification groundwork; native gamepad HID output is not closed by this PR.

## Validation

- `venv/bin/python -m black --check src tests`
- `venv/bin/python -m ruff check src tests`
- `venv/bin/python -m unittest discover -s tests -v`
- `venv/bin/python -m unittest tests.test_relay tests.test_loopback_harness -v`
- `venv/bin/python -m unittest tests.test_capture_device tests.test_loopback_harness -v`
- `venv/bin/python -m compileall src tests`
- `venv/bin/python -m bluetooth_2_usb --help`
- `venv/bin/python -m bluetooth_2_usb --version`
- `venv/bin/shfmt -d -i 2 -ci -bn` over all shell scripts
- `venv/bin/shellcheck -x` over all shell scripts
- `bash -n` over all shell scripts
- `venv/bin/yamllint .github/workflows/ci.yml`
- `venv/bin/python -m build`
- script `--help` checks per the doc consistency guide
- descriptor byte identity check for the keyboard and mouse descriptors after formatting them into two-byte rows
- `pi4b` loopback `mouse` passed through installed scripts, including 16-bit X/Y, vertical wheel, pan, all 8 mouse button bits, and coalesced frame capture
- verified `pi4b` new module path works and old `bluetooth_2_usb.test_harness` path fails
- verified cleaned Adafruit HID fork no longer exports `adafruit_hid.gamepad` or `adafruit_hid.digitizer`
- verified cleaned Blinka fork no longer exports `usb_hid.Device.GAMEPAD` or `usb_hid.Device.DIGITIZER`
- verified `pi0w` remained active and was not touched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added device input capture functionality to record hardware capabilities and live events
  * Extended mouse support with additional button recognition and horizontal wheel movement
  * Added keyboard LED synchronization between host and device

* **Documentation**
  * Added device capture workflow guide
  * Updated contribution guidelines for naming conventions
  * Extended harness testing documentation

* **Refactor**
  * Optimized mouse relay processing with frame coalescing for improved event handling
  * Renamed test harness to loopback harness throughout
  * Improved relay architecture for better HID compatibility

* **Tests**
  * Added comprehensive tests for device capture and classification
  * Enhanced relay and inventory test coverage

* **Chores**
  * Updated dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->