### PR TITLE
perf: reuse managed venv during install

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,13 +182,16 @@ console command.
 ### `install`
 
 Apply the current checkout in `/opt/bluetooth_2_usb` to the managed install.
-Use this after cloning into the supported install path.
+Use this after cloning into the supported install path. The managed virtual
+environment is reused when it is valid; pass `--recreate-venv` to delete and
+recreate it before installing.
 
 ### `update`
 
 Fast-forward the managed checkout and reapply `install`. This is the normal
-update path for an installed system, and it rebuilds the managed environment
-even when the checkout is already current.
+update path for an installed system. The managed virtual environment is reused
+when it is valid; pass `--recreate-venv` after dependency removals, suspected
+venv corruption, or clean-install release validation.
 
 ### `uninstall`
 

--- a/docs/cli-service-test.md
+++ b/docs/cli-service-test.md
@@ -109,6 +109,9 @@ until new_boot_id="$(ssh -o ConnectTimeout=5 <pi-host> 'cat /proc/sys/kernel/ran
 done
 ```
 
+The installer reuses a valid managed virtual environment. Use
+`install --recreate-venv` when validating a clean environment rebuild.
+
 After reboot:
 
 ```bash
@@ -131,7 +134,10 @@ ssh <pi-host> 'sudo -n bluetooth_2_usb update'
 ```
 
 If no new commit is available on the checked-out branch, this should exit `0`
-after reapplying the managed install and restarting the service.
+after reapplying the managed install and restarting the service. The update
+path reuses a valid managed virtual environment; use
+`sudo -n bluetooth_2_usb update --recreate-venv` after dependency removals,
+suspected venv corruption, or clean-install release validation.
 
 Reboot and repeat the post-boot smoketest checks if the updated change touched boot
 configuration or other reboot-sensitive behavior.

--- a/docs/release-versioning-policy.md
+++ b/docs/release-versioning-policy.md
@@ -72,10 +72,12 @@ This avoids hard-coded version strings in runtime code and keeps these outputs a
 - installed service/runtime logs
 
 The managed `/opt/bluetooth_2_usb` clone-based install works with that
-versioning model. The installer rebuilds the venv from the checked-out Git
-tree in `/opt/bluetooth_2_usb`, so an install from the exact tagged commit will
-show that exact release version. A separate release artifact install is not required for
-the runtime to report `1.0.0`.
+versioning model. The installer updates the managed venv from the checked-out
+Git tree in `/opt/bluetooth_2_usb`, so an install from the exact tagged commit
+will show that exact release version. Use `install --recreate-venv` or
+`update --recreate-venv` when release validation requires a clean environment
+rebuild. A separate release artifact install is not required for the runtime to
+report `1.0.0`.
 
 In practice:
 

--- a/src/bluetooth_2_usb/ops/cli.py
+++ b/src/bluetooth_2_usb/ops/cli.py
@@ -40,8 +40,18 @@ def _main(argv: list[str], *, prog: str) -> int:
     parser = argparse.ArgumentParser(prog=prog)
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    _command_parser(subparsers, "install", "Apply the managed system install.")
-    _command_parser(subparsers, "update", "Fast-forward and reapply the managed install.")
+    install_parser = _command_parser(subparsers, "install", "Apply the managed system install.")
+    install_parser.add_argument(
+        "--recreate-venv",
+        action="store_true",
+        help="Delete and recreate the managed virtual environment instead of reusing a valid one.",
+    )
+    update_parser = _command_parser(subparsers, "update", "Fast-forward and reapply the managed install.")
+    update_parser.add_argument(
+        "--recreate-venv",
+        action="store_true",
+        help="Delete and recreate the managed virtual environment instead of reusing a valid one.",
+    )
     _command_parser(subparsers, "uninstall", "Remove the managed system integration.")
     smoketest_parser = _command_parser(subparsers, "smoketest", "Run deployment health checks.")
     smoketest_parser.add_argument("--verbose", action="store_true")
@@ -92,9 +102,9 @@ def _main(argv: list[str], *, prog: str) -> int:
         prepare_log(log_name)
 
     if command_path == ("install",):
-        install(repo_root)
+        install(repo_root, recreate_venv=namespace.recreate_venv)
     elif command_path == ("update",):
-        update(repo_root)
+        update(repo_root, recreate_venv=namespace.recreate_venv)
     elif command_path == ("uninstall",):
         uninstall()
     elif command_path == ("smoketest",):

--- a/src/bluetooth_2_usb/ops/deployment.py
+++ b/src/bluetooth_2_usb/ops/deployment.py
@@ -60,9 +60,13 @@ def recreate_venv(venv_dir: Path) -> None:
     run(["python3", "-m", "venv", venv_dir])
 
 
-def rebuild_venv(venv_dir: Path, package_dir: Path) -> None:
-    shutil.rmtree(venv_dir, ignore_errors=True)
-    recreate_venv(venv_dir)
+def venv_usable(venv_dir: Path) -> bool:
+    return (venv_dir / "bin/python").is_file() and (venv_dir / "bin/pip").is_file()
+
+
+def rebuild_venv(venv_dir: Path, package_dir: Path, *, recreate: bool = False) -> None:
+    if recreate or not venv_usable(venv_dir):
+        recreate_venv(venv_dir)
     run([venv_dir / "bin/pip", "install", "--upgrade", "pip", "setuptools", "wheel"])
     run([venv_dir / "bin/pip", "install", "--upgrade", package_dir])
     run([venv_dir / "bin/python", "-m", "bluetooth_2_usb", "--version"], capture=True)
@@ -81,7 +85,7 @@ def service_installed() -> bool | None:
     return any(line.split(None, 1)[0] == PATHS.service_unit for line in completed.stdout.splitlines() if line.split())
 
 
-def install(repo_root: Path) -> None:
+def install(repo_root: Path, *, recreate_venv: bool = False) -> None:
     require_commands(["apt-get", "awk", "grep", "git", "install", "python3", "sed", "systemctl"])
     if repo_root != PATHS.install_dir:
         fail(f"Clone this repository to {PATHS.install_dir} and rerun install from there.")
@@ -123,8 +127,14 @@ def install(repo_root: Path) -> None:
         info(f"Stopping {PATHS.service_unit} before rebuilding the managed installation")
         run(["systemctl", "stop", PATHS.service_unit])
 
-    info(f"Rebuilding virtual environment at {PATHS.install_dir / 'venv'}")
-    rebuild_venv(PATHS.install_dir / "venv", PATHS.install_dir)
+    venv_dir = PATHS.install_dir / "venv"
+    if recreate_venv:
+        info(f"Recreating virtual environment at {venv_dir}")
+    elif venv_usable(venv_dir):
+        info(f"Updating virtual environment at {venv_dir}")
+    else:
+        info(f"Creating virtual environment at {venv_dir}")
+    rebuild_venv(venv_dir, PATHS.install_dir, recreate=recreate_venv)
     ok(f"Virtual environment updated at {PATHS.install_dir / 'venv'}")
 
     install_service_unit(repo_root)
@@ -152,7 +162,7 @@ def install(repo_root: Path) -> None:
     info("   Then run: sudo bluetooth_2_usb readonly enable")
 
 
-def update(repo_root: Path) -> None:
+def update(repo_root: Path, *, recreate_venv: bool = False) -> None:
     require_commands(["git"])
     if repo_root != PATHS.install_dir:
         fail(f"Clone this repository to {PATHS.install_dir} and rerun update from there.")
@@ -167,7 +177,7 @@ def update(repo_root: Path) -> None:
     info(f"Pulling latest {branch}")
     run(["git", "-C", PATHS.install_dir, "pull", "--ff-only", "origin", branch])
     info("Reapplying managed install")
-    install(repo_root)
+    install(repo_root, recreate_venv=recreate_venv)
 
 
 def uninstall() -> None:

--- a/tests/test_ops_cli.py
+++ b/tests/test_ops_cli.py
@@ -36,6 +36,46 @@ class OpsCliTest(unittest.TestCase):
 
         setup.assert_called_once_with("/dev/sda1")
 
+    def test_install_reuses_managed_venv_by_default(self) -> None:
+        with (
+            patch("bluetooth_2_usb.ops.cli.ensure_root"),
+            patch("bluetooth_2_usb.ops.cli.prepare_log"),
+            patch("bluetooth_2_usb.ops.cli.install") as install,
+        ):
+            self.assertEqual(cli.main(["install"]), 0)
+
+        install.assert_called_once_with(ManagedPaths().install_dir, recreate_venv=False)
+
+    def test_install_recreate_venv_flag_dispatches_to_install(self) -> None:
+        with (
+            patch("bluetooth_2_usb.ops.cli.ensure_root"),
+            patch("bluetooth_2_usb.ops.cli.prepare_log"),
+            patch("bluetooth_2_usb.ops.cli.install") as install,
+        ):
+            self.assertEqual(cli.main(["install", "--recreate-venv"]), 0)
+
+        install.assert_called_once_with(ManagedPaths().install_dir, recreate_venv=True)
+
+    def test_update_reuses_managed_venv_by_default(self) -> None:
+        with (
+            patch("bluetooth_2_usb.ops.cli.ensure_root"),
+            patch("bluetooth_2_usb.ops.cli.prepare_log"),
+            patch("bluetooth_2_usb.ops.cli.update") as update,
+        ):
+            self.assertEqual(cli.main(["update"]), 0)
+
+        update.assert_called_once_with(ManagedPaths().install_dir, recreate_venv=False)
+
+    def test_update_recreate_venv_flag_dispatches_to_update(self) -> None:
+        with (
+            patch("bluetooth_2_usb.ops.cli.ensure_root"),
+            patch("bluetooth_2_usb.ops.cli.prepare_log"),
+            patch("bluetooth_2_usb.ops.cli.update") as update,
+        ):
+            self.assertEqual(cli.main(["update", "--recreate-venv"]), 0)
+
+        update.assert_called_once_with(ManagedPaths().install_dir, recreate_venv=True)
+
     def test_nested_operational_commands_dispatch_to_selected_workflow(self) -> None:
         cases = (
             (["readonly", "status"], "print_readonly_status"),

--- a/tests/test_ops_deployment.py
+++ b/tests/test_ops_deployment.py
@@ -36,66 +36,128 @@ class OpsDeploymentTest(unittest.TestCase):
         )
         unlink.assert_any_call(Path("/usr/local/bin/bluetooth_2_usb"), missing_ok=True)
 
-    def test_rebuild_venv_recreates_existing_environment(self) -> None:
+    def test_rebuild_venv_reuses_existing_valid_environment(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             venv = root / "venv"
             (venv / "bin").mkdir(parents=True)
+            (venv / "bin/python").touch()
+            (venv / "bin/pip").touch()
             (venv / "marker").write_text("previous", encoding="utf-8")
 
-            def fake_recreate_venv(target: Path) -> None:
-                (target / "bin").mkdir(parents=True)
-                (target / "marker").write_text("new", encoding="utf-8")
-
             with (
-                patch("bluetooth_2_usb.ops.deployment.recreate_venv", side_effect=fake_recreate_venv),
+                patch("bluetooth_2_usb.ops.deployment.recreate_venv") as recreate,
                 patch("bluetooth_2_usb.ops.deployment.run") as run,
             ):
                 rebuild_venv(venv, root)
 
-            self.assertEqual((venv / "marker").read_text(encoding="utf-8"), "new")
+            recreate.assert_not_called()
+            self.assertEqual((venv / "marker").read_text(encoding="utf-8"), "previous")
+            self.assertEqual(
+                run.call_args_list[0], call([venv / "bin/pip", "install", "--upgrade", "pip", "setuptools", "wheel"])
+            )
+            self.assertEqual(run.call_args_list[1], call([venv / "bin/pip", "install", "--upgrade", root]))
             self.assertEqual(
                 run.call_args_list[-1], call([venv / "bin/python", "-m", "bluetooth_2_usb", "--version"], capture=True)
             )
+
+    def test_rebuild_venv_creates_missing_environment(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            venv = root / "venv"
+
+            def fake_recreate_venv(target: Path) -> None:
+                (target / "bin").mkdir(parents=True)
+                (target / "bin/python").touch()
+                (target / "bin/pip").touch()
+
+            with (
+                patch("bluetooth_2_usb.ops.deployment.recreate_venv", side_effect=fake_recreate_venv) as recreate,
+                patch("bluetooth_2_usb.ops.deployment.run"),
+            ):
+                rebuild_venv(venv, root)
+
+            recreate.assert_called_once_with(venv)
+            self.assertTrue((venv / "bin/python").is_file())
+            self.assertTrue((venv / "bin/pip").is_file())
+
+    def test_rebuild_venv_recreates_invalid_environment(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            venv = root / "venv"
+            (venv / "bin").mkdir(parents=True)
+            (venv / "bin/python").touch()
+
+            def fake_recreate_venv(target: Path) -> None:
+                (target / "bin").mkdir(parents=True, exist_ok=True)
+                (target / "bin/python").touch()
+                (target / "bin/pip").touch()
+
+            with (
+                patch("bluetooth_2_usb.ops.deployment.recreate_venv", side_effect=fake_recreate_venv) as recreate,
+                patch("bluetooth_2_usb.ops.deployment.run"),
+            ):
+                rebuild_venv(venv, root)
+
+            recreate.assert_called_once_with(venv)
+
+    def test_rebuild_venv_recreate_flag_removes_existing_environment(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            venv = root / "venv"
+            (venv / "bin").mkdir(parents=True)
+            (venv / "bin/python").touch()
+            (venv / "bin/pip").touch()
+            (venv / "marker").write_text("previous", encoding="utf-8")
+
+            def fake_recreate_venv(target: Path) -> None:
+                (target / "marker").write_text("new", encoding="utf-8")
+
+            with (
+                patch("bluetooth_2_usb.ops.deployment.recreate_venv", side_effect=fake_recreate_venv) as recreate,
+                patch("bluetooth_2_usb.ops.deployment.run"),
+            ):
+                rebuild_venv(venv, root, recreate=True)
+
+            recreate.assert_called_once_with(venv)
+            self.assertEqual((venv / "marker").read_text(encoding="utf-8"), "new")
 
     def test_rebuild_venv_fails_loudly_when_package_install_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             venv = root / "venv"
             (venv / "bin").mkdir(parents=True)
+            (venv / "bin/python").touch()
+            (venv / "bin/pip").touch()
             (venv / "marker").write_text("previous", encoding="utf-8")
-
-            def fake_recreate_venv(target: Path) -> None:
-                (target / "bin").mkdir(parents=True)
-                (target / "marker").write_text("new", encoding="utf-8")
 
             def fake_run(command, **_kwargs):
                 if command[:2] == [venv / "bin/pip", "install"] and command[-1] == root:
                     raise OpsError("package install failed")
 
             with (
-                patch("bluetooth_2_usb.ops.deployment.recreate_venv", side_effect=fake_recreate_venv),
+                patch("bluetooth_2_usb.ops.deployment.recreate_venv"),
                 patch("bluetooth_2_usb.ops.deployment.run", side_effect=fake_run),
                 self.assertRaisesRegex(OpsError, "package install failed"),
             ):
                 rebuild_venv(venv, root)
 
-            self.assertEqual((venv / "marker").read_text(encoding="utf-8"), "new")
+            self.assertEqual((venv / "marker").read_text(encoding="utf-8"), "previous")
 
     def test_rebuild_venv_fails_loudly_when_version_check_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             venv = root / "venv"
-
-            def fake_recreate_venv(target: Path) -> None:
-                (target / "bin").mkdir(parents=True)
+            (venv / "bin").mkdir(parents=True)
+            (venv / "bin/python").touch()
+            (venv / "bin/pip").touch()
 
             def fake_run(command, **_kwargs):
                 if command[:3] == [venv / "bin/python", "-m", "bluetooth_2_usb"]:
                     raise OpsError("version check failed")
 
             with (
-                patch("bluetooth_2_usb.ops.deployment.recreate_venv", side_effect=fake_recreate_venv),
+                patch("bluetooth_2_usb.ops.deployment.recreate_venv"),
                 patch("bluetooth_2_usb.ops.deployment.run", side_effect=fake_run),
                 self.assertRaisesRegex(OpsError, "version check failed"),
             ):
@@ -135,16 +197,17 @@ class OpsDeploymentTest(unittest.TestCase):
                 stack.enter_context(patch("bluetooth_2_usb.ops.deployment.clear_bluetooth_rfkill_soft_blocks"))
                 stack.enter_context(patch(f"{BOOT_CONFIG}.normalize_dwc2_overlay"))
                 stack.enter_context(patch(f"{BOOT_CONFIG}.normalize_modules_load"))
-                stack.enter_context(
+                rebuild = stack.enter_context(
                     patch("bluetooth_2_usb.ops.deployment.rebuild_venv", side_effect=OpsError("venv failed"))
                 )
                 stack.enter_context(patch("bluetooth_2_usb.ops.deployment.run", side_effect=fake_run))
 
                 with self.assertRaises(OpsError):
-                    install(root)
+                    install(root, recreate_venv=True)
 
         self.assertIn(["systemctl", "stop", paths.service_unit], commands)
         self.assertNotIn(["systemctl", "start", paths.service_unit], commands)
+        rebuild.assert_called_once_with(paths.install_dir / "venv", paths.install_dir, recreate=True)
 
     def test_install_canonicalizes_managed_env_file(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -175,7 +238,7 @@ class OpsDeploymentTest(unittest.TestCase):
                 stack.enter_context(patch("bluetooth_2_usb.ops.deployment.clear_bluetooth_rfkill_soft_blocks"))
                 stack.enter_context(patch(f"{BOOT_CONFIG}.normalize_dwc2_overlay"))
                 stack.enter_context(patch(f"{BOOT_CONFIG}.normalize_modules_load"))
-                stack.enter_context(patch("bluetooth_2_usb.ops.deployment.rebuild_venv", return_value=None))
+                rebuild = stack.enter_context(patch("bluetooth_2_usb.ops.deployment.rebuild_venv", return_value=None))
                 stack.enter_context(patch("bluetooth_2_usb.ops.deployment.install_service_unit"))
                 stack.enter_context(patch("bluetooth_2_usb.ops.deployment.install_cli_links"))
                 stack.enter_context(patch("bluetooth_2_usb.ops.deployment.activate_service_unit"))
@@ -190,6 +253,7 @@ class OpsDeploymentTest(unittest.TestCase):
                 install(root)
 
         self.assertEqual(canonicalized_paths, [paths.env_file])
+        rebuild.assert_called_once_with(paths.install_dir / "venv", paths.install_dir, recreate=False)
 
     def test_update_pulls_current_branch_then_reapplies_install(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -215,10 +279,10 @@ class OpsDeploymentTest(unittest.TestCase):
                 patch("bluetooth_2_usb.ops.deployment.run", side_effect=fake_run),
                 patch("bluetooth_2_usb.ops.deployment.install") as managed_install,
             ):
-                update(root)
+                update(root, recreate_venv=True)
 
         self.assertEqual(commands, [["git", "-C", root, "pull", "--ff-only", "origin", "staging"]])
-        managed_install.assert_called_once_with(root)
+        managed_install.assert_called_once_with(root, recreate_venv=True)
 
     def test_update_reapplies_install_even_when_pull_has_no_changes(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -242,7 +306,7 @@ class OpsDeploymentTest(unittest.TestCase):
             ):
                 update(root)
 
-        managed_install.assert_called_once_with(root)
+        managed_install.assert_called_once_with(root, recreate_venv=False)
 
     def test_update_refuses_dirty_checkout_before_pull_or_install(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- reuse the managed virtualenv by default during install/update when it is already valid
- add `--recreate-venv` for explicit full rebuilds
- document the default reuse behavior and force-rebuild option

## Validation
- `PYTHONPATH=src /home/benfred/VS/quaxalber/bluetooth_2_usb/venv/bin/python -m unittest tests.test_ops_cli tests.test_ops_deployment -v`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--recreate-venv` flag to the install and update commands, allowing users to rebuild the managed Python virtual environment when needed.

* **Documentation**
  * Enhanced installation and update documentation to clarify how the managed virtual environment is reused by default and when to recreate it for a clean rebuild.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->