### PR TITLE
fix: split readonly disable and migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,8 +280,13 @@ Bluetooth state on separate persistent storage.
 
 ### `readonly disable`
 
-Return the system to normal writable mode while keeping the persistent
-Bluetooth-state storage configuration available.
+Turn off read-only mode. Persistent Bluetooth state remains mounted until it is
+migrated back to the root filesystem.
+
+### `readonly migrate`
+
+Move Bluetooth state from persistent storage back to `/var/lib/bluetooth` on the
+root filesystem, then unmount the persistent storage.
 
 ## Managed paths
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -123,6 +123,11 @@ Interpretation:
 For the full setup and validation flow, use
 [docs/persistent-readonly.md](docs/persistent-readonly.md).
 
+If read-only mode is disabled but the persistent Bluetooth mount is still
+active, run `sudo bluetooth_2_usb readonly migrate` after rebooting onto the
+normal root filesystem. The migrate command copies Bluetooth state back to
+`/var/lib/bluetooth` and unmounts the persistent storage.
+
 ## SSH, ping, or DNS access to the Pi is flaky
 
 Symptom: the Pi looks online enough to suspect it is reachable, but `ssh`,

--- a/docs/cli-service-test.md
+++ b/docs/cli-service-test.md
@@ -323,12 +323,20 @@ until new_boot_id="$(ssh -o ConnectTimeout=5 <pi-host> 'cat /proc/sys/kernel/ran
   fi
   sleep 2
 done
+ssh <pi-host> 'sudo -n bluetooth_2_usb readonly migrate'
+ssh <pi-host> 'sudo -n bluetooth_2_usb smoketest --verbose'
 ```
 
 > [!WARNING]
 > Only run destructive read-only rollback checks after disabling read-only mode
 > and rebooting, once `findmnt -no FSTYPE,SOURCE /` no longer shows `overlay`
 > for the live root filesystem.
+
+Expected outcome:
+
+- read-only mode is disabled
+- Bluetooth state is migrated back to the root filesystem
+- persistent Bluetooth storage is unmounted
 
 ## Uninstall validation
 

--- a/docs/persistent-readonly.md
+++ b/docs/persistent-readonly.md
@@ -137,7 +137,18 @@ instead of leaving you with a half-configured read-only boot path.
 bluetooth_2_usb readonly status
 sudo bluetooth_2_usb readonly disable
 sudo reboot
+sudo bluetooth_2_usb readonly migrate
+bluetooth_2_usb smoketest --verbose
 ```
+
+`readonly disable` turns off OverlayFS/read-only mode. It does not move
+Bluetooth state by itself, so smoketest may warn that the persistent Bluetooth
+mount is still active while read-only mode is disabled.
+
+After reboot, run `readonly migrate` to copy Bluetooth state back to the root
+filesystem and unmount the persistent storage. The migration command refuses to
+run while the live root filesystem is still overlay-backed because writes to
+`/var/lib/bluetooth` would not persist safely.
 
 ## Validation
 

--- a/src/bluetooth_2_usb/ops/cli.py
+++ b/src/bluetooth_2_usb/ops/cli.py
@@ -11,7 +11,13 @@ from .deployment import install, uninstall, update
 from .diagnostics import SmokeTest, debug_report
 from .hid_udev_rule import install_hid_udev_rule
 from .paths import PATHS
-from .readonly import disable_readonly, enable_readonly, print_readonly_status, setup_persistent_bluetooth_state
+from .readonly import (
+    disable_readonly,
+    enable_readonly,
+    migrate_readonly_bluetooth_state,
+    print_readonly_status,
+    setup_persistent_bluetooth_state,
+)
 
 OPERATIONAL_COMMANDS = frozenset({"install", "update", "uninstall", "smoketest", "debug", "readonly", "udev"})
 
@@ -51,6 +57,7 @@ def _main(argv: list[str], *, prog: str) -> int:
     _command_parser(readonly_subparsers, "status", "Show read-only status.")
     _command_parser(readonly_subparsers, "enable", "Enable read-only mode.")
     _command_parser(readonly_subparsers, "disable", "Disable OverlayFS.")
+    _command_parser(readonly_subparsers, "migrate", "Move Bluetooth state back to rootfs.")
 
     udev_parser = _command_parser(subparsers, "udev", "Manage host-side hidapi udev rules.")
     udev_subparsers = udev_parser.add_subparsers(dest="udev_command", required=True)
@@ -83,6 +90,7 @@ def _main(argv: list[str], *, prog: str) -> int:
         ("readonly", "setup"),
         ("readonly", "enable"),
         ("readonly", "disable"),
+        ("readonly", "migrate"),
     }:
         prepare_log(log_name)
 
@@ -111,6 +119,8 @@ def _main(argv: list[str], *, prog: str) -> int:
         enable_readonly()
     elif command_path == ("readonly", "disable"):
         disable_readonly()
+    elif command_path == ("readonly", "migrate"):
+        migrate_readonly_bluetooth_state()
     elif command_path == ("udev", "install"):
         ensure_root()
         install_hid_udev_rule(repo_root)

--- a/src/bluetooth_2_usb/ops/diagnostics/smoketest.py
+++ b/src/bluetooth_2_usb/ops/diagnostics/smoketest.py
@@ -107,12 +107,12 @@ class SmokeTest:
             missing_venv = f"Virtualenv interpreter is missing: {PATHS.venv_python}"
             validate_log = (127, missing_venv)
             service_settings_log = (127, missing_venv)
+        self._heading("Bluetooth")
         self._command_ok(
             ["systemctl", "is-active", "bluetooth.service"],
             "bluetooth.service is active",
             "bluetooth.service is not active",
         )
-        self._heading("Bluetooth")
         bt_show = self._capture(["bluetoothctl", "show"])
         self.record_bool(
             bt_show[0] == 0 and bluetooth_controller_powered_from_text(bt_show[1]),
@@ -134,6 +134,10 @@ class SmokeTest:
                 )
         else:
             self.soft_warn("No bluetooth rfkill entries found")
+        paired_count = self._paired_count()
+        self._path_exists(
+            Path("/var/lib/bluetooth"), "Bluetooth state directory exists", "Bluetooth state directory is missing"
+        )
         self._heading("Devices")
         inventory = (
             self._capture([PATHS.venv_python, "-m", "bluetooth_2_usb", "--list_devices", "--output", "json"])
@@ -141,14 +145,11 @@ class SmokeTest:
             else (127, missing_venv)
         )
         relayable_count = self._relayable_count(inventory)
-        paired_count = self._paired_count()
-        self._path_exists(
-            Path("/var/lib/bluetooth"), "Bluetooth state directory exists", "Bluetooth state directory is missing"
-        )
         self._heading("Read-Only Mode")
+        self._check_readonly_mode(readonly, overlay, root_overlay_active, post_reboot)
         self._check_overlay_runtime(overlay, root_overlay_active, post_reboot)
         self._check_initramfs(overlay, root_overlay_active, readonly, expected_initramfs_path)
-        self._check_readonly(readonly, overlay, root_overlay_active, bluetooth_persistent, post_reboot)
+        self._check_bluetooth_persistent(readonly, overlay, bluetooth_persistent)
 
         self.summary_groups = [
             (
@@ -275,19 +276,7 @@ class SmokeTest:
         else:
             self.soft_warn(f"Boot initramfs is not present yet ({path})")
 
-    def _check_readonly(
-        self, readonly: str, overlay: str, root_overlay_active: str, bluetooth_persistent: bool, post_reboot: bool
-    ) -> None:
-        if bluetooth_persistent:
-            ok(
-                "Bluetooth persistent mount is mounted"
-                if readonly == "persistent"
-                else "Bluetooth persistent mount is active"
-            )
-        elif overlay == "enabled" or readonly == "persistent":
-            self.warn_fail("Bluetooth persistent mount is not mounted")
-        else:
-            ok("Bluetooth persistent mount is not configured")
+    def _check_readonly_mode(self, readonly: str, overlay: str, root_overlay_active: str, post_reboot: bool) -> None:
         if readonly == "persistent":
             ok("Read-only mode is enabled")
         elif readonly == "unknown":
@@ -306,6 +295,20 @@ class SmokeTest:
             )
         else:
             self.warn_fail("Read-only mode is not enabled")
+
+    def _check_bluetooth_persistent(self, readonly: str, overlay: str, bluetooth_persistent: bool) -> None:
+        if bluetooth_persistent:
+            if readonly == "persistent":
+                ok("Bluetooth persistent mount is mounted")
+            else:
+                self.soft_warn(
+                    "Bluetooth persistent mount is active while read-only mode is disabled; "
+                    + "run bluetooth_2_usb readonly migrate to move state back to rootfs"
+                )
+        elif overlay == "enabled" or readonly == "persistent":
+            self.warn_fail("Bluetooth persistent mount is not mounted")
+        else:
+            ok("Bluetooth persistent mount is not configured")
 
     def _relayable_count(self, inventory: tuple[int, str]) -> int:
         if inventory[0] != 0:

--- a/src/bluetooth_2_usb/ops/readonly/__init__.py
+++ b/src/bluetooth_2_usb/ops/readonly/__init__.py
@@ -27,7 +27,12 @@ from .units import (
     write_bluetooth_bind_mount_unit,
     write_persist_mount_unit,
 )
-from .workflows import disable_readonly, enable_readonly, setup_persistent_bluetooth_state
+from .workflows import (
+    disable_readonly,
+    enable_readonly,
+    migrate_readonly_bluetooth_state,
+    setup_persistent_bluetooth_state,
+)
 
 __all__ = [
     "READONLY_PACKAGES",
@@ -41,6 +46,7 @@ __all__ = [
     "install_bluetooth_persist_dropin",
     "load_readonly_config",
     "machine_id_valid",
+    "migrate_readonly_bluetooth_state",
     "overlay_configured_status",
     "overlay_status",
     "package_status",

--- a/src/bluetooth_2_usb/ops/readonly/workflows.py
+++ b/src/bluetooth_2_usb/ops/readonly/workflows.py
@@ -10,6 +10,7 @@ from ..boot_config import (
     configured_initramfs_file,
     configured_kernel_image,
     current_kernel_release,
+    current_root_filesystem_type,
     ensure_bootable_initramfs_for_current_kernel,
     expected_boot_initramfs_file,
     versioned_initrd_candidates,
@@ -30,6 +31,9 @@ from .status import (
 from .units import (
     install_bluetooth_persist_dropin,
     persist_spec_from_device,
+    remove_bluetooth_bind_mount_unit,
+    remove_bluetooth_persist_dropin,
+    remove_persist_mount_unit,
     write_bluetooth_bind_mount_unit,
     write_persist_mount_unit,
 )
@@ -230,4 +234,87 @@ def disable_readonly() -> None:
     config.mode = "disabled"
     write_readonly_config(config)
     ok("OverlayFS has been disabled")
-    warn("Persistent Bluetooth state mount configuration was kept. Reboot to return to a writable root filesystem.")
+    try:
+        live_root = current_root_filesystem_type()
+    except Exception:
+        live_root = "unknown"
+    if live_root == "overlay":
+        warn("The live root filesystem is still overlay-backed until reboot.")
+    if bluetooth_state_persistent(config):
+        warn(
+            "Persistent Bluetooth state is still mounted. Run `sudo bluetooth_2_usb readonly migrate` "
+            + "to move Bluetooth state back to rootfs and unmount persistent storage."
+        )
+
+
+def migrate_readonly_bluetooth_state() -> None:
+    require_commands(["findmnt", "mkdir", "mountpoint", "systemctl", "systemd-escape", "umount"])
+    config = load_readonly_config()
+    if current_root_filesystem_type() == "overlay":
+        fail(
+            "Root filesystem is still overlay-backed. Run `sudo bluetooth_2_usb readonly disable`, reboot, "
+            + "then run `sudo bluetooth_2_usb readonly migrate`."
+        )
+    config.mode = "disabled"
+    if not bluetooth_state_persistent(config):
+        write_readonly_config(config)
+        ok("Bluetooth persistent mount is not active; no migration needed.")
+        return
+
+    bluetooth_was_active = _systemctl_active("bluetooth.service")
+    b2u_was_active = stop_b2u_if_installed("before migrating Bluetooth state back to rootfs")
+    try:
+        run(["systemctl", "stop", "bluetooth.service"])
+        run(["systemctl", "disable", "--now", "var-lib-bluetooth.mount"], check=False)
+        if run(["findmnt", "-rn", "/var/lib/bluetooth"], check=False, capture=True).returncode == 0:
+            run(["umount", "/var/lib/bluetooth"])
+        _copy_persistent_bluetooth_state_to_rootfs(config.persist_bluetooth_dir, Path("/var/lib/bluetooth"))
+
+        persist_unit = output(["systemd-escape", "--path", "--suffix=mount", config.persist_mount])
+        run(["systemctl", "disable", "--now", persist_unit], check=False)
+        if run(["findmnt", "-rn", config.persist_mount], check=False, capture=True).returncode == 0:
+            run(["umount", config.persist_mount])
+        remove_bluetooth_persist_dropin()
+        remove_bluetooth_bind_mount_unit()
+        remove_persist_mount_unit(config.persist_mount)
+        run(["systemctl", "daemon-reload"])
+        write_readonly_config(config)
+    finally:
+        if bluetooth_was_active:
+            run(["systemctl", "start", "bluetooth.service"], check=False)
+        restart_b2u_if_installed(b2u_was_active, "after migrating Bluetooth state back to rootfs")
+    ok("Bluetooth state has been migrated back to rootfs and persistent storage has been unmounted.")
+
+
+def _copy_persistent_bluetooth_state_to_rootfs(source: Path, destination: Path) -> None:
+    if not source.is_dir():
+        fail(f"Persistent Bluetooth state directory is missing: {source}")
+    ignored = {".b2u-seed.lock", ".b2u-seeded", ".b2u-persistent-state"}
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temp_dir = destination.with_name(f"{destination.name}.tmp-{uuid.uuid4().hex}")
+    backup_dir = destination.with_name(f"{destination.name}.backup-{uuid.uuid4().hex}")
+    try:
+        temp_dir.mkdir()
+        for child in source.iterdir():
+            if child.name in ignored:
+                continue
+            target = temp_dir / child.name
+            if child.is_dir():
+                shutil.copytree(child, target, symlinks=True, dirs_exist_ok=True)
+            else:
+                shutil.copy2(child, target)
+        had_destination = destination.exists()
+        if had_destination:
+            destination.rename(backup_dir)
+        try:
+            temp_dir.rename(destination)
+        except Exception:
+            if destination.exists():
+                shutil.rmtree(destination)
+            if had_destination:
+                backup_dir.rename(destination)
+            raise
+        else:
+            shutil.rmtree(backup_dir, ignore_errors=True)
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)

--- a/tests/test_bluetooth_ops.py
+++ b/tests/test_bluetooth_ops.py
@@ -15,6 +15,7 @@ from bluetooth_2_usb.ops.readonly import (
     disable_readonly,
     enable_readonly,
     load_readonly_config,
+    migrate_readonly_bluetooth_state,
     overlay_configured_status,
     overlay_status,
     package_status,
@@ -545,7 +546,7 @@ class ReadonlyConfigTest(unittest.TestCase):
         )
         self.assertIn("disable OverlayFS", stdout.getvalue())
 
-    def test_disable_readonly_disables_overlayfs_and_keeps_persistent_mount_config(self) -> None:
+    def test_disable_readonly_disables_overlayfs_and_warns_when_persistent_mount_remains(self) -> None:
         config = ReadonlyConfig(
             mode="persistent",
             persist_mount=Path("/mnt/persist"),
@@ -570,6 +571,8 @@ class ReadonlyConfigTest(unittest.TestCase):
             stack.enter_context(patch(f"{READONLY_WORKFLOWS}.load_readonly_config", return_value=config))
             stack.enter_context(patch(f"{READONLY_WORKFLOWS}.run", side_effect=fake_run))
             stack.enter_context(patch(f"{READONLY_WORKFLOWS}.write_readonly_config", side_effect=written.append))
+            stack.enter_context(patch(f"{READONLY_WORKFLOWS}.current_root_filesystem_type", return_value="ext4"))
+            stack.enter_context(patch(f"{READONLY_WORKFLOWS}.bluetooth_state_persistent", return_value=True))
 
             with redirect_stdout(StringIO()) as stdout:
                 disable_readonly()
@@ -578,4 +581,126 @@ class ReadonlyConfigTest(unittest.TestCase):
         self.assertEqual(config.mode, "disabled")
         self.assertEqual(written, [config])
         self.assertEqual(config.persist_spec, "/dev/disk/by-uuid/abc")
-        self.assertIn("Persistent Bluetooth state mount configuration was kept.", stdout.getvalue())
+        self.assertIn("readonly migrate", stdout.getvalue())
+
+    def test_migrate_readonly_bluetooth_state_moves_state_back_to_rootfs_and_unmounts_storage(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            persistent_bt = root / "persist" / "bluetooth"
+            persistent_bt.mkdir(parents=True)
+            (persistent_bt / "AA:BB:CC:DD:EE:FF").mkdir()
+            (persistent_bt / "AA:BB:CC:DD:EE:FF" / "info").write_text("paired\n", encoding="utf-8")
+            (persistent_bt / ".b2u-persistent-state").write_text("", encoding="utf-8")
+            root_bt = root / "var/lib/bluetooth"
+            root_bt.mkdir(parents=True)
+            (root_bt / "stale").write_text("old\n", encoding="utf-8")
+            config = ReadonlyConfig(
+                mode="persistent",
+                persist_mount=root / "persist",
+                persist_bluetooth_dir=persistent_bt,
+                persist_spec="/dev/disk/by-uuid/abc",
+                persist_device="/dev/sda1",
+            )
+            commands = []
+            written = []
+
+            def fake_run(command, *, check=True, capture=False):
+                commands.append(command)
+
+                class Completed:
+                    returncode = 0
+                    stdout = ""
+
+                if command[:2] == ["findmnt", "-rn"]:
+                    Completed.returncode = 0
+                return Completed()
+
+            def local_path(value: str) -> Path:
+                if value == "/var/lib/bluetooth":
+                    return root_bt
+                return Path(value)
+
+            with ExitStack() as stack:
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.require_commands"))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.load_readonly_config", return_value=config))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.current_root_filesystem_type", return_value="ext4"))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.bluetooth_state_persistent", return_value=True))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}._systemctl_active", return_value=True))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.stop_b2u_if_installed", return_value=True))
+                restart_b2u = stack.enter_context(patch(f"{READONLY_WORKFLOWS}.restart_b2u_if_installed"))
+                remove_dropin = stack.enter_context(patch(f"{READONLY_WORKFLOWS}.remove_bluetooth_persist_dropin"))
+                remove_bind = stack.enter_context(patch(f"{READONLY_WORKFLOWS}.remove_bluetooth_bind_mount_unit"))
+                remove_persist = stack.enter_context(patch(f"{READONLY_WORKFLOWS}.remove_persist_mount_unit"))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.output", return_value="mnt-persist.mount"))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.run", side_effect=fake_run))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.Path", side_effect=local_path))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.write_readonly_config", side_effect=written.append))
+
+                with redirect_stdout(StringIO()) as stdout:
+                    migrate_readonly_bluetooth_state()
+
+            self.assertFalse((root_bt / "stale").exists())
+            self.assertEqual((root_bt / "AA:BB:CC:DD:EE:FF" / "info").read_text(encoding="utf-8"), "paired\n")
+            self.assertFalse((root_bt / ".b2u-persistent-state").exists())
+            self.assertIn(["systemctl", "stop", "bluetooth.service"], commands)
+            self.assertIn(["systemctl", "disable", "--now", "var-lib-bluetooth.mount"], commands)
+            self.assertIn(["umount", "/var/lib/bluetooth"], commands)
+            self.assertIn(["systemctl", "disable", "--now", "mnt-persist.mount"], commands)
+            self.assertIn(["umount", config.persist_mount], commands)
+            self.assertIn(["systemctl", "daemon-reload"], commands)
+            self.assertIn(["systemctl", "start", "bluetooth.service"], commands)
+            remove_dropin.assert_called_once_with()
+            remove_bind.assert_called_once_with()
+            remove_persist.assert_called_once_with(config.persist_mount)
+            restart_b2u.assert_called_once_with(True, "after migrating Bluetooth state back to rootfs")
+            self.assertEqual(written, [config])
+            self.assertEqual(config.mode, "disabled")
+            self.assertIn("migrated back to rootfs", stdout.getvalue())
+
+    def test_migrate_readonly_bluetooth_state_refuses_overlay_root(self) -> None:
+        config = ReadonlyConfig(
+            mode="persistent",
+            persist_mount=Path("/mnt/persist"),
+            persist_bluetooth_dir=Path("/mnt/persist/bluetooth"),
+            persist_spec="/dev/disk/by-uuid/abc",
+            persist_device="/dev/sda1",
+        )
+
+        with ExitStack() as stack:
+            stack.enter_context(patch(f"{READONLY_WORKFLOWS}.require_commands"))
+            stack.enter_context(patch(f"{READONLY_WORKFLOWS}.load_readonly_config", return_value=config))
+            stack.enter_context(patch(f"{READONLY_WORKFLOWS}.current_root_filesystem_type", return_value="overlay"))
+            run_command = stack.enter_context(patch(f"{READONLY_WORKFLOWS}.run"))
+            write_config = stack.enter_context(patch(f"{READONLY_WORKFLOWS}.write_readonly_config"))
+
+            with self.assertRaises(OpsError):
+                migrate_readonly_bluetooth_state()
+
+        run_command.assert_not_called()
+        write_config.assert_not_called()
+
+    def test_migrate_readonly_bluetooth_state_noops_when_persistent_mount_is_inactive(self) -> None:
+        config = ReadonlyConfig(
+            mode="persistent",
+            persist_mount=Path("/mnt/persist"),
+            persist_bluetooth_dir=Path("/mnt/persist/bluetooth"),
+            persist_spec="/dev/disk/by-uuid/abc",
+            persist_device="/dev/sda1",
+        )
+        written = []
+
+        with ExitStack() as stack:
+            stack.enter_context(patch(f"{READONLY_WORKFLOWS}.require_commands"))
+            stack.enter_context(patch(f"{READONLY_WORKFLOWS}.load_readonly_config", return_value=config))
+            stack.enter_context(patch(f"{READONLY_WORKFLOWS}.current_root_filesystem_type", return_value="ext4"))
+            stack.enter_context(patch(f"{READONLY_WORKFLOWS}.bluetooth_state_persistent", return_value=False))
+            run_command = stack.enter_context(patch(f"{READONLY_WORKFLOWS}.run"))
+            stack.enter_context(patch(f"{READONLY_WORKFLOWS}.write_readonly_config", side_effect=written.append))
+
+            with redirect_stdout(StringIO()) as stdout:
+                migrate_readonly_bluetooth_state()
+
+        run_command.assert_not_called()
+        self.assertEqual(written, [config])
+        self.assertEqual(config.mode, "disabled")
+        self.assertIn("no migration needed", stdout.getvalue())

--- a/tests/test_ops_cli.py
+++ b/tests/test_ops_cli.py
@@ -41,6 +41,7 @@ class OpsCliTest(unittest.TestCase):
             (["readonly", "status"], "print_readonly_status"),
             (["readonly", "enable"], "enable_readonly"),
             (["readonly", "disable"], "disable_readonly"),
+            (["readonly", "migrate"], "migrate_readonly_bluetooth_state"),
             (["udev", "install"], "install_hid_udev_rule"),
         )
 

--- a/tests/test_ops_diagnostics.py
+++ b/tests/test_ops_diagnostics.py
@@ -91,7 +91,8 @@ class OpsDiagnosticsTest(unittest.TestCase):
                 "_command_ok",
                 "_check_overlay_runtime",
                 "_check_initramfs",
-                "_check_readonly",
+                "_check_readonly_mode",
+                "_check_bluetooth_persistent",
             ):
                 stack.enter_context(patch.object(smoke, method))
             stack.enter_context(patch.object(smoke, "_capture", return_value=(0, "[]")))
@@ -193,6 +194,83 @@ class OpsDiagnosticsTest(unittest.TestCase):
         self.assertEqual(rfkill_results[0].detail, "rfkill0 type=bluetooth soft=0 hard=0 state=1")
         self.assertEqual(stdout.getvalue().count("[+] Bluetooth rfkill state is not blocked"), 1)
 
+    def test_smoketest_groups_bluetooth_service_and_state_checks_under_bluetooth(self) -> None:
+        smoke = SmokeTest(verbose=False, allow_non_pi=True)
+        current_heading = ""
+        command_headings: list[tuple[str, list[str]]] = []
+        path_headings: list[tuple[str, Path]] = []
+
+        def record_heading(title: str) -> None:
+            nonlocal current_heading
+            current_heading = title
+
+        def record_command(command, _success, _failure):
+            command_headings.append((current_heading, command))
+
+        def record_path(path, _success, _failure):
+            path_headings.append((current_heading, path))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with ExitStack() as stack:
+                stack.enter_context(patch(f"{DIAGNOSTICS_SMOKETEST}.readonly_mode", return_value="disabled"))
+                stack.enter_context(patch(f"{DIAGNOSTICS_SMOKETEST}.overlay_status", return_value="disabled"))
+                stack.enter_context(
+                    patch(f"{DIAGNOSTICS_SMOKETEST}._first_modules_load", return_value="modules-load=dwc2")
+                )
+                stack.enter_context(patch(f"{DIAGNOSTICS_SMOKETEST}.boot_config.dwc2_mode", return_value="module"))
+                stack.enter_context(
+                    patch(f"{DIAGNOSTICS_SMOKETEST}.boot_config.required_boot_modules_csv", return_value="dwc2")
+                )
+                stack.enter_context(
+                    patch(
+                        f"{DIAGNOSTICS_SMOKETEST}.boot_config.boot_config_path",
+                        return_value=Path(tmpdir) / "config.txt",
+                    )
+                )
+                stack.enter_context(
+                    patch(
+                        f"{DIAGNOSTICS_SMOKETEST}.boot_config.boot_cmdline_path",
+                        return_value=Path(tmpdir) / "cmdline.txt",
+                    )
+                )
+                stack.enter_context(
+                    patch(f"{DIAGNOSTICS_SMOKETEST}.boot_config.expected_dwc2_overlay_line", return_value="")
+                )
+                stack.enter_context(
+                    patch(f"{DIAGNOSTICS_SMOKETEST}.boot_config.current_root_filesystem_type", return_value="ext4")
+                )
+                stack.enter_context(
+                    patch(f"{DIAGNOSTICS_SMOKETEST}.boot_config.configured_kernel_image", return_value="kernel8.img")
+                )
+                stack.enter_context(
+                    patch(f"{DIAGNOSTICS_SMOKETEST}.boot_config.configured_initramfs_file", return_value="")
+                )
+                stack.enter_context(
+                    patch(f"{DIAGNOSTICS_SMOKETEST}.boot_config.expected_boot_initramfs_file", return_value="")
+                )
+                stack.enter_context(patch(f"{DIAGNOSTICS_SMOKETEST}.bluetooth_state_persistent", return_value=False))
+                stack.enter_context(
+                    patch(f"{DIAGNOSTICS_SMOKETEST}._udc_states", return_value={"dummy.udc": "configured"})
+                )
+                stack.enter_context(patch(f"{DIAGNOSTICS_SMOKETEST}.bluetooth_rfkill_entries", return_value=[]))
+                stack.enter_context(patch.object(smoke, "_heading", side_effect=record_heading))
+                stack.enter_context(patch.object(smoke, "_check_boot_overlay"))
+                stack.enter_context(patch.object(smoke, "_check_modules"))
+                stack.enter_context(patch.object(smoke, "_path_exists", side_effect=record_path))
+                stack.enter_context(patch.object(smoke, "_command_ok", side_effect=record_command))
+                stack.enter_context(patch.object(smoke, "_capture", return_value=(0, "[]")))
+                stack.enter_context(patch.object(smoke, "_relayable_count", return_value=0))
+                stack.enter_context(patch.object(smoke, "_paired_count", return_value=0))
+                stack.enter_context(patch.object(smoke, "_check_overlay_runtime"))
+                stack.enter_context(patch.object(smoke, "_check_initramfs"))
+                stack.enter_context(patch.object(smoke, "_check_readonly_mode"))
+                stack.enter_context(patch.object(smoke, "_check_bluetooth_persistent"))
+
+                smoke.run()
+
+        self.assertIn(("Bluetooth", ["systemctl", "is-active", "bluetooth.service"]), command_headings)
+        self.assertIn(("Bluetooth", Path("/var/lib/bluetooth")), path_headings)
+
     def test_smoketest_verbose_summary_groups_related_items_in_logical_order(self) -> None:
         smoke = SmokeTest(verbose=True, allow_non_pi=True)
 
@@ -214,6 +292,34 @@ class OpsDiagnosticsTest(unittest.TestCase):
             readonly_group.index("Root overlay active:"), readonly_group.index("Bluetooth persistent mount:")
         )
         self.assertEqual(smoke.result_dict()["summary"]["Bluetooth persistent mount"], "not mounted")
+
+    def test_readonly_mode_probe_is_recorded_before_persistent_mount_probe(self) -> None:
+        smoke = SmokeTest(verbose=False, allow_non_pi=True)
+        with redirect_stdout(StringIO()) as stdout:
+            smoke._check_readonly_mode("persistent", "enabled", "yes", post_reboot=True)
+            smoke._check_bluetooth_persistent("persistent", "enabled", bluetooth_persistent=True)
+
+        self.assertLess(
+            stdout.getvalue().index("Read-only mode is enabled"),
+            stdout.getvalue().index("Bluetooth persistent mount is mounted"),
+        )
+
+    def test_disabled_mode_with_persistent_mount_is_soft_warning(self) -> None:
+        smoke = SmokeTest(verbose=False, allow_non_pi=True)
+        with redirect_stdout(StringIO()):
+            smoke._check_bluetooth_persistent("disabled", "disabled", bluetooth_persistent=True)
+
+        self.assertEqual(smoke.exit_code, 0)
+        self.assertEqual(smoke.soft_warnings, 1)
+        self.assertIn("readonly migrate", smoke.results[0].message)
+
+    def test_enabled_mode_without_persistent_mount_fails(self) -> None:
+        smoke = SmokeTest(verbose=False, allow_non_pi=True)
+        with redirect_stdout(StringIO()):
+            smoke._check_bluetooth_persistent("persistent", "enabled", bluetooth_persistent=False)
+
+        self.assertEqual(smoke.exit_code, 1)
+        self.assertEqual(smoke.results[0].message, "Bluetooth persistent mount is not mounted")
 
     def test_debug_report_keeps_writing_when_initial_systemctl_probe_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- move Bluetooth-specific smoketest checks under the Bluetooth heading
- show the read-only mode probe first in the Read-Only Mode section
- split rollback into `readonly disable` and explicit `readonly migrate`
- keep disabled mode with persistent Bluetooth storage mounted as a smoketest warning
- document the updated disable/migrate flow

## Validation

- `venv/bin/python -m unittest tests.test_ops_diagnostics tests.test_bluetooth_ops tests.test_ops_cli -v`
- `venv/bin/black --check src tests`
- `venv/bin/ruff check src tests`
- `venv/bin/python -m compileall src tests`
- `venv/bin/python -m unittest discover -s tests -v`
- `rg -n "persistent read-only|Persistent read-only|persistent Read-only|Persistent Read-only" README.md TROUBLESHOOTING.md docs src tests`
- `rg -n -i "writable" README.md TROUBLESHOOTING.md docs src tests AGENTS.md CONTRIBUTING.md`

No live Pi read-only deployment was run for this branch yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `readonly migrate` command to copy Bluetooth pairing state back to the root filesystem and unmount persistent Bluetooth storage after disabling read-only mode.

* **Documentation**
  * Updated operational guides and troubleshooting with new migration command and post-disable procedures.
  * Added clarification that read-only mode disabling requires a migration step to complete relocation of Bluetooth state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->