### PR TITLE
fix: install readonly prerequisites during setup

### DIFF
--- a/docs/cli-service-test.md
+++ b/docs/cli-service-test.md
@@ -215,12 +215,6 @@ until new_boot_id="$(ssh -o ConnectTimeout=5 <pi-host> 'cat /proc/sys/kernel/ran
 done
 ```
 
-> [!TIP]
-> If the enable step fails with `mkinitramfs: failed to determine device for /`,
-> follow the repair step in
-> [persistent-readonly.md](persistent-readonly.md#enable-read-only-mode),
-> then rerun `readonly enable` and resume validation here before rebooting.
-
 After reboot:
 
 ```bash

--- a/docs/persistent-readonly.md
+++ b/docs/persistent-readonly.md
@@ -59,6 +59,10 @@ sudo mkfs.ext4 -L B2U_PERSIST <persist-partition>
 
 ## Enable read-only mode
 
+The setup step installs the OverlayFS and initramfs prerequisites, configures
+initramfs-tools for read-only operation, and prepares persistent Bluetooth
+state storage.
+
 Run:
 
 ```bash
@@ -85,22 +89,6 @@ else:
     print(f"boot initramfs: {path}")
 PY
 ```
-
-> [!TIP]
-> If `readonly enable` fails while `overlayroot` is being installed and the log
-> shows `mkinitramfs: failed to determine device for /`, repair the package
-> state before rebooting:
-
-### OverlayFS Repair Guidance
-
-```bash
-sudo sed -i 's/^MODULES=dep$/MODULES=most/' /etc/initramfs-tools/initramfs.conf
-sudo dpkg --configure -a
-sudo bluetooth_2_usb readonly enable
-```
-
-That failure mode has been observed on current Raspberry Pi OS releases when
-`initramfs-tools` cannot infer the root device during `overlayroot` setup.
 
 After any failed `readonly enable`, inspect the current state before rebooting:
 

--- a/src/bluetooth_2_usb/ops/readonly/__init__.py
+++ b/src/bluetooth_2_usb/ops/readonly/__init__.py
@@ -13,9 +13,7 @@ from .status import (
     print_readonly_status,
     readonly_mode,
     readonly_stack_package_report,
-    readonly_stack_packages_bootstrap_safe,
     readonly_stack_packages_healthy,
-    readonly_stack_packages_missing,
 )
 from .units import (
     install_bluetooth_persist_dropin,
@@ -49,9 +47,7 @@ __all__ = [
     "print_readonly_status",
     "readonly_mode",
     "readonly_stack_package_report",
-    "readonly_stack_packages_bootstrap_safe",
     "readonly_stack_packages_healthy",
-    "readonly_stack_packages_missing",
     "remove_bluetooth_bind_mount_unit",
     "remove_bluetooth_persist_dropin",
     "remove_persist_mount_unit",

--- a/src/bluetooth_2_usb/ops/readonly/status.py
+++ b/src/bluetooth_2_usb/ops/readonly/status.py
@@ -60,14 +60,6 @@ def readonly_stack_packages_healthy() -> bool:
     return all(package_status(package) == "install ok installed" for package in READONLY_PACKAGES)
 
 
-def readonly_stack_packages_bootstrap_safe() -> bool:
-    return all(package_status(package) in {"", "install ok installed"} for package in READONLY_PACKAGES)
-
-
-def readonly_stack_packages_missing() -> bool:
-    return any(package_status(package) != "install ok installed" for package in READONLY_PACKAGES)
-
-
 def readonly_stack_package_report() -> str:
     lines = []
     for package in READONLY_PACKAGES:

--- a/src/bluetooth_2_usb/ops/readonly/workflows.py
+++ b/src/bluetooth_2_usb/ops/readonly/workflows.py
@@ -14,18 +14,17 @@ from ..boot_config import (
     expected_boot_initramfs_file,
     versioned_initrd_candidates,
 )
-from ..commands import fail, info, ok, output, require_commands, run, warn
+from ..commands import backup_file, fail, info, ok, output, require_commands, run, warn
 from .config import ReadonlyConfig, load_readonly_config, write_readonly_config
 from .service import _systemctl_active, restart_b2u_if_installed, stop_b2u_if_installed
 from .status import (
+    READONLY_PACKAGES,
     bluetooth_state_persistent,
     machine_id_valid,
     overlay_configured_status,
     overlay_status,
     readonly_stack_package_report,
-    readonly_stack_packages_bootstrap_safe,
     readonly_stack_packages_healthy,
-    readonly_stack_packages_missing,
 )
 from .units import (
     install_bluetooth_persist_dropin,
@@ -34,10 +33,25 @@ from .units import (
     write_persist_mount_unit,
 )
 
+INITRAMFS_CONF = Path("/etc/initramfs-tools/initramfs.conf")
+
 
 def setup_persistent_bluetooth_state(device: str) -> None:
     require_commands(
-        ["blkid", "cp", "findmnt", "mkdir", "mount", "mountpoint", "systemctl", "systemd-escape", "umount"]
+        [
+            "apt-get",
+            "blkid",
+            "cp",
+            "dpkg",
+            "dpkg-query",
+            "findmnt",
+            "mkdir",
+            "mount",
+            "mountpoint",
+            "systemctl",
+            "systemd-escape",
+            "umount",
+        ]
     )
     if not machine_id_valid():
         fail("/etc/machine-id is missing or invalid. Read-only mode requires a stable machine-id.")
@@ -46,6 +60,7 @@ def setup_persistent_bluetooth_state(device: str) -> None:
         fail(f"No filesystem detected on {device}. Create an ext4 filesystem first, then rerun this command.")
     if detected_type != "ext4":
         fail(f"Expected ext4 on {device}, got {detected_type}")
+    _ensure_readonly_stack_installed()
 
     current = load_readonly_config()
     persist_mount = current.persist_mount
@@ -95,6 +110,80 @@ def setup_persistent_bluetooth_state(device: str) -> None:
             run(["systemctl", "stop", "bluetooth.service"], check=False)
         restart_b2u_if_installed(b2u_was_active, "after enabling the persistent Bluetooth state bind mount")
     ok(f"Persistent Bluetooth state storage is active at {persist_bluetooth_dir}")
+
+
+def _ensure_readonly_stack_installed() -> None:
+    info("Installing read-only mode prerequisites")
+    run(["apt-get", "update", "-y"])
+
+    initramfs_install = run(
+        ["apt-get", "install", "-y", "--no-install-recommends", "initramfs-tools"], check=False, capture=True
+    )
+    if initramfs_install.returncode != 0:
+        warn("Initial initramfs-tools install did not complete cleanly; attempting package configuration repair.")
+        _print_completed_output(initramfs_install)
+    _ensure_initramfs_modules_most()
+    if initramfs_install.returncode != 0:
+        _configure_pending_packages()
+
+    install = run(
+        ["apt-get", "install", "-y", "--no-install-recommends", *READONLY_PACKAGES], check=False, capture=True
+    )
+    if install.returncode != 0:
+        warn(
+            "Read-only prerequisite package install did not complete cleanly; attempting package configuration repair."
+        )
+        _print_completed_output(install)
+    _configure_pending_packages()
+
+    if not readonly_stack_packages_healthy():
+        warn("OverlayFS package state is incomplete:")
+        print(readonly_stack_package_report())
+        fail(
+            "Read-only prerequisite package setup did not complete cleanly. Rerun readonly setup after fixing apt/dpkg."
+        )
+
+
+def _configure_pending_packages() -> None:
+    completed = run(["dpkg", "--configure", "-a"], check=False, capture=True)
+    if completed.returncode != 0:
+        _print_completed_output(completed)
+        fail("dpkg could not finish configuring read-only prerequisite packages.")
+
+
+def _print_completed_output(completed) -> None:
+    output_text = "\n".join(part.strip() for part in (completed.stdout, completed.stderr) if part and part.strip())
+    if output_text:
+        print(output_text)
+
+
+def _ensure_initramfs_modules_most(path: Path = INITRAMFS_CONF) -> None:
+    if path.is_file():
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    else:
+        lines = []
+
+    changed = False
+    found = False
+    updated_lines = []
+    for line in lines:
+        if re.fullmatch(r"\s*MODULES\s*=.*", line) and not line.lstrip().startswith("#"):
+            found = True
+            if line != "MODULES=most":
+                changed = True
+            updated_lines.append("MODULES=most")
+        else:
+            updated_lines.append(line)
+
+    if not found:
+        updated_lines.append("MODULES=most")
+        changed = True
+
+    if not changed:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    backup_file(path)
+    path.write_text("\n".join(updated_lines) + "\n", encoding="utf-8")
 
 
 def _seed_bluetooth_state(persist_bluetooth_dir: Path) -> None:
@@ -152,11 +241,12 @@ def enable_readonly() -> None:
             "Persistent Bluetooth state storage is not active. "
             + "Run bluetooth_2_usb readonly setup --device /dev/... first."
         )
-    if not readonly_stack_packages_bootstrap_safe():
+    if not readonly_stack_packages_healthy():
         warn("OverlayFS package state is incomplete:")
         print(readonly_stack_package_report())
         fail(
-            "OverlayFS package setup did not complete cleanly. Repair the package state before enabling read-only mode."
+            "Read-only prerequisite packages are not fully installed. "
+            + "Rerun bluetooth_2_usb readonly setup --device /dev/... before enabling read-only mode."
         )
 
     kernel_release = current_kernel_release()
@@ -172,18 +262,14 @@ def enable_readonly() -> None:
     overlay_before = overlay_status()
     try:
         if overlay_before != "enabled":
-            if readonly_stack_packages_missing():
-                info(
-                    "OverlayFS prerequisites are not fully installed yet; raspi-config will install or finish them now."
-                )
             run(["raspi-config", "nonint", "enable_overlayfs"])
 
         if not readonly_stack_packages_healthy():
             warn("OverlayFS package state is incomplete:")
             print(readonly_stack_package_report())
             fail(
-                "OverlayFS package setup did not complete cleanly. "
-                + "Repair the package state before enabling read-only mode."
+                "Read-only prerequisite packages are not fully installed. "
+                + "Rerun bluetooth_2_usb readonly setup --device /dev/... before enabling read-only mode."
             )
 
         target = ensure_bootable_initramfs_for_current_kernel()
@@ -208,10 +294,7 @@ def enable_readonly() -> None:
     except Exception:
         warn(
             "OverlayFS was requested but validation did not complete. "
-            + "Run `bluetooth_2_usb readonly status` and repair the reported package or boot state before rebooting. "
-            + "See: https://github.com/quaxalber/bluetooth_2_usb/blob/main/docs/persistent-readonly.md"
-            + "#overlayfs-repair-guidance "
-            + "for repair steps. "
+            + "Run `bluetooth_2_usb readonly status` and inspect the reported package or boot state before rebooting. "
             + "To explicitly disable OverlayFS, run: sudo bluetooth_2_usb readonly disable"
         )
         raise

--- a/src/bluetooth_2_usb/ops/readonly/workflows.py
+++ b/src/bluetooth_2_usb/ops/readonly/workflows.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import shutil
+import subprocess
 import uuid
 from pathlib import Path
 
@@ -151,7 +152,7 @@ def _configure_pending_packages() -> None:
         fail("dpkg could not finish configuring read-only prerequisite packages.")
 
 
-def _print_completed_output(completed) -> None:
+def _print_completed_output(completed: subprocess.CompletedProcess[str]) -> None:
     output_text = "\n".join(part.strip() for part in (completed.stdout, completed.stderr) if part and part.strip())
     if output_text:
         print(output_text)

--- a/tests/test_bluetooth_ops.py
+++ b/tests/test_bluetooth_ops.py
@@ -5,6 +5,7 @@ from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
+import bluetooth_2_usb.ops.readonly.workflows as readonly_workflows
 from bluetooth_2_usb.ops import boot_config
 from bluetooth_2_usb.ops.bluetooth import clear_bluetooth_rfkill_soft_blocks, rfkill_list_bluetooth
 from bluetooth_2_usb.ops.commands import OpsError
@@ -196,6 +197,39 @@ class ReadonlyConfigTest(unittest.TestCase):
     def test_package_status_returns_empty_when_dpkg_probe_fails(self) -> None:
         with patch(f"{READONLY_STATUS}.run", side_effect=OpsError("dpkg unavailable")):
             self.assertEqual(package_status("overlayroot"), "")
+
+    def test_initramfs_modules_most_replaces_dep_setting(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "initramfs.conf"
+            path.write_text("# keep\nMODULES=dep\nBUSYBOX=auto\n", encoding="utf-8")
+
+            with patch(f"{READONLY_WORKFLOWS}.backup_file") as backup:
+                readonly_workflows._ensure_initramfs_modules_most(path)
+
+            self.assertEqual(path.read_text(encoding="utf-8"), "# keep\nMODULES=most\nBUSYBOX=auto\n")
+            backup.assert_called_once_with(path)
+
+    def test_initramfs_modules_most_appends_missing_setting(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "initramfs.conf"
+            path.write_text("# MODULES=dep\nBUSYBOX=auto\n", encoding="utf-8")
+
+            with patch(f"{READONLY_WORKFLOWS}.backup_file") as backup:
+                readonly_workflows._ensure_initramfs_modules_most(path)
+
+            self.assertEqual(path.read_text(encoding="utf-8"), "# MODULES=dep\nBUSYBOX=auto\nMODULES=most\n")
+            backup.assert_called_once_with(path)
+
+    def test_initramfs_modules_most_is_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "initramfs.conf"
+            path.write_text("MODULES=most\n", encoding="utf-8")
+
+            with patch(f"{READONLY_WORKFLOWS}.backup_file") as backup:
+                readonly_workflows._ensure_initramfs_modules_most(path)
+
+            self.assertEqual(path.read_text(encoding="utf-8"), "MODULES=most\n")
+            backup.assert_not_called()
 
     def test_readonly_config_round_trips_supported_keys(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -390,6 +424,7 @@ class ReadonlyConfigTest(unittest.TestCase):
                 persist_device="",
             )
             commands = []
+            events = []
             written = []
             var_lib_bluetooth = root / "var/lib/bluetooth"
 
@@ -414,12 +449,21 @@ class ReadonlyConfigTest(unittest.TestCase):
             with ExitStack() as stack:
                 stack.enter_context(patch(f"{READONLY_WORKFLOWS}.require_commands"))
                 stack.enter_context(patch(f"{READONLY_WORKFLOWS}.machine_id_valid", return_value=True))
+                ensure_stack = stack.enter_context(
+                    patch(
+                        f"{READONLY_WORKFLOWS}._ensure_readonly_stack_installed",
+                        side_effect=lambda: events.append("packages"),
+                    )
+                )
                 stack.enter_context(patch(f"{READONLY_WORKFLOWS}.load_readonly_config", return_value=config))
                 stack.enter_context(
                     patch(f"{READONLY_WORKFLOWS}.persist_spec_from_device", return_value="/dev/disk/by-uuid/abc")
                 )
                 stack.enter_context(
-                    patch(f"{READONLY_WORKFLOWS}.write_persist_mount_unit", return_value="mnt-persist.mount")
+                    patch(
+                        f"{READONLY_WORKFLOWS}.write_persist_mount_unit",
+                        side_effect=lambda *_args: events.append("mount_unit") or "mnt-persist.mount",
+                    )
                 )
                 write_bind = stack.enter_context(patch(f"{READONLY_WORKFLOWS}.write_bluetooth_bind_mount_unit"))
                 install_dropin = stack.enter_context(patch(f"{READONLY_WORKFLOWS}.install_bluetooth_persist_dropin"))
@@ -434,6 +478,8 @@ class ReadonlyConfigTest(unittest.TestCase):
                 setup_persistent_bluetooth_state("/dev/sda1")
 
             self.assertTrue(var_lib_bluetooth.is_dir())
+            ensure_stack.assert_called_once_with()
+            self.assertEqual(events[:2], ["packages", "mount_unit"])
             self.assertEqual(written[0].persist_spec, "/dev/disk/by-uuid/abc")
             self.assertEqual(written[0].persist_device, "/dev/sda1")
             write_bind.assert_called_once_with(root / "persist" / "bluetooth", root / "persist")
@@ -444,6 +490,98 @@ class ReadonlyConfigTest(unittest.TestCase):
             self.assertIn(["systemctl", "enable", "--now", "mnt-persist.mount"], commands)
             self.assertIn(["systemctl", "enable", "--now", "var-lib-bluetooth.mount"], commands)
             self.assertIn(["systemctl", "start", "bluetooth.service"], commands)
+
+    def test_setup_persistent_bluetooth_state_fails_before_mount_migration_when_packages_fail(self) -> None:
+        config = ReadonlyConfig(
+            mode="disabled",
+            persist_mount=Path("/mnt/persist"),
+            persist_bluetooth_dir=Path("/mnt/persist/bluetooth"),
+            persist_spec="",
+            persist_device="",
+        )
+
+        def fake_run(command, *, check=True, capture=False):
+            class Completed:
+                returncode = 0
+                stdout = "ext4\n" if command[:4] == ["blkid", "-s", "TYPE", "-o"] else ""
+
+            return Completed()
+
+        with ExitStack() as stack:
+            stack.enter_context(patch(f"{READONLY_WORKFLOWS}.require_commands"))
+            stack.enter_context(patch(f"{READONLY_WORKFLOWS}.machine_id_valid", return_value=True))
+            stack.enter_context(patch(f"{READONLY_WORKFLOWS}.run", side_effect=fake_run))
+            stack.enter_context(
+                patch(f"{READONLY_WORKFLOWS}._ensure_readonly_stack_installed", side_effect=OpsError("apt failed"))
+            )
+            stack.enter_context(patch(f"{READONLY_WORKFLOWS}.load_readonly_config", return_value=config))
+            write_mount = stack.enter_context(patch(f"{READONLY_WORKFLOWS}.write_persist_mount_unit"))
+            stop_b2u = stack.enter_context(patch(f"{READONLY_WORKFLOWS}.stop_b2u_if_installed"))
+
+            with self.assertRaisesRegex(OpsError, "apt failed"):
+                setup_persistent_bluetooth_state("/dev/sda1")
+
+        write_mount.assert_not_called()
+        stop_b2u.assert_not_called()
+
+    def test_ensure_readonly_stack_installs_packages_and_configures_dpkg(self) -> None:
+        commands = []
+
+        def fake_run(command, *, check=True, capture=False):
+            commands.append(command)
+
+            class Completed:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            return Completed()
+
+        with (
+            patch(f"{READONLY_WORKFLOWS}.run", side_effect=fake_run),
+            patch(f"{READONLY_WORKFLOWS}._ensure_initramfs_modules_most") as ensure_modules,
+            patch(f"{READONLY_WORKFLOWS}.readonly_stack_packages_healthy", return_value=True),
+        ):
+            readonly_workflows._ensure_readonly_stack_installed()
+
+        self.assertEqual(commands[0], ["apt-get", "update", "-y"])
+        self.assertEqual(commands[1], ["apt-get", "install", "-y", "--no-install-recommends", "initramfs-tools"])
+        ensure_modules.assert_called_once_with()
+        self.assertIn(["dpkg", "--configure", "-a"], commands)
+        self.assertIn(
+            [
+                "apt-get",
+                "install",
+                "-y",
+                "--no-install-recommends",
+                "overlayroot",
+                "cryptsetup",
+                "cryptsetup-bin",
+                "initramfs-tools",
+            ],
+            commands,
+        )
+
+    def test_ensure_readonly_stack_fails_with_package_report_when_packages_remain_incomplete(self) -> None:
+        def fake_run(_command, *, check=True, capture=False):
+            class Completed:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            return Completed()
+
+        with (
+            patch(f"{READONLY_WORKFLOWS}.run", side_effect=fake_run),
+            patch(f"{READONLY_WORKFLOWS}._ensure_initramfs_modules_most"),
+            patch(f"{READONLY_WORKFLOWS}.readonly_stack_packages_healthy", return_value=False),
+            patch(f"{READONLY_WORKFLOWS}.readonly_stack_package_report", return_value="overlayroot: half-configured"),
+            redirect_stdout(StringIO()) as stdout,
+            self.assertRaisesRegex(OpsError, "Read-only prerequisite package setup did not complete cleanly"),
+        ):
+            readonly_workflows._ensure_readonly_stack_installed()
+
+        self.assertIn("overlayroot: half-configured", stdout.getvalue())
 
     def test_enable_readonly_does_not_rollback_overlayfs_when_validation_fails(self) -> None:
         config = ReadonlyConfig(
@@ -470,10 +608,6 @@ class ReadonlyConfigTest(unittest.TestCase):
             stack.enter_context(patch(f"{READONLY_WORKFLOWS}.load_readonly_config", return_value=config))
             stack.enter_context(patch(f"{READONLY_WORKFLOWS}.machine_id_valid", return_value=True))
             stack.enter_context(patch(f"{READONLY_WORKFLOWS}.bluetooth_state_persistent", return_value=True))
-            stack.enter_context(
-                patch(f"{READONLY_WORKFLOWS}.readonly_stack_packages_bootstrap_safe", return_value=True)
-            )
-            stack.enter_context(patch(f"{READONLY_WORKFLOWS}.readonly_stack_packages_missing", return_value=False))
             stack.enter_context(patch(f"{READONLY_WORKFLOWS}.readonly_stack_packages_healthy", return_value=True))
             stack.enter_context(patch(f"{READONLY_WORKFLOWS}.overlay_status", return_value="disabled"))
             stack.enter_context(patch(f"{READONLY_WORKFLOWS}.current_kernel_release", return_value="6.6.1"))
@@ -499,13 +633,10 @@ class ReadonlyConfigTest(unittest.TestCase):
         self.assertEqual(config.mode, "disabled")
         self.assertEqual(written, [])
         self.assertIn("readonly status", stdout.getvalue())
-        self.assertIn(
-            "https://github.com/quaxalber/bluetooth_2_usb/blob/main/docs/persistent-readonly.md"
-            "#overlayfs-repair-guidance",
-            stdout.getvalue(),
-        )
+        self.assertNotIn("overlayfs-repair-guidance", stdout.getvalue())
+        self.assertNotIn("for repair steps", stdout.getvalue())
 
-    def test_enable_readonly_reports_repair_guidance_when_overlayfs_enable_fails(self) -> None:
+    def test_enable_readonly_reports_status_guidance_when_overlayfs_enable_fails(self) -> None:
         config = ReadonlyConfig(
             mode="disabled",
             persist_mount=Path("/mnt/persist"),
@@ -519,10 +650,7 @@ class ReadonlyConfigTest(unittest.TestCase):
             stack.enter_context(patch(f"{READONLY_WORKFLOWS}.load_readonly_config", return_value=config))
             stack.enter_context(patch(f"{READONLY_WORKFLOWS}.machine_id_valid", return_value=True))
             stack.enter_context(patch(f"{READONLY_WORKFLOWS}.bluetooth_state_persistent", return_value=True))
-            stack.enter_context(
-                patch(f"{READONLY_WORKFLOWS}.readonly_stack_packages_bootstrap_safe", return_value=True)
-            )
-            stack.enter_context(patch(f"{READONLY_WORKFLOWS}.readonly_stack_packages_missing", return_value=False))
+            stack.enter_context(patch(f"{READONLY_WORKFLOWS}.readonly_stack_packages_healthy", return_value=True))
             stack.enter_context(patch(f"{READONLY_WORKFLOWS}.overlay_status", return_value="disabled"))
             stack.enter_context(patch(f"{READONLY_WORKFLOWS}.current_kernel_release", return_value="6.6.1"))
             stack.enter_context(patch(f"{READONLY_WORKFLOWS}.configured_kernel_image", return_value="kernel8.img"))
@@ -538,12 +666,35 @@ class ReadonlyConfigTest(unittest.TestCase):
 
         write_config.assert_not_called()
         self.assertIn("readonly status", stdout.getvalue())
-        self.assertIn(
-            "https://github.com/quaxalber/bluetooth_2_usb/blob/main/docs/persistent-readonly.md"
-            "#overlayfs-repair-guidance",
-            stdout.getvalue(),
-        )
+        self.assertNotIn("overlayfs-repair-guidance", stdout.getvalue())
         self.assertIn("disable OverlayFS", stdout.getvalue())
+
+    def test_enable_readonly_tells_user_to_rerun_setup_when_packages_are_incomplete(self) -> None:
+        config = ReadonlyConfig(
+            mode="disabled",
+            persist_mount=Path("/mnt/persist"),
+            persist_bluetooth_dir=Path("/mnt/persist/bluetooth"),
+            persist_spec="/dev/sda1",
+            persist_device="/dev/sda1",
+        )
+
+        with ExitStack() as stack:
+            stack.enter_context(patch(f"{READONLY_WORKFLOWS}.require_commands"))
+            stack.enter_context(patch(f"{READONLY_WORKFLOWS}.load_readonly_config", return_value=config))
+            stack.enter_context(patch(f"{READONLY_WORKFLOWS}.machine_id_valid", return_value=True))
+            stack.enter_context(patch(f"{READONLY_WORKFLOWS}.bluetooth_state_persistent", return_value=True))
+            stack.enter_context(patch(f"{READONLY_WORKFLOWS}.readonly_stack_packages_healthy", return_value=False))
+            stack.enter_context(
+                patch(f"{READONLY_WORKFLOWS}.readonly_stack_package_report", return_value="bad package")
+            )
+            run_command = stack.enter_context(patch(f"{READONLY_WORKFLOWS}.run"))
+
+            with redirect_stdout(StringIO()) as stdout:
+                with self.assertRaisesRegex(OpsError, "Rerun bluetooth_2_usb readonly setup"):
+                    enable_readonly()
+
+        run_command.assert_not_called()
+        self.assertIn("bad package", stdout.getvalue())
 
     def test_disable_readonly_disables_overlayfs_and_keeps_persistent_mount_config(self) -> None:
         config = ReadonlyConfig(


### PR DESCRIPTION
## Summary

- Move read-only prerequisite installation into `bluetooth_2_usb readonly setup`.
- Configure initramfs-tools with `MODULES=most`, install the OverlayFS package stack, and run `dpkg --configure -a` before persistent Bluetooth mount migration.
- Make `readonly enable` fail on incomplete package state with rerun-setup guidance and remove the old manual repair instructions from docs.

## Validation

- `PYTHONPATH=src /home/benfred/VS/quaxalber/bluetooth_2_usb/venv/bin/python -m compileall src tests`
- `PYTHONPATH=src /home/benfred/VS/quaxalber/bluetooth_2_usb/venv/bin/ruff check src tests`
- `/home/benfred/VS/quaxalber/bluetooth_2_usb/venv/bin/black --check src tests`
- `PYTHONPATH=src /home/benfred/VS/quaxalber/bluetooth_2_usb/venv/bin/python -m unittest discover -s tests -v`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated read-only mode setup guidance with clearer prerequisites and failure recovery steps.

* **Improvements**
  * Enhanced preflight validation and installation routines for read-only mode initialization.
  * Improved error messaging when prerequisites are not fully met.

* **Tests**
  * Expanded test coverage for read-only mode workflows and related configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->