### PR TITLE
fix: downgrade optional initramfs smoketest warning

### DIFF
--- a/src/bluetooth_2_usb/ops/diagnostics/smoketest.py
+++ b/src/bluetooth_2_usb/ops/diagnostics/smoketest.py
@@ -11,7 +11,7 @@ from ..bluetooth import (
     bluetooth_rfkill_blocked,
     bluetooth_rfkill_entries,
 )
-from ..commands import OpsError, bold, fail_final, ok, ok_final, run, warn
+from ..commands import OpsError, bold, fail_final, info, ok, ok_final, run, warn
 from ..commands import warn_fail as red_warn
 from ..paths import PATHS
 from ..readonly import bluetooth_state_persistent, display_readonly_mode, overlay_status, readonly_mode
@@ -274,7 +274,7 @@ class SmokeTest:
         elif should_require:
             self.warn_fail(f"Boot initramfs is missing or empty ({path})")
         else:
-            self.soft_warn(f"Boot initramfs is not present yet ({path})")
+            info(f"Boot initramfs is not present yet ({path})")
 
     def _check_readonly(
         self, readonly: str, overlay: str, root_overlay_active: str, bluetooth_persistent: bool, post_reboot: bool

--- a/tests/test_ops_diagnostics.py
+++ b/tests/test_ops_diagnostics.py
@@ -177,6 +177,30 @@ class OpsDiagnosticsTest(unittest.TestCase):
         self.assertTrue(any("UDC is not configured" in result.message for result in warnings))
         self.assertEqual(smoke.summary["UDC state"], "dummy.udc=not attached")
 
+    def test_smoketest_treats_missing_initramfs_as_info_when_not_required(self) -> None:
+        smoke = SmokeTest(verbose=False, allow_non_pi=False)
+
+        stdout = StringIO()
+        with redirect_stdout(stdout):
+            smoke._check_initramfs("disabled", "no", "disabled", "/boot/firmware/initramfs-b2u-wake")
+
+        self.assertIn("[i] Boot initramfs is not present yet (/boot/firmware/initramfs-b2u-wake)", stdout.getvalue())
+        self.assertEqual(smoke.soft_warnings, 0)
+        self.assertEqual(smoke.exit_code, 0)
+        self.assertEqual(smoke.results, [])
+
+    def test_smoketest_fails_missing_initramfs_when_required(self) -> None:
+        smoke = SmokeTest(verbose=False, allow_non_pi=False)
+
+        stdout = StringIO()
+        with redirect_stdout(stdout):
+            smoke._check_initramfs("enabled", "no", "disabled", "/boot/firmware/initramfs-b2u-wake")
+
+        self.assertIn("[!] Boot initramfs is missing or empty (/boot/firmware/initramfs-b2u-wake)", stdout.getvalue())
+        self.assertEqual(smoke.soft_warnings, 0)
+        self.assertEqual(smoke.exit_code, 1)
+        self.assertEqual(smoke.results[0].status, ProbeStatus.FAIL)
+
     def test_smoketest_records_healthy_rfkill_probe(self) -> None:
         smoke = SmokeTest(verbose=False, allow_non_pi=True)
 

--- a/tests/test_ops_diagnostics.py
+++ b/tests/test_ops_diagnostics.py
@@ -181,7 +181,7 @@ class OpsDiagnosticsTest(unittest.TestCase):
         smoke = SmokeTest(verbose=False, allow_non_pi=False)
 
         stdout = StringIO()
-        with redirect_stdout(stdout):
+        with redirect_stdout(stdout), patch(f"{DIAGNOSTICS_SMOKETEST}.Path.is_file", return_value=False):
             smoke._check_initramfs("disabled", "no", "disabled", "/boot/firmware/initramfs-b2u-wake")
 
         self.assertIn("[i] Boot initramfs is not present yet (/boot/firmware/initramfs-b2u-wake)", stdout.getvalue())
@@ -193,7 +193,7 @@ class OpsDiagnosticsTest(unittest.TestCase):
         smoke = SmokeTest(verbose=False, allow_non_pi=False)
 
         stdout = StringIO()
-        with redirect_stdout(stdout):
+        with redirect_stdout(stdout), patch(f"{DIAGNOSTICS_SMOKETEST}.Path.is_file", return_value=False):
             smoke._check_initramfs("enabled", "no", "disabled", "/boot/firmware/initramfs-b2u-wake")
 
         self.assertIn("[!] Boot initramfs is missing or empty (/boot/firmware/initramfs-b2u-wake)", stdout.getvalue())


### PR DESCRIPTION
## Summary
- report a missing boot initramfs as informational when boot config does not require it
- keep the failure path when initramfs is required
- add smoketest coverage for both optional and required missing-initramfs cases

## Validation
- `PYTHONPATH=src venv/bin/python -m unittest tests.test_ops_diagnostics -v`
- `venv/bin/ruff check src tests`
- `venv/bin/black --check src tests`

Hardware validation was not rerun for this diagnostics-only message severity change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified system diagnostic messaging when optional initialization files are unavailable, now providing informational feedback instead of warning-level alerts.
* **Tests**
  * Added unit tests validating diagnostic behavior when initialization files are present or missing, covering both required and optional scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->