### PR TITLE
fix: find custom kernel config in firmware boot dir

### DIFF
--- a/src/bluetooth_2_usb/ops/boot_config.py
+++ b/src/bluetooth_2_usb/ops/boot_config.py
@@ -216,6 +216,17 @@ def find_versioned_initramfs_image(kernel_release: str | None = None) -> Path | 
     return None
 
 
+def kernel_config_candidates(kernel_release: str | None = None) -> list[Path]:
+    resolved = current_kernel_release() if kernel_release is None else kernel_release
+    candidates = [Path(f"/boot/config-{resolved}")]
+    boot_dir = detect_boot_dir()
+    firmware_candidate = boot_dir / f"config-{resolved}"
+    if firmware_candidate not in candidates:
+        candidates.append(firmware_candidate)
+    candidates.append(Path("/proc/config.gz"))
+    return candidates
+
+
 def ensure_initramfs_tools_ready() -> None:
     require_commands(["install", "python3", "update-initramfs"])
     if not any(Path(path, "mkinitramfs").exists() for path in os.environ.get("PATH", "").split(os.pathsep)):
@@ -225,10 +236,11 @@ def ensure_initramfs_tools_ready() -> None:
 def ensure_kernel_artifacts_present_for_initramfs(kernel_release: str) -> None:
     if not Path(f"/lib/modules/{kernel_release}").is_dir():
         fail(f"Kernel modules for {kernel_release} are missing at /lib/modules/{kernel_release}.")
-    if not Path(f"/boot/config-{kernel_release}").is_file() and not Path("/proc/config.gz").is_file():
+    if not any(candidate.is_file() for candidate in kernel_config_candidates(kernel_release)):
         fail(
             f"Kernel configuration for {kernel_release} is unavailable. "
-            + f"Expected /boot/config-{kernel_release} or /proc/config.gz."
+            + "Expected one of: "
+            + ", ".join(str(candidate) for candidate in kernel_config_candidates(kernel_release))
         )
 
 
@@ -292,12 +304,16 @@ def ensure_bootable_initramfs_for_current_kernel() -> Path:
 
 
 def kernel_config_snippet() -> str:
-    kernel_config = Path(f"/boot/config-{current_kernel_release()}")
-    if kernel_config.is_file():
-        text = kernel_config.read_text(encoding="utf-8", errors="replace")
-    elif Path("/proc/config.gz").is_file():
-        text = gzip.decompress(Path("/proc/config.gz").read_bytes()).decode("utf-8", "replace")
-    else:
+    text = ""
+    for kernel_config in kernel_config_candidates():
+        if not kernel_config.is_file():
+            continue
+        if kernel_config == Path("/proc/config.gz"):
+            text = gzip.decompress(kernel_config.read_bytes()).decode("utf-8", "replace")
+        else:
+            text = kernel_config.read_text(encoding="utf-8", errors="replace")
+        break
+    if not text:
         return ""
     return "\n".join(
         line for line in text.splitlines() if line.startswith(("CONFIG_USB_DWC2=", "CONFIG_USB_LIBCOMPOSITE="))

--- a/tests/test_bluetooth_ops.py
+++ b/tests/test_bluetooth_ops.py
@@ -164,6 +164,36 @@ class BootConfigOpsTest(unittest.TestCase):
                 with self.assertRaises(OpsError):
                     boot_config.boot_initramfs_target_path(target)
 
+    def test_kernel_config_candidates_include_detected_firmware_boot_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            firmware = Path(tmpdir) / "firmware"
+
+            with patch("bluetooth_2_usb.ops.boot_config.detect_boot_dir", return_value=firmware):
+                candidates = boot_config.kernel_config_candidates("6.12.81-b2u-wake")
+
+        self.assertEqual(
+            candidates,
+            [Path("/boot/config-6.12.81-b2u-wake"), firmware / "config-6.12.81-b2u-wake", Path("/proc/config.gz")],
+        )
+
+    def test_kernel_config_snippet_reads_detected_firmware_boot_dir_config(self) -> None:
+        release = "99.99.99-b2u-test"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            firmware = Path(tmpdir) / "firmware"
+            firmware.mkdir()
+            (firmware / f"config-{release}").write_text(
+                "\n".join(["CONFIG_USB_DWC2=y", "CONFIG_USB_LIBCOMPOSITE=m", "CONFIG_UNRELATED=y"]) + "\n",
+                encoding="utf-8",
+            )
+
+            with (
+                patch("bluetooth_2_usb.ops.boot_config.detect_boot_dir", return_value=firmware),
+                patch("bluetooth_2_usb.ops.boot_config.current_kernel_release", return_value=release),
+            ):
+                snippet = boot_config.kernel_config_snippet()
+
+        self.assertEqual(snippet, "CONFIG_USB_DWC2=y\nCONFIG_USB_LIBCOMPOSITE=m")
+
 
 class ReadonlyConfigTest(unittest.TestCase):
     def test_overlay_status_prefers_live_state(self) -> None:


### PR DESCRIPTION
## Summary
- include the detected firmware boot directory in kernel config discovery
- reuse that candidate list for initramfs validation and DWC2 mode detection
- cover firmware config discovery in boot config tests

## Validation
- `PYTHONPATH=src /home/benfred/VS/quaxalber/bluetooth_2_usb/venv/bin/python -m unittest tests.test_bluetooth_ops -v`
- `/home/benfred/VS/quaxalber/bluetooth_2_usb/venv/bin/ruff check src tests`
- `/home/benfred/VS/quaxalber/bluetooth_2_usb/venv/bin/black --check src tests`
- `PYTHONPATH=src /home/benfred/VS/quaxalber/bluetooth_2_usb/venv/bin/python -m unittest discover -s tests -v`
- `PYTHONPATH=src python3 -m compileall src tests`

Live context: pi4b custom kernel exposed config at `/boot/firmware/config-6.12.81-b2u-wake`; without this change read-only enable required a manual copy to `/boot/config-6.12.81-b2u-wake`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved kernel configuration detection to support systems with non-standard boot directory layouts.
  * Enhanced error messaging when kernel configuration files are unavailable.

* **Tests**
  * Added comprehensive unit tests validating kernel configuration discovery and snippet extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->