### PR TITLE
feat: refine read-only diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,19 +94,15 @@ sudo bluetooth_2_usb uninstall
 
 ## Diagnostics
 
-For most issues, start with the two built-in diagnostics:
+Start with:
 
 ```bash
-sudo bluetooth_2_usb smoketest --verbose
+sudo bluetooth_2_usb smoketest
 sudo bluetooth_2_usb debug --duration 10
 ```
 
-The `smoketest` is the quick health gate. `debug` collects a fuller
-redacted snapshot and can run a short bounded foreground debug session. Debug
-reports are written under `/var/log/bluetooth_2_usb/` and are made copyable by
-the invoking sudo user when possible. If you need the next steps after those
-checks, use
-[TROUBLESHOOTING.md](TROUBLESHOOTING.md).
+Use `smoketest --verbose` or [TROUBLESHOOTING.md](TROUBLESHOOTING.md)
+when you need detailed probe output and interpretation.
 
 ## Runtime behavior
 
@@ -218,23 +214,24 @@ sudo bluetooth_2_usb uninstall
 
 ### `smoketest`
 
-Fast health check for the supported managed deployment. Use this first when you
-want to confirm that the service, gadget path, and Bluetooth basics are
-healthy.
+Run the managed deployment health check.
 
 ```bash
-sudo bluetooth_2_usb smoketest --verbose
+sudo bluetooth_2_usb smoketest
 ```
+
+Use `--verbose` for the full probe transcript.
 
 ### `debug`
 
-Collect a redacted diagnostics report and optionally run a bounded live
-foreground debug session. Use this when the `smoketest` is not enough or when
-you need a report to share.
+Write a redacted diagnostics report.
 
 ```bash
 sudo bluetooth_2_usb debug --duration DURATION_SEC
 ```
+
+See [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for what to collect and how to
+interpret it.
 
 ### `loopback inject`
 
@@ -299,8 +296,8 @@ sudo bluetooth_2_usb readonly setup --device DEVICE
 
 ### `readonly status`
 
-Show the configured and live read-only state, including OverlayFS, root
-filesystem, and persistent Bluetooth-state mount status.
+Show live read-only state, OverlayFS boot configuration, root filesystem, and
+Bluetooth-state storage status.
 
 ```bash
 bluetooth_2_usb readonly status
@@ -324,6 +321,17 @@ Bluetooth-state storage configuration available.
 sudo bluetooth_2_usb readonly disable
 ```
 
+### `readonly migrate`
+
+After disabling read-only mode and rebooting back to a writable root filesystem,
+move Bluetooth state back from persistent storage to rootfs. This disables and
+unmounts the managed persistent-state mounts, but intentionally leaves the old
+data on the persistent device intact as a rollback copy.
+
+```bash
+sudo bluetooth_2_usb readonly migrate
+```
+
 ## Managed paths
 
 | Path | Purpose |
@@ -331,7 +339,7 @@ sudo bluetooth_2_usb readonly disable
 | `/opt/bluetooth_2_usb` | Managed installation root |
 | `/opt/bluetooth_2_usb/venv` | Managed virtual environment |
 | `/etc/default/bluetooth_2_usb` | Structured runtime settings |
-| `/etc/default/bluetooth_2_usb_readonly` | Read-only configuration |
+| `/etc/default/bluetooth_2_usb_readonly` | Persistent Bluetooth state configuration |
 | `/var/log/bluetooth_2_usb` | Operational command and runtime diagnostic output |
 | `/mnt/b2u-persist` | Default persistent mount target |
 | `/mnt/b2u-persist/bluetooth` | Default persistent Bluetooth state directory |

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -4,12 +4,34 @@
 > Most troubleshooting sessions should start with the two built-in diagnostics:
 
 ```bash
-sudo bluetooth_2_usb smoketest --verbose
+sudo bluetooth_2_usb smoketest
 sudo bluetooth_2_usb debug --duration 10
 ```
 
-The `smoketest` is the quick health gate. `debug` gives you the fuller redacted
-snapshot when you need to understand what the runtime actually sees.
+## Diagnostics commands
+
+Use `smoketest` as the quick health gate:
+
+```bash
+sudo bluetooth_2_usb smoketest
+```
+
+Use verbose mode when you need the full probe transcript:
+
+```bash
+sudo bluetooth_2_usb smoketest --verbose
+```
+
+Use `debug` when you need a redacted report under
+`/var/log/bluetooth_2_usb/`:
+
+```bash
+sudo bluetooth_2_usb debug --duration 10
+```
+
+`debug` can also run a bounded foreground runtime session so the report
+includes what the service sees live. Reports are made copyable by the invoking
+sudo user when possible.
 
 If you want an end-to-end relay check without depending on a paired Bluetooth
 device, use the loopback inject/capture validation in

--- a/docs/cli-service-test.md
+++ b/docs/cli-service-test.md
@@ -85,6 +85,7 @@ ssh <pi-host> '
   PYTHONPATH=src python3 -m bluetooth_2_usb readonly status --help >/dev/null
   PYTHONPATH=src python3 -m bluetooth_2_usb readonly enable --help >/dev/null
   PYTHONPATH=src python3 -m bluetooth_2_usb readonly disable --help >/dev/null
+  PYTHONPATH=src python3 -m bluetooth_2_usb readonly migrate --help >/dev/null
   PYTHONPATH=src python3 -m bluetooth_2_usb readonly setup --help >/dev/null
 '
 ```
@@ -239,6 +240,10 @@ grep '^B2U_' /etc/default/bluetooth_2_usb_readonly
 EOF
 ```
 
+The read-only config file should contain only persistent Bluetooth state
+settings: `B2U_PERSIST_MOUNT`, `B2U_PERSIST_BLUETOOTH_DIR`,
+`B2U_PERSIST_SPEC`, and `B2U_PERSIST_DEVICE`.
+
 ## Pairing persistence across reboot
 
 Before reboot:
@@ -327,9 +332,29 @@ done
 ```
 
 > [!WARNING]
-> Only run destructive read-only rollback checks after disabling read-only mode
-> and rebooting, once `findmnt -no FSTYPE,SOURCE /` no longer shows `overlay`
-> for the live root filesystem.
+> Only run `readonly migrate` after disabling read-only mode and rebooting, once
+> `findmnt -no FSTYPE,SOURCE /` no longer shows `overlay` for the live root
+> filesystem.
+
+Optional Bluetooth state migration back to rootfs:
+
+```bash
+ssh <pi-host> 'sudo -n bluetooth_2_usb readonly migrate'
+ssh <pi-host> '
+  persist_unit="$(systemd-escape --path --suffix=mount /mnt/b2u-persist)"
+  bluetooth_2_usb readonly status
+  findmnt /var/lib/bluetooth || true
+  findmnt /mnt/b2u-persist || true
+  systemctl is-enabled var-lib-bluetooth.mount || true
+  systemctl is-enabled "$persist_unit" || true
+  systemctl is-active bluetooth_2_usb.service
+  bluetoothctl devices Paired
+'
+```
+
+`readonly migrate` disables and unmounts the managed persistent-state mounts.
+It preserves the old Bluetooth state on the persistent device as a rollback
+copy; wipe or reformat that device manually only when you intend to reuse it.
 
 ## Uninstall validation
 
@@ -359,7 +384,7 @@ ssh <pi-host> '
   uname -a
   cat /etc/os-release
   echo SERVICE=$(systemctl is-active bluetooth_2_usb.service || true)
-  echo READONLY=$(grep "^B2U_READONLY_MODE=" /etc/default/bluetooth_2_usb_readonly 2>/dev/null || echo disabled)
+  bluetooth_2_usb readonly status
   sudo -n journalctl -u bluetooth_2_usb.service -n 100 --no-pager || true
 '
 ```

--- a/docs/persistent-readonly.md
+++ b/docs/persistent-readonly.md
@@ -127,6 +127,7 @@ instead of leaving you with a half-configured read-only boot path.
 | `readonly status` | n/a | This command has no command-specific arguments. |
 | `readonly enable` | n/a | This command has no command-specific arguments. |
 | `readonly disable` | n/a | This command has no command-specific arguments. |
+| `readonly migrate` | n/a | This command has no command-specific arguments. |
 
 ## Disable read-only mode
 
@@ -135,6 +136,21 @@ bluetooth_2_usb readonly status
 sudo bluetooth_2_usb readonly disable
 sudo reboot
 ```
+
+`readonly disable` leaves Bluetooth state on the persistent storage mount. If
+you want to move Bluetooth state back to the root filesystem, reboot first so
+the root filesystem is writable, then run:
+
+```bash
+sudo bluetooth_2_usb readonly migrate
+```
+
+`readonly migrate` refuses to run while the root filesystem is still
+overlay-backed, because writes to rootfs would be discarded on the next reboot.
+When migration succeeds, the managed persistent-state mounts are disabled and
+unmounted. The old Bluetooth state on the persistent device is preserved; wipe
+or reformat that device manually only if you intentionally want to reuse it for
+something else.
 
 ## Validation
 

--- a/src/bluetooth_2_usb/ops/cli.py
+++ b/src/bluetooth_2_usb/ops/cli.py
@@ -11,7 +11,13 @@ from .deployment import install, uninstall, update
 from .diagnostics import SmokeTest, debug_report
 from .hid_udev_rule import install_hid_udev_rule
 from .paths import PATHS
-from .readonly import disable_readonly, enable_readonly, print_readonly_status, setup_persistent_bluetooth_state
+from .readonly import (
+    disable_readonly,
+    enable_readonly,
+    migrate_bluetooth_state_to_rootfs,
+    print_readonly_status,
+    setup_persistent_bluetooth_state,
+)
 
 OPERATIONAL_COMMANDS = frozenset({"install", "update", "uninstall", "smoketest", "debug", "readonly", "udev", "device"})
 
@@ -65,6 +71,7 @@ def _main(argv: list[str], *, prog: str) -> int:
     _command_parser(readonly_subparsers, "status", "Show read-only status.")
     _command_parser(readonly_subparsers, "enable", "Enable read-only mode.")
     _command_parser(readonly_subparsers, "disable", "Disable OverlayFS.")
+    _command_parser(readonly_subparsers, "migrate", "Move persistent Bluetooth state back to the root filesystem.")
 
     udev_parser = _command_parser(subparsers, "udev", "Manage host-side hidapi udev rules.")
     udev_subparsers = udev_parser.add_subparsers(dest="udev_command", required=True)
@@ -85,7 +92,7 @@ def _main(argv: list[str], *, prog: str) -> int:
         ensure_root()
 
     log_name = "_".join(command_path)
-    if command_path in {
+    prepare_command_log = command_path in {
         ("install",),
         ("update",),
         ("uninstall",),
@@ -94,7 +101,11 @@ def _main(argv: list[str], *, prog: str) -> int:
         ("readonly", "setup"),
         ("readonly", "enable"),
         ("readonly", "disable"),
-    }:
+        ("readonly", "migrate"),
+    }
+    if command_path == ("smoketest",) and namespace.output == "json":
+        prepare_command_log = False
+    if prepare_command_log:
         prepare_log(log_name)
 
     if command_path == ("install",):
@@ -107,7 +118,9 @@ def _main(argv: list[str], *, prog: str) -> int:
         smoke_test = SmokeTest(verbose=namespace.verbose)
         if namespace.output == "json":
             with redirect_stdout(sys.stderr):
+                prepare_log(log_name)
                 exit_code = smoke_test.run()
+                close_log()
             print(json.dumps(smoke_test.result_dict(), sort_keys=True))
         else:
             exit_code = smoke_test.run()
@@ -122,6 +135,8 @@ def _main(argv: list[str], *, prog: str) -> int:
         enable_readonly()
     elif command_path == ("readonly", "disable"):
         disable_readonly()
+    elif command_path == ("readonly", "migrate"):
+        migrate_bluetooth_state_to_rootfs()
     elif command_path == ("udev", "install"):
         ensure_root()
         repo_root = Path(namespace.repo_root).resolve() if namespace.repo_root else None

--- a/src/bluetooth_2_usb/ops/diagnostics/report.py
+++ b/src/bluetooth_2_usb/ops/diagnostics/report.py
@@ -21,6 +21,8 @@ from ..readonly import (
 )
 from .redaction import redact
 
+DEBUG_COMMAND_TIMEOUT_SECONDS = 20
+
 
 def debug_report(duration: int | None) -> int:
     PATHS.log_dir.mkdir(parents=True, exist_ok=True)
@@ -32,7 +34,7 @@ def debug_report(duration: int | None) -> int:
         readonly_config_error = ""
     except Exception as exc:
         config = None
-        readonly_config_error = f"Read-only config parse error: {exc}"
+        readonly_config_error = f"Persistent Bluetooth state config parse error: {exc}"
 
     def heading(title: str) -> None:
         body.append(f"## {title}\n")
@@ -41,23 +43,33 @@ def debug_report(duration: int | None) -> int:
         heading(title)
         body.append("```text\n" + redact(text or "<no output>", hostname) + "\n```\n")
 
-    def command_block(title: str, command: list[str | Path], timeout: int = 8) -> None:
+    def command_block(title: str, command: list[str | Path]) -> None:
         heading(title)
         try:
-            completed = run(command, check=False, capture=True, timeout=timeout)
+            completed = run(command, check=False, capture=True, timeout=DEBUG_COMMAND_TIMEOUT_SECONDS)
             text = completed.stdout + completed.stderr
             suffix = "" if completed.returncode == 0 else f"\n[command exited with status {completed.returncode}]"
         except (OSError, OpsError) as exc:
             text = str(exc)
-            suffix = "\n[command failed]"
+            suffix = (
+                f"\n[timed out after {DEBUG_COMMAND_TIMEOUT_SECONDS}s]"
+                if "timed out after" in text
+                else "\n[command failed]"
+            )
         except subprocess.TimeoutExpired as exc:
             text = ((exc.stdout or "") + (exc.stderr or "")) if isinstance(exc.stdout, str) else ""
-            suffix = f"\n[timed out after {timeout}s]"
+            suffix = f"\n[timed out after {DEBUG_COMMAND_TIMEOUT_SECONDS}s]"
         body.append("```console\n" + redact((text or "<no output>") + suffix, hostname) + "\n```\n")
 
     try:
         initial_service_state = (
-            run(["systemctl", "is-active", PATHS.service_unit], check=False, capture=True).stdout.strip() or "unknown"
+            run(
+                ["systemctl", "is-active", PATHS.service_unit],
+                check=False,
+                capture=True,
+                timeout=DEBUG_COMMAND_TIMEOUT_SECONDS,
+            ).stdout.strip()
+            or "unknown"
         )
     except (OpsError, OSError):
         initial_service_state = "unknown"
@@ -82,11 +94,11 @@ def debug_report(duration: int | None) -> int:
             if line
         ),
     )
-    command_block("Kernel", ["uname", "-a"], 5)
+    command_block("Kernel", ["uname", "-a"])
     command_block(
-        "OS release", ["bash", "-lc", "grep -E '^(PRETTY_NAME|ID|VERSION|VERSION_CODENAME)=' /etc/os-release"], 5
+        "OS release", ["bash", "-lc", "grep -E '^(PRETTY_NAME|ID|VERSION|VERSION_CODENAME)=' /etc/os-release"]
     )
-    command_block("Hardware model", ["bash", "-lc", "tr -d '\\0' </proc/device-tree/model 2>/dev/null || true"], 5)
+    command_block("Hardware model", ["bash", "-lc", "tr -d '\\0' </proc/device-tree/model 2>/dev/null || true"])
     command_block(
         "config.txt dwc2 lines",
         [
@@ -94,10 +106,9 @@ def debug_report(duration: int | None) -> int:
             "-lc",
             f"grep -nE '^\\[all\\]|dtoverlay=dwc2.*' '{boot_config.boot_config_path()}' 2>/dev/null || true",
         ],
-        5,
     )
-    command_block("cmdline.txt", ["cat", boot_config.boot_cmdline_path()], 5)
-    command_block("UDC controllers", ["ls", "/sys/class/udc"], 5)
+    command_block("cmdline.txt", ["cat", boot_config.boot_cmdline_path()])
+    command_block("UDC controllers", ["ls", "/sys/class/udc"])
     command_block(
         "USB gadget identity",
         [
@@ -108,38 +119,33 @@ def debug_report(duration: int | None) -> int:
             + "test -f /var/lib/bluetooth_2_usb/usb_identity.json && "
             + "printf 'state=' && cat /var/lib/bluetooth_2_usb/usb_identity.json || true",
         ],
-        5,
     )
-    command_block("Overlay and tmpfs mounts", ["findmnt", "-t", "overlay,tmpfs"], 5)
-    command_block("Bluetooth state mount", ["findmnt", "-n", "-T", "/var/lib/bluetooth"], 5)
+    command_block("Overlay and tmpfs mounts", ["findmnt", "-t", "overlay,tmpfs"])
+    command_block("Bluetooth state mount", ["findmnt", "-n", "-T", "/var/lib/bluetooth"])
     if config is not None:
-        command_block("Persistent state storage mount", ["findmnt", "-n", config.persist_mount], 5)
+        command_block("Persistent state storage mount", ["findmnt", "-n", config.persist_mount])
     if PATHS.readonly_env_file.is_file():
-        command_block("Read-only environment file", ["cat", PATHS.readonly_env_file], 5)
-    command_block("Service status", ["systemctl", "--no-pager", "--full", "status", PATHS.service_unit], 8)
-    command_block(
-        "Recent service journal", ["journalctl", "-b", "-u", PATHS.service_unit, "-n", "200", "--no-pager"], 8
-    )
-    command_block("bluetooth.service status", ["systemctl", "--no-pager", "--full", "status", "bluetooth.service"], 8)
+        command_block("Persistent Bluetooth state config", ["cat", PATHS.readonly_env_file])
+    command_block("Service status", ["systemctl", "--no-pager", "--full", "status", PATHS.service_unit])
+    command_block("Recent service journal", ["journalctl", "-b", "-u", PATHS.service_unit, "-n", "200", "--no-pager"])
+    command_block("bluetooth.service status", ["systemctl", "--no-pager", "--full", "status", "bluetooth.service"])
     command_block(
         "Relevant kernel log lines",
         ["bash", "-lc", "dmesg | grep -Ei 'dwc2|gadget|udc|bluetooth|overlay' | tail -200 || true"],
-        8,
     )
-    command_block("bluetoothctl show", ["bluetoothctl", "show"], 8)
-    command_block("Paired devices", ["bluetoothctl", "devices", "Paired"], 8)
-    command_block("btmgmt info", ["btmgmt", "info"], 8)
+    command_block("bluetoothctl show", ["bluetoothctl", "show"])
+    command_block("Paired devices", ["bluetoothctl", "devices", "Paired"])
+    command_block("btmgmt info", ["btmgmt", "info"])
     text_block("rfkill bluetooth state", rfkill_list_bluetooth())
     if PATHS.venv_python.exists():
-        command_block("CLI version", [PATHS.venv_python, "-m", "bluetooth_2_usb", "--version"], 5)
-        command_block("CLI environment validation", [PATHS.venv_python, "-m", "bluetooth_2_usb", "--validate-env"], 5)
+        command_block("CLI version", [PATHS.venv_python, "-m", "bluetooth_2_usb", "--version"])
+        command_block("CLI environment validation", [PATHS.venv_python, "-m", "bluetooth_2_usb", "--validate-env"])
         command_block(
             "Service settings summary",
             [PATHS.venv_python, "-m", "bluetooth_2_usb.service_settings", "--print-summary-json"],
-            5,
         )
         command_block(
-            "Device inventory (json)", [PATHS.venv_python, "-m", "bluetooth_2_usb", "--list", "--output", "json"], 8
+            "Device inventory (json)", [PATHS.venv_python, "-m", "bluetooth_2_usb", "--list", "--output", "json"]
         )
         try:
             debug_command = run(
@@ -152,7 +158,7 @@ def debug_report(duration: int | None) -> int:
                 ],
                 check=False,
                 capture=True,
-                timeout=5,
+                timeout=DEBUG_COMMAND_TIMEOUT_SECONDS,
             ).stdout.strip()
         except (OSError, OpsError, subprocess.TimeoutExpired):
             debug_command = ""
@@ -176,8 +182,17 @@ def debug_report(duration: int | None) -> int:
 
 def _run_live_debug(command: str, duration: int | None, hostname: str) -> str:
     stopped_service = False
-    if run(["systemctl", "is-active", "--quiet", PATHS.service_unit], check=False).returncode == 0:
-        stop = run(["systemctl", "stop", PATHS.service_unit], check=False, capture=True)
+    if (
+        run(
+            ["systemctl", "is-active", "--quiet", PATHS.service_unit],
+            check=False,
+            timeout=DEBUG_COMMAND_TIMEOUT_SECONDS,
+        ).returncode
+        == 0
+    ):
+        stop = run(
+            ["systemctl", "stop", PATHS.service_unit], check=False, capture=True, timeout=DEBUG_COMMAND_TIMEOUT_SECONDS
+        )
         if stop.returncode != 0:
             output_text = stop.stdout + stop.stderr
             return redact(
@@ -204,7 +219,12 @@ def _run_live_debug(command: str, duration: int | None, hostname: str) -> str:
             debug_output = output_file.read()
     finally:
         if stopped_service:
-            start = run(["systemctl", "start", PATHS.service_unit], check=False, capture=True)
+            start = run(
+                ["systemctl", "start", PATHS.service_unit],
+                check=False,
+                capture=True,
+                timeout=DEBUG_COMMAND_TIMEOUT_SECONDS,
+            )
             if start.returncode != 0:
                 debug_output += (
                     "\n[failed to restart bluetooth_2_usb.service: "

--- a/src/bluetooth_2_usb/ops/diagnostics/smoketest.py
+++ b/src/bluetooth_2_usb/ops/diagnostics/smoketest.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import json
 import os
+import sys
+from contextlib import contextmanager
 from pathlib import Path
+
+from rich.console import Console
 
 from .. import boot_config
 from ..bluetooth import (
@@ -14,8 +18,16 @@ from ..bluetooth import (
 from ..commands import OpsError, bold, fail_final, info, ok, ok_final, run, warn
 from ..commands import warn_fail as red_warn
 from ..paths import PATHS
-from ..readonly import bluetooth_state_persistent, display_readonly_mode, overlay_status, readonly_mode
+from ..readonly import (
+    bluetooth_state_persistent,
+    bluetooth_state_storage,
+    display_readonly_mode,
+    overlay_status,
+    readonly_mode,
+)
 from .types import ProbeResult, ProbeStatus
+
+SMOKETEST_COMMAND_TIMEOUT_SECONDS = 20
 
 
 class SmokeTest:
@@ -27,6 +39,8 @@ class SmokeTest:
         self.summary: dict[str, str] = {}
         self.summary_groups: list[tuple[str, list[tuple[str, str]]]] = []
         self.results: list[ProbeResult] = []
+        self.current_section = ""
+        self.section_statuses: dict[str, ProbeStatus] = {}
 
     def run(self) -> int:
         config_txt = boot_config.boot_config_path()
@@ -45,6 +59,7 @@ class SmokeTest:
         if root_filesystem_type == "unknown":
             root_overlay_active = "unknown"
         bluetooth_persistent = bluetooth_state_persistent()
+        bluetooth_storage = bluetooth_state_storage()
         expected_initramfs_file = boot_config.expected_boot_initramfs_file()
         expected_initramfs_path = (
             str(boot_config.boot_initramfs_target_path(expected_initramfs_file)) if expected_initramfs_file else ""
@@ -66,7 +81,7 @@ class SmokeTest:
         if udc_states:
             configured_udcs = [name for name, state in udc_states.items() if state == "configured"]
             if configured_udcs:
-                ok("UDC state is configured (" + ", ".join(configured_udcs) + ")")
+                self.pass_probe("UDC state is configured (" + ", ".join(configured_udcs) + ")")
             else:
                 self.soft_warn(
                     "UDC is not configured; relay output is gated until the host attaches. "
@@ -87,15 +102,17 @@ class SmokeTest:
         venv_present = PATHS.venv_python.is_file()
         self._path_exists(PATHS.venv_python, "Virtualenv interpreter is present", "Virtualenv interpreter is missing")
         if venv_present:
-            validate_log = self._capture([PATHS.venv_python, "-m", "bluetooth_2_usb", "--validate-env"])
+            validate_log = self._capture_with_status(
+                [PATHS.venv_python, "-m", "bluetooth_2_usb", "--validate-env"], "Validating CLI environment"
+            )
             self.record_bool(
                 validate_log[0] == 0,
                 "CLI environment validation passed",
                 "CLI environment validation failed",
                 validate_log[1],
             )
-            service_settings_log = self._capture(
-                [PATHS.venv_python, "-m", "bluetooth_2_usb.service_settings", "--check"]
+            service_settings_log = self._capture_with_status(
+                [PATHS.venv_python, "-m", "bluetooth_2_usb.service_settings", "--check"], "Checking runtime settings"
             )
             self.record_bool(
                 service_settings_log[0] == 0,
@@ -113,14 +130,14 @@ class SmokeTest:
             "bluetooth.service is not active",
         )
         self._heading("Bluetooth")
-        bt_show = self._capture(["bluetoothctl", "show"])
+        bt_show = self._capture_with_status(["bluetoothctl", "show"], "Checking Bluetooth controller")
         self.record_bool(
             bt_show[0] == 0 and bluetooth_controller_powered_from_text(bt_show[1]),
             "Bluetooth controller is powered",
             "bluetoothctl show failed or controller is not powered",
             bt_show[1],
         )
-        btmgmt = self._capture(["btmgmt", "info"])
+        btmgmt = self._capture_with_status(["btmgmt", "info"], "Checking Bluetooth management state")
         self.record_bool(btmgmt[0] == 0, "btmgmt info succeeded", "btmgmt info failed", btmgmt[1])
         entries = bluetooth_rfkill_entries()
         if entries:
@@ -136,7 +153,9 @@ class SmokeTest:
             self.soft_warn("No bluetooth rfkill entries found")
         self._heading("Devices")
         inventory = (
-            self._capture([PATHS.venv_python, "-m", "bluetooth_2_usb", "--list", "--output", "json"])
+            self._capture_with_status(
+                [PATHS.venv_python, "-m", "bluetooth_2_usb", "--list", "--output", "json"], "Checking input devices"
+            )
             if venv_present
             else (127, missing_venv)
         )
@@ -148,7 +167,10 @@ class SmokeTest:
         self._heading("Read-Only Mode")
         self._check_overlay_runtime(overlay, root_overlay_active, post_reboot)
         self._check_initramfs(overlay, root_overlay_active, readonly, expected_initramfs_path)
-        self._check_readonly(readonly, overlay, root_overlay_active, bluetooth_persistent, post_reboot)
+        self._check_readonly(
+            readonly, overlay, root_overlay_active, bluetooth_persistent, bluetooth_storage, post_reboot
+        )
+        self._print_readonly_summary(readonly, overlay, root_overlay_active, bluetooth_storage)
 
         self.summary_groups = [
             (
@@ -178,11 +200,20 @@ class SmokeTest:
             (
                 "Read-Only Mode",
                 [
-                    ("Read-only mode", display_readonly_mode(readonly)),
-                    ("OverlayFS configured", overlay),
+                    ("Read-only state", display_readonly_mode(readonly)),
+                    ("OverlayFS boot setting", overlay),
                     ("Root filesystem type", root_filesystem_type),
-                    ("Root overlay active", root_overlay_active),
-                    ("Bluetooth persistent mount", "mounted" if bluetooth_persistent else "not mounted"),
+                    (
+                        "Root source",
+                        self._capture(["findmnt", "-n", "-o", "SOURCE", "--target", "/"])[1].strip() or "<unknown>",
+                    ),
+                    ("Bluetooth state storage", bluetooth_storage),
+                    (
+                        "Bluetooth state source",
+                        self._capture(["findmnt", "-n", "-o", "SOURCE", "--target", "/var/lib/bluetooth"])[1].strip()
+                        or "<none>",
+                    ),
+                    ("Persistent storage mount", "mounted" if bluetooth_persistent else "not mounted"),
                 ],
             ),
             ("Result", [("Non-fatal warning count", str(self.soft_warnings))]),
@@ -218,7 +249,7 @@ class SmokeTest:
             config_txt.is_file()
             and expected_overlay in config_txt.read_text(encoding="utf-8", errors="replace").splitlines()
         ):
-            ok(f"config.txt contains expected overlay ({expected_overlay})")
+            self.pass_probe(f"config.txt contains expected overlay ({expected_overlay})")
         else:
             self.warn_fail(f"config.txt is missing expected overlay ({expected_overlay})")
 
@@ -230,36 +261,36 @@ class SmokeTest:
                 f"cmdline.txt is missing required modules ({','.join(required)}); current value: {token or '<missing>'}"
             )
         else:
-            ok(f"cmdline.txt contains required modules-load ({token or '<missing>'})")
+            self.pass_probe(f"cmdline.txt contains required modules-load ({token or '<missing>'})")
 
     def _check_overlay_runtime(self, overlay: str, root_overlay_active: str, post_reboot: bool) -> None:
         if overlay in {"enabled", "disabled"}:
-            ok(f"OverlayFS boot configuration is {overlay}")
+            self.pass_probe(f"OverlayFS boot setting is {overlay}")
         else:
             (
-                self.soft_warn("OverlayFS boot configuration status is unknown")
+                self.soft_warn("OverlayFS boot setting is unknown")
                 if self.allow_non_pi
-                else self.warn_fail("OverlayFS boot configuration status is unknown")
+                else self.warn_fail("OverlayFS boot setting is unknown")
             )
         if root_overlay_active == "yes":
-            ok("Root overlay is active")
+            self.pass_probe("Root filesystem is overlay-backed")
         elif root_overlay_active == "unknown":
             (
-                self.soft_warn("Could not determine whether the root overlay is active")
+                self.soft_warn("Could not determine root filesystem read-only state")
                 if self.allow_non_pi or (overlay == "enabled" and not post_reboot)
-                else self.warn_fail("Could not determine whether the root overlay is active")
+                else self.warn_fail("Could not determine root filesystem read-only state")
             )
             report = boot_config.root_overlay_report()
             if report:
                 print(report)
         elif overlay == "enabled":
             (
-                self.warn_fail("Root overlay is not active")
+                self.warn_fail("Root filesystem is not overlay-backed")
                 if post_reboot
-                else self.soft_warn("Root overlay is not active; reboot may still be pending")
+                else self.soft_warn("Read-only mode enablement is pending reboot")
             )
         else:
-            ok("Root overlay is inactive")
+            self.pass_probe("Root filesystem is writable")
 
     def _check_initramfs(self, overlay: str, root_overlay_active: str, readonly: str, expected_path: str) -> None:
         should_require = overlay == "enabled" or root_overlay_active == "yes" or readonly == "enabled"
@@ -270,27 +301,33 @@ class SmokeTest:
         path = Path(expected_path)
         present = path.is_file() and path.stat().st_size > 0
         if present:
-            ok(f"Boot initramfs is present ({path})")
+            self.pass_probe(f"Boot initramfs is present ({path})")
         elif should_require:
             self.warn_fail(f"Boot initramfs is missing or empty ({path})")
         else:
             info(f"Boot initramfs is not present yet ({path})")
 
     def _check_readonly(
-        self, readonly: str, overlay: str, root_overlay_active: str, bluetooth_persistent: bool, post_reboot: bool
+        self,
+        readonly: str,
+        overlay: str,
+        root_overlay_active: str,
+        bluetooth_persistent: bool,
+        bluetooth_storage: str,
+        post_reboot: bool,
     ) -> None:
-        if bluetooth_persistent:
-            ok(
-                "Bluetooth persistent mount is mounted"
-                if readonly == "enabled"
-                else "Bluetooth persistent mount is active"
-            )
+        if bluetooth_storage == "persistent":
+            self.pass_probe("Bluetooth state is stored on persistent storage")
+        elif bluetooth_storage == "rootfs":
+            self.pass_probe("Bluetooth state is stored on rootfs")
         elif overlay == "enabled" or readonly == "enabled":
-            self.warn_fail("Bluetooth persistent mount is not mounted")
+            self.warn_fail("Bluetooth persistent state is required but not mounted")
+        elif bluetooth_storage == "missing":
+            self.warn_fail("Bluetooth state directory is missing")
         else:
-            ok("Bluetooth persistent mount is not configured")
+            self.soft_warn("Bluetooth state storage could not be determined")
         if readonly == "enabled":
-            ok("Read-only mode is enabled")
+            self.pass_probe("Read-only mode is active")
         elif readonly == "unknown":
             (
                 self.soft_warn("Read-only mode could not be determined")
@@ -298,15 +335,15 @@ class SmokeTest:
                 else self.warn_fail("Read-only mode could not be determined")
             )
         elif overlay == "disabled" and root_overlay_active == "no":
-            ok("Read-only mode is disabled")
+            self.pass_probe("Read-only mode is disabled")
         elif overlay == "enabled" and root_overlay_active == "no":
             (
-                self.warn_fail("Read-only mode is not enabled")
+                self.warn_fail("Read-only mode is not active")
                 if post_reboot
-                else self.soft_warn("Read-only mode is not enabled")
+                else self.soft_warn("Read-only mode enablement is pending reboot")
             )
         else:
-            self.warn_fail("Read-only mode is not enabled")
+            self.warn_fail("Read-only mode is not active")
 
     def _relayable_count(self, inventory: tuple[int, str]) -> int:
         if inventory[0] != 0:
@@ -319,7 +356,7 @@ class SmokeTest:
             self.warn_fail("Failed to parse relayable device inventory", inventory[1])
             return 0
         if count:
-            ok(f"Relayable input devices detected ({count})")
+            self.pass_probe(f"Relayable input devices detected ({count})", visible=True)
         else:
             self.soft_warn("No relayable input devices detected")
         return count
@@ -331,38 +368,44 @@ class SmokeTest:
             self.warn_fail("bluetoothctl failed while listing paired devices")
             return 0
         if count:
-            ok(f"Paired Bluetooth devices detected ({count})")
+            self.pass_probe(f"Paired Bluetooth devices detected ({count})", visible=True)
         else:
             self.soft_warn("No paired Bluetooth devices detected")
         return count
 
-    def _path_exists(self, path: Path, success: str, failure: str) -> None:
-        self.record_bool(path.exists(), success, failure)
+    def _path_exists(self, path: Path, success: str, failure: str, *, visible: bool = False) -> None:
+        self.record_bool(path.exists(), success, failure, visible=visible)
 
-    def _command_ok(self, command: list[str], success: str, failure: str) -> None:
+    def _command_ok(self, command: list[str], success: str, failure: str, *, visible: bool = False) -> None:
         try:
-            completed = run(command, check=False, capture=True)
+            completed = run(command, check=False, capture=True, timeout=SMOKETEST_COMMAND_TIMEOUT_SECONDS)
         except (FileNotFoundError, OpsError) as exc:
             self.warn_fail(failure, str(exc))
             return
-        self.record_bool(completed.returncode == 0, success, failure)
+        self.record_bool(completed.returncode == 0, success, failure, visible=visible)
 
-    def record_bool(self, condition: bool, success: str, failure: str, detail: str = "") -> None:
+    def record_bool(
+        self, condition: bool, success: str, failure: str, detail: str = "", *, visible: bool = False
+    ) -> None:
         if condition:
-            self.pass_probe(success, detail)
+            self.pass_probe(success, detail, visible=visible)
         else:
             self.warn_fail(failure, detail)
 
-    def pass_probe(self, message: str, detail: str = "") -> None:
-        ok(message)
+    def pass_probe(self, message: str, detail: str = "", *, visible: bool = False) -> None:
+        self._mark_section(ProbeStatus.PASS)
+        if self.verbose or visible:
+            ok(message)
         self.results.append(ProbeResult(ProbeStatus.PASS, message, detail))
 
     def soft_warn(self, message: str) -> None:
+        self._mark_section(ProbeStatus.WARN)
         warn(message)
         self.soft_warnings += 1
         self.results.append(ProbeResult(ProbeStatus.WARN, message))
 
     def warn_fail(self, message: str, detail: str = "") -> None:
+        self._mark_section(ProbeStatus.FAIL)
         red_warn(message)
         if detail:
             print("\n".join(detail.splitlines()[:20]))
@@ -371,14 +414,54 @@ class SmokeTest:
 
     def _capture(self, command: list[str | Path]) -> tuple[int, str]:
         try:
-            completed = run(command, check=False, capture=True)
+            completed = run(command, check=False, capture=True, timeout=SMOKETEST_COMMAND_TIMEOUT_SECONDS)
         except (FileNotFoundError, OpsError) as exc:
             return 127, str(exc)
         return completed.returncode, (completed.stdout + completed.stderr)
 
+    def _capture_with_status(self, command: list[str | Path], message: str) -> tuple[int, str]:
+        with self._status(message):
+            return self._capture(command)
+
+    @contextmanager
+    def _status(self, message: str):
+        if self.verbose:
+            yield
+            return
+        with Console(file=sys.stdout).status(message, spinner="dots"):
+            yield
+
     def _heading(self, title: str) -> None:
+        if self.current_section:
+            self._finish_section(self.current_section)
+        self.current_section = title
+        self.section_statuses.setdefault(title, ProbeStatus.PASS)
         print()
         print(bold(title))
+
+    def _finish_section(self, title: str) -> None:
+        if self.verbose or self.section_statuses.get(title) is not ProbeStatus.PASS:
+            return
+        if title in {"Boot and USB", "Service and Runtime", "Bluetooth"}:
+            ok("All checks passed")
+
+    def _mark_section(self, status: ProbeStatus) -> None:
+        if not self.current_section:
+            return
+        current = self.section_statuses.get(self.current_section, ProbeStatus.PASS)
+        if current is ProbeStatus.FAIL:
+            return
+        if status is ProbeStatus.FAIL or current is ProbeStatus.PASS:
+            self.section_statuses[self.current_section] = status
+
+    def _print_readonly_summary(
+        self, readonly: str, overlay: str, root_overlay_active: str, bluetooth_storage: str
+    ) -> None:
+        if self.verbose or self.section_statuses.get("Read-Only Mode") is ProbeStatus.FAIL:
+            return
+        self.pass_probe(
+            _readonly_summary_message(readonly, overlay, root_overlay_active, bluetooth_storage), visible=True
+        )
 
     def _print_verbose(self, rfkill_entries, *logs: tuple[int, str]) -> None:
         print("\n## Details")
@@ -399,13 +482,28 @@ class SmokeTest:
         print("\n## rfkill bluetooth")
         print("\n".join(entry.line() for entry in rfkill_entries) or "<no output>")
         print("\n## Mount details")
-        print(self._capture(["findmnt", "-n", "-T", "/"])[1] or "<no output>")
-        print(self._capture(["findmnt", "-n", "-T", "/var/lib/bluetooth"])[1] or "<no output>")
+        print(
+            self._capture_with_status(["findmnt", "-n", "-T", "/"], "Collecting root mount details")[1] or "<no output>"
+        )
+        print(
+            self._capture_with_status(
+                ["findmnt", "-n", "-T", "/var/lib/bluetooth"], "Collecting Bluetooth mount details"
+            )[1]
+            or "<no output>"
+        )
         print("\n## Service status")
-        print(self._capture(["systemctl", "--no-pager", "--full", "status", PATHS.service_unit])[1] or "<no output>")
+        print(
+            self._capture_with_status(
+                ["systemctl", "--no-pager", "--full", "status", PATHS.service_unit], "Collecting service status"
+            )[1]
+            or "<no output>"
+        )
         print("\n## Journal")
         print(
-            self._capture(["journalctl", "-b", "-u", PATHS.service_unit, "-n", "100", "--no-pager"])[1] or "<no output>"
+            self._capture_with_status(
+                ["journalctl", "-b", "-u", PATHS.service_unit, "-n", "100", "--no-pager"], "Collecting service journal"
+            )[1]
+            or "<no output>"
         )
 
 
@@ -444,6 +542,25 @@ def _usb_gadget_identity() -> str:
         if values:
             return f"{gadget_root.name}: " + ", ".join(values)
     return "<none>"
+
+
+def _readonly_summary_message(readonly: str, overlay: str, root_overlay_active: str, bluetooth_storage: str) -> str:
+    root_text = {"yes": "overlay root active", "no": "rootfs writable", "unknown": "root filesystem state unknown"}.get(
+        root_overlay_active, "root filesystem state unknown"
+    )
+    storage_text = {
+        "persistent": "Bluetooth state on persistent storage",
+        "rootfs": "Bluetooth state on rootfs",
+        "missing": "Bluetooth state missing",
+        "unknown": "Bluetooth state unknown",
+    }.get(bluetooth_storage, "Bluetooth state unknown")
+    if overlay == "enabled" and root_overlay_active == "no":
+        state = "pending reboot"
+    elif readonly in {"enabled", "disabled"}:
+        state = readonly
+    else:
+        state = "unknown"
+    return f"{state}: {root_text}, {storage_text}"
 
 
 def _try(func, default: str = "") -> str:

--- a/src/bluetooth_2_usb/ops/readonly/__init__.py
+++ b/src/bluetooth_2_usb/ops/readonly/__init__.py
@@ -5,6 +5,7 @@ from .service import restart_b2u_if_installed, stop_b2u_if_installed
 from .status import (
     READONLY_PACKAGES,
     bluetooth_state_persistent,
+    bluetooth_state_storage,
     display_readonly_mode,
     machine_id_valid,
     overlay_configured_status,
@@ -25,7 +26,12 @@ from .units import (
     write_bluetooth_bind_mount_unit,
     write_persist_mount_unit,
 )
-from .workflows import disable_readonly, enable_readonly, setup_persistent_bluetooth_state
+from .workflows import (
+    disable_readonly,
+    enable_readonly,
+    migrate_bluetooth_state_to_rootfs,
+    setup_persistent_bluetooth_state,
+)
 
 __all__ = [
     "READONLY_PACKAGES",
@@ -33,12 +39,14 @@ __all__ = [
     "restart_b2u_if_installed",
     "stop_b2u_if_installed",
     "bluetooth_state_persistent",
+    "bluetooth_state_storage",
     "disable_readonly",
     "enable_readonly",
     "display_readonly_mode",
     "install_bluetooth_persist_dropin",
     "load_readonly_config",
     "machine_id_valid",
+    "migrate_bluetooth_state_to_rootfs",
     "overlay_configured_status",
     "overlay_status",
     "package_status",

--- a/src/bluetooth_2_usb/ops/readonly/config.py
+++ b/src/bluetooth_2_usb/ops/readonly/config.py
@@ -10,7 +10,6 @@ from ..paths import PATHS
 
 @dataclass(slots=True)
 class ReadonlyConfig:
-    mode: str = "disabled"
     persist_mount: Path = PATHS.persist_mount
     persist_bluetooth_dir: Path = PATHS.default_persist_bluetooth_dir
     persist_spec: str = ""
@@ -52,12 +51,7 @@ def load_readonly_config(path: Path = PATHS.readonly_env_file) -> ReadonlyConfig
         path,
     )
 
-    mode = _normalize_readonly_mode(values.get("B2U_READONLY_MODE", "disabled"))
-    if mode not in {"enabled", "disabled"}:
-        fail(f"Refusing to load invalid B2U_READONLY_MODE from {path}: {mode}")
-
     return ReadonlyConfig(
-        mode=mode,
         persist_mount=persist_mount,
         persist_bluetooth_dir=persist_bluetooth_dir,
         persist_spec=values.get("B2U_PERSIST_SPEC", ""),
@@ -74,20 +68,10 @@ def _required_absolute_path(raw_value: str, key: str, config_path: Path) -> Path
     return value
 
 
-def _normalize_readonly_mode(mode: str) -> str:
-    if mode == "persistent":
-        return "enabled"
-    return mode
-
-
 def write_readonly_config(config: ReadonlyConfig, path: Path = PATHS.readonly_env_file) -> None:
-    mode = _normalize_readonly_mode(config.mode)
-    if mode not in {"enabled", "disabled"}:
-        fail(f"Refusing to write invalid B2U_READONLY_MODE to {path}: {config.mode}")
     path.write_text(
         "\n".join(
             [
-                f'B2U_READONLY_MODE="{mode}"',
                 f'B2U_PERSIST_MOUNT="{config.persist_mount}"',
                 f'B2U_PERSIST_BLUETOOTH_DIR="{config.persist_bluetooth_dir}"',
                 f'B2U_PERSIST_SPEC="{config.persist_spec}"',

--- a/src/bluetooth_2_usb/ops/readonly/status.py
+++ b/src/bluetooth_2_usb/ops/readonly/status.py
@@ -113,7 +113,7 @@ def readonly_mode() -> str:
         root_fstype = current_root_filesystem_type()
     except Exception:
         return "unknown"
-    if root_fstype == "overlay" and bluetooth_state_persistent():
+    if root_fstype == "overlay":
         return "enabled"
     return "disabled"
 
@@ -122,21 +122,43 @@ def display_readonly_mode(mode: str) -> str:
     return mode
 
 
+def bluetooth_state_storage(config: ReadonlyConfig | None = None) -> str:
+    resolved = config
+    if resolved is None:
+        try:
+            resolved = load_readonly_config()
+        except Exception as exc:
+            logger.warning("Unable to read read-only configuration: %s", exc)
+            resolved = None
+    state_dir = Path("/var/lib/bluetooth")
+    if not state_dir.exists():
+        return "missing"
+    if resolved is not None and bluetooth_state_persistent(resolved):
+        return "persistent"
+    try:
+        if run(["mountpoint", "-q", state_dir], check=False).returncode == 0:
+            return "unknown"
+    except (FileNotFoundError, OpsError, OSError):
+        return "unknown"
+    return "rootfs"
+
+
 def print_readonly_status() -> None:
     config = _load_readonly_config_or_default()
+    state_storage = bluetooth_state_storage(config)
     print("Read-only status")
     print(f"read-only mode: {display_readonly_mode(readonly_mode())}")
-    print(f"configured read-only mode: {display_readonly_mode(config.mode)}")
     print(f"overlay_live: {overlay_status()}")
     print(f"overlay_configured: {overlay_configured_status()}")
     print(f"root_filesystem: {_root_filesystem_type()}")
     print(f"root_source: {_findmnt_value('/', 'SOURCE') or '<unknown>'}")
-    print(f"bluetooth persistent mount: {'mounted' if bluetooth_state_persistent(config) else 'not mounted'}")
+    print(f"bluetooth state storage: {state_storage}")
     print(f"bluetooth_state_source: {_findmnt_value('/var/lib/bluetooth', 'SOURCE') or '<none>'}")
     print(f"persist_mount: {config.persist_mount}")
     print(f"persist_mount_active: {'yes' if _mountpoint(config.persist_mount) else 'no'}")
     print(f"persist_device: {config.persist_device or '<unset>'}")
     print(f"persist_spec: {config.persist_spec or '<unset>'}")
+    print(f"migration available: {'yes' if readonly_mode() == 'disabled' and state_storage == 'persistent' else 'no'}")
 
 
 def _root_filesystem_type() -> str:

--- a/src/bluetooth_2_usb/ops/readonly/workflows.py
+++ b/src/bluetooth_2_usb/ops/readonly/workflows.py
@@ -11,11 +11,12 @@ from ..boot_config import (
     configured_initramfs_file,
     configured_kernel_image,
     current_kernel_release,
+    current_root_filesystem_type,
     ensure_bootable_initramfs_for_current_kernel,
     expected_boot_initramfs_file,
     versioned_initrd_candidates,
 )
-from ..commands import backup_file, fail, info, ok, output, require_commands, run, warn
+from ..commands import OpsError, backup_file, fail, info, ok, output, require_commands, run, warn
 from .config import ReadonlyConfig, load_readonly_config, write_readonly_config
 from .service import _systemctl_active, restart_b2u_if_installed, stop_b2u_if_installed
 from .status import (
@@ -30,6 +31,9 @@ from .status import (
 from .units import (
     install_bluetooth_persist_dropin,
     persist_spec_from_device,
+    remove_bluetooth_bind_mount_unit,
+    remove_bluetooth_persist_dropin,
+    remove_persist_mount_unit,
     write_bluetooth_bind_mount_unit,
     write_persist_mount_unit,
 )
@@ -73,7 +77,6 @@ def setup_persistent_bluetooth_state(device: str) -> None:
     install_bluetooth_persist_dropin()
     write_readonly_config(
         ReadonlyConfig(
-            mode="disabled",
             persist_mount=persist_mount,
             persist_bluetooth_dir=persist_bluetooth_dir,
             persist_spec=persist_spec,
@@ -290,8 +293,6 @@ def enable_readonly() -> None:
                 )
             else:
                 fail("OverlayFS is still not configured after raspi-config completed.")
-        config.mode = "enabled"
-        write_readonly_config(config)
     except Exception:
         warn(
             "OverlayFS was requested but validation did not complete. "
@@ -309,9 +310,73 @@ def enable_readonly() -> None:
 
 def disable_readonly() -> None:
     require_commands(["raspi-config"])
-    config = load_readonly_config()
     run(["raspi-config", "nonint", "disable_overlayfs"])
-    config.mode = "disabled"
-    write_readonly_config(config)
     ok("OverlayFS has been disabled")
-    warn("Persistent Bluetooth state mount configuration was kept. Reboot to return to a writable root filesystem.")
+    warn("Persistent Bluetooth state mount configuration was kept.")
+    warn("Reboot to return to a writable root filesystem.")
+    warn(
+        "After reboot, run `sudo bluetooth_2_usb readonly migrate` if you want to move Bluetooth state back to rootfs."
+    )
+
+
+def migrate_bluetooth_state_to_rootfs() -> None:
+    require_commands(["findmnt", "mountpoint", "systemctl", "systemd-escape", "umount"])
+    config = load_readonly_config()
+    root_fstype = current_root_filesystem_type()
+    if root_fstype == "overlay":
+        fail(
+            "Refusing to migrate Bluetooth state while the root filesystem is overlay-backed. "
+            + "Reboot after disabling read-only mode first."
+        )
+    if not bluetooth_state_persistent(config):
+        fail("Persistent Bluetooth state is not mounted at /var/lib/bluetooth; nothing to migrate.")
+    if not config.persist_bluetooth_dir.is_dir():
+        fail(f"Persistent Bluetooth state directory is missing: {config.persist_bluetooth_dir}")
+
+    bluetooth_was_active = _systemctl_active("bluetooth.service")
+    b2u_was_active = stop_b2u_if_installed("before migrating Bluetooth state back to rootfs")
+    target = Path("/var/lib/bluetooth")
+    temp_dir = target.with_name(f"{target.name}.b2u-migrate-{uuid.uuid4().hex}")
+    backup_dir = target.with_name(f"{target.name}.b2u-backup-{uuid.uuid4().hex}")
+    try:
+        if bluetooth_was_active:
+            run(["systemctl", "stop", "bluetooth.service"])
+        shutil.copytree(config.persist_bluetooth_dir, temp_dir, symlinks=True)
+        run(["systemctl", "disable", "--now", "var-lib-bluetooth.mount"], check=False)
+        if run(["mountpoint", "-q", target], check=False).returncode == 0:
+            run(["umount", target])
+        if target.exists():
+            target.rename(backup_dir)
+        try:
+            temp_dir.rename(target)
+        except Exception:
+            if target.exists():
+                shutil.rmtree(target, ignore_errors=True)
+            if backup_dir.exists():
+                backup_dir.rename(target)
+            raise
+        else:
+            shutil.rmtree(backup_dir, ignore_errors=True)
+        remove_bluetooth_persist_dropin()
+        remove_bluetooth_bind_mount_unit()
+        _disable_persistent_storage_mount(config)
+        run(["systemctl", "daemon-reload"])
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        if bluetooth_was_active and not _systemctl_active("bluetooth.service"):
+            run(["systemctl", "start", "bluetooth.service"], check=False)
+        restart_b2u_if_installed(b2u_was_active, "after migrating Bluetooth state back to rootfs")
+    ok("Bluetooth state has been migrated back to /var/lib/bluetooth on the root filesystem.")
+    ok("Persistent storage mount has been disabled and unmounted.")
+    warn("Data on the persistent device was left intact.")
+
+
+def _disable_persistent_storage_mount(config: ReadonlyConfig) -> None:
+    unit = output(["systemd-escape", "--path", "--suffix=mount", config.persist_mount])
+    run(["systemctl", "disable", "--now", unit], check=False)
+    if run(["findmnt", "-rn", config.persist_mount], check=False, capture=True).returncode == 0:
+        try:
+            run(["umount", config.persist_mount])
+        except OpsError:
+            fail(f"Persistent storage mount is no longer needed but could not be unmounted: {config.persist_mount}")
+    remove_persist_mount_unit(config.persist_mount)

--- a/tests/test_bluetooth_ops.py
+++ b/tests/test_bluetooth_ops.py
@@ -16,6 +16,7 @@ from bluetooth_2_usb.ops.readonly import (
     disable_readonly,
     enable_readonly,
     load_readonly_config,
+    migrate_bluetooth_state_to_rootfs,
     overlay_configured_status,
     overlay_status,
     package_status,
@@ -265,7 +266,6 @@ class ReadonlyConfigTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "readonly.env"
             config = ReadonlyConfig(
-                mode="enabled",
                 persist_mount=Path("/mnt/persist"),
                 persist_bluetooth_dir=Path("/mnt/persist/bluetooth"),
                 persist_spec="/dev/disk/by-uuid/abc",
@@ -276,7 +276,7 @@ class ReadonlyConfigTest(unittest.TestCase):
 
             self.assertEqual(load_readonly_config(path), config)
 
-    def test_readonly_config_loads_persistent_mode_as_enabled(self) -> None:
+    def test_readonly_config_ignores_legacy_mode_key(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "readonly.env"
             path.write_text(
@@ -293,15 +293,16 @@ class ReadonlyConfigTest(unittest.TestCase):
 
             config = load_readonly_config(path)
 
-        self.assertEqual(config.mode, "enabled")
+        self.assertEqual(config.persist_mount, Path("/mnt/persist"))
+        self.assertEqual(config.persist_bluetooth_dir, Path("/mnt/persist/bluetooth"))
 
-    def test_write_readonly_config_normalizes_persistent_mode_to_enabled(self) -> None:
+    def test_write_readonly_config_omits_legacy_mode_key(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "readonly.env"
 
-            write_readonly_config(ReadonlyConfig(mode="persistent"), path)
+            write_readonly_config(ReadonlyConfig(), path)
 
-            self.assertIn('B2U_READONLY_MODE="enabled"', path.read_text(encoding="utf-8"))
+            self.assertNotIn("B2U_READONLY_MODE", path.read_text(encoding="utf-8"))
 
     def test_readonly_config_rejects_unexpected_keys(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -332,12 +333,10 @@ class ReadonlyConfigTest(unittest.TestCase):
             with patch(f"{READONLY_CONFIG}.PATHS", paths):
                 config = load_readonly_config(Path(tmpdir) / "missing")
 
-        self.assertEqual(config.mode, "disabled")
         self.assertEqual(config.persist_bluetooth_dir, Path("/tmp/persist/bt-state"))
 
     def test_bluetooth_state_persistent_rejects_bluetooth_dir_outside_persist_mount(self) -> None:
         config = ReadonlyConfig(
-            mode="enabled",
             persist_mount=Path("/mnt/persist"),
             persist_bluetooth_dir=Path("/var/lib/bluetooth"),
             persist_spec="/dev/sda1",
@@ -357,7 +356,6 @@ class ReadonlyConfigTest(unittest.TestCase):
 
     def test_bluetooth_state_persistent_returns_false_when_findmnt_fails(self) -> None:
         config = ReadonlyConfig(
-            mode="enabled",
             persist_mount=Path("/mnt/persist"),
             persist_bluetooth_dir=Path("/mnt/persist/bluetooth"),
             persist_spec="/dev/sda1",
@@ -373,7 +371,6 @@ class ReadonlyConfigTest(unittest.TestCase):
 
     def test_print_readonly_status_reports_configured_and_live_state(self) -> None:
         config = ReadonlyConfig(
-            mode="enabled",
             persist_mount=Path("/mnt/persist"),
             persist_bluetooth_dir=Path("/mnt/persist/bluetooth"),
             persist_spec="/dev/disk/by-uuid/abc",
@@ -400,10 +397,10 @@ class ReadonlyConfigTest(unittest.TestCase):
 
         output = stdout.getvalue()
         self.assertIn("read-only mode: enabled\n", output)
-        self.assertIn("configured read-only mode: enabled\n", output)
         self.assertIn("overlay_live: enabled\n", output)
-        self.assertIn("bluetooth persistent mount: mounted\n", output)
+        self.assertIn("bluetooth state storage: persistent\n", output)
         self.assertIn("persist_device: /dev/sda1\n", output)
+        self.assertNotIn("configured read-only mode:", output)
 
     def test_print_readonly_status_uses_safe_defaults_when_config_cannot_load(self) -> None:
         stdout = StringIO()
@@ -421,9 +418,9 @@ class ReadonlyConfigTest(unittest.TestCase):
             print_readonly_status()
 
         output = stdout.getvalue()
-        self.assertIn("configured read-only mode: disabled\n", output)
-        self.assertIn("bluetooth persistent mount: not mounted\n", output)
+        self.assertIn("bluetooth state storage:", output)
         self.assertIn("persist_device: <unset>\n", output)
+        self.assertNotIn("configured read-only mode:", output)
 
     def test_b2u_service_helpers_preserve_inactive_service_state(self) -> None:
         calls = []
@@ -474,7 +471,6 @@ class ReadonlyConfigTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             config = ReadonlyConfig(
-                mode="disabled",
                 persist_mount=root / "persist",
                 persist_bluetooth_dir=root / "persist" / "bluetooth",
                 persist_spec="",
@@ -550,7 +546,6 @@ class ReadonlyConfigTest(unittest.TestCase):
 
     def test_setup_persistent_bluetooth_state_fails_before_mount_migration_when_packages_fail(self) -> None:
         config = ReadonlyConfig(
-            mode="disabled",
             persist_mount=Path("/mnt/persist"),
             persist_bluetooth_dir=Path("/mnt/persist/bluetooth"),
             persist_spec="",
@@ -642,14 +637,12 @@ class ReadonlyConfigTest(unittest.TestCase):
 
     def test_enable_readonly_does_not_rollback_overlayfs_when_validation_fails(self) -> None:
         config = ReadonlyConfig(
-            mode="disabled",
             persist_mount=Path("/mnt/persist"),
             persist_bluetooth_dir=Path("/mnt/persist/bluetooth"),
             persist_spec="/dev/sda1",
             persist_device="/dev/sda1",
         )
         commands = []
-        written = []
 
         def fake_run(command, *, check=True, capture=False):
             commands.append(command)
@@ -679,7 +672,6 @@ class ReadonlyConfigTest(unittest.TestCase):
                 )
             )
             stack.enter_context(patch(f"{READONLY_WORKFLOWS}.run", side_effect=fake_run))
-            stack.enter_context(patch(f"{READONLY_WORKFLOWS}.write_readonly_config", side_effect=written.append))
 
             with self.assertRaises(OpsError):
                 with redirect_stdout(StringIO()) as stdout:
@@ -687,15 +679,12 @@ class ReadonlyConfigTest(unittest.TestCase):
 
         self.assertIn(["raspi-config", "nonint", "enable_overlayfs"], commands)
         self.assertNotIn(["raspi-config", "nonint", "disable_overlayfs"], commands)
-        self.assertEqual(config.mode, "disabled")
-        self.assertEqual(written, [])
         self.assertIn("readonly status", stdout.getvalue())
         self.assertNotIn("overlayfs-repair-guidance", stdout.getvalue())
         self.assertNotIn("for repair steps", stdout.getvalue())
 
     def test_enable_readonly_reports_status_guidance_when_overlayfs_enable_fails(self) -> None:
         config = ReadonlyConfig(
-            mode="disabled",
             persist_mount=Path("/mnt/persist"),
             persist_bluetooth_dir=Path("/mnt/persist/bluetooth"),
             persist_spec="/dev/sda1",
@@ -728,7 +717,6 @@ class ReadonlyConfigTest(unittest.TestCase):
 
     def test_enable_readonly_tells_user_to_rerun_setup_when_packages_are_incomplete(self) -> None:
         config = ReadonlyConfig(
-            mode="disabled",
             persist_mount=Path("/mnt/persist"),
             persist_bluetooth_dir=Path("/mnt/persist/bluetooth"),
             persist_spec="/dev/sda1",
@@ -754,15 +742,7 @@ class ReadonlyConfigTest(unittest.TestCase):
         self.assertIn("bad package", stdout.getvalue())
 
     def test_disable_readonly_disables_overlayfs_and_keeps_persistent_mount_config(self) -> None:
-        config = ReadonlyConfig(
-            mode="enabled",
-            persist_mount=Path("/mnt/persist"),
-            persist_bluetooth_dir=Path("/mnt/persist/bluetooth"),
-            persist_spec="/dev/disk/by-uuid/abc",
-            persist_device="/dev/sda1",
-        )
         commands = []
-        written = []
 
         def fake_run(command, *, check=True, capture=False):
             commands.append(command)
@@ -775,15 +755,211 @@ class ReadonlyConfigTest(unittest.TestCase):
 
         with ExitStack() as stack:
             stack.enter_context(patch(f"{READONLY_WORKFLOWS}.require_commands"))
-            stack.enter_context(patch(f"{READONLY_WORKFLOWS}.load_readonly_config", return_value=config))
             stack.enter_context(patch(f"{READONLY_WORKFLOWS}.run", side_effect=fake_run))
-            stack.enter_context(patch(f"{READONLY_WORKFLOWS}.write_readonly_config", side_effect=written.append))
 
             with redirect_stdout(StringIO()) as stdout:
                 disable_readonly()
 
         self.assertEqual(commands, [["raspi-config", "nonint", "disable_overlayfs"]])
-        self.assertEqual(config.mode, "disabled")
-        self.assertEqual(written, [config])
-        self.assertEqual(config.persist_spec, "/dev/disk/by-uuid/abc")
         self.assertIn("Persistent Bluetooth state mount configuration was kept.", stdout.getvalue())
+        self.assertIn("readonly migrate", stdout.getvalue())
+
+    def test_migrate_bluetooth_state_refuses_overlay_root(self) -> None:
+        with (
+            patch(f"{READONLY_WORKFLOWS}.require_commands"),
+            patch(f"{READONLY_WORKFLOWS}.load_readonly_config", return_value=ReadonlyConfig()),
+            patch(f"{READONLY_WORKFLOWS}.current_root_filesystem_type", return_value="overlay"),
+        ):
+            with self.assertRaisesRegex(OpsError, "overlay-backed"):
+                migrate_bluetooth_state_to_rootfs()
+
+    def test_migrate_bluetooth_state_refuses_when_persistent_state_is_not_mounted(self) -> None:
+        config = ReadonlyConfig(
+            persist_mount=Path("/mnt/persist"),
+            persist_bluetooth_dir=Path("/mnt/persist/bluetooth"),
+            persist_spec="/dev/disk/by-uuid/abc",
+            persist_device="/dev/sda1",
+        )
+        with (
+            patch(f"{READONLY_WORKFLOWS}.require_commands"),
+            patch(f"{READONLY_WORKFLOWS}.load_readonly_config", return_value=config),
+            patch(f"{READONLY_WORKFLOWS}.current_root_filesystem_type", return_value="ext4"),
+            patch(f"{READONLY_WORKFLOWS}.bluetooth_state_persistent", return_value=False),
+        ):
+            with self.assertRaisesRegex(OpsError, "not mounted"):
+                migrate_bluetooth_state_to_rootfs()
+
+    def test_migrate_bluetooth_state_copies_state_and_removes_bind_mount(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            persist_bluetooth = root / "persist/bluetooth"
+            persist_bluetooth.mkdir(parents=True)
+            (persist_bluetooth / "controller").mkdir()
+            (persist_bluetooth / "controller/settings").write_text("paired\n", encoding="utf-8")
+            root_bluetooth = root / "var/lib/bluetooth"
+            root_bluetooth.mkdir(parents=True)
+            (root_bluetooth / "old").write_text("old\n", encoding="utf-8")
+            config = ReadonlyConfig(
+                persist_mount=root / "persist",
+                persist_bluetooth_dir=persist_bluetooth,
+                persist_spec="/dev/disk/by-uuid/abc",
+                persist_device="/dev/sda1",
+            )
+            commands = []
+
+            def fake_run(command, *, check=True, capture=False):
+                commands.append(command)
+
+                class Completed:
+                    returncode = 0
+                    stdout = ""
+
+                if command[:2] == ["mountpoint", "-q"]:
+                    Completed.returncode = 1
+                return Completed()
+
+            def local_path(value: str) -> Path:
+                if value == "/var/lib/bluetooth":
+                    return root_bluetooth
+                return Path(value)
+
+            with ExitStack() as stack:
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.require_commands"))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.load_readonly_config", return_value=config))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.current_root_filesystem_type", return_value="ext4"))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.bluetooth_state_persistent", return_value=True))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}._systemctl_active", side_effect=[True, False]))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.stop_b2u_if_installed", return_value=True))
+                restart_b2u = stack.enter_context(patch(f"{READONLY_WORKFLOWS}.restart_b2u_if_installed"))
+                remove_dropin = stack.enter_context(patch(f"{READONLY_WORKFLOWS}.remove_bluetooth_persist_dropin"))
+                remove_bind = stack.enter_context(patch(f"{READONLY_WORKFLOWS}.remove_bluetooth_bind_mount_unit"))
+                remove_persist = stack.enter_context(patch(f"{READONLY_WORKFLOWS}.remove_persist_mount_unit"))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.output", return_value="persist.mount"))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.run", side_effect=fake_run))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.Path", side_effect=local_path))
+
+                with redirect_stdout(StringIO()) as stdout:
+                    migrate_bluetooth_state_to_rootfs()
+
+            self.assertEqual((root_bluetooth / "controller/settings").read_text(encoding="utf-8"), "paired\n")
+            self.assertFalse((root_bluetooth / "old").exists())
+            self.assertTrue((persist_bluetooth / "controller/settings").exists())
+            self.assertIn(["systemctl", "disable", "--now", "var-lib-bluetooth.mount"], commands)
+            self.assertIn(["systemctl", "disable", "--now", "persist.mount"], commands)
+            self.assertIn(["umount", config.persist_mount], commands)
+            self.assertIn(["systemctl", "start", "bluetooth.service"], commands)
+            self.assertIn("Data on the persistent device was left intact.", stdout.getvalue())
+            remove_dropin.assert_called_once_with()
+            remove_bind.assert_called_once_with()
+            remove_persist.assert_called_once_with(config.persist_mount)
+            restart_b2u.assert_called_once_with(True, "after migrating Bluetooth state back to rootfs")
+
+    def test_migrate_bluetooth_state_removes_persist_unit_when_persist_mount_already_unmounted(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            persist_bluetooth = root / "persist/bluetooth"
+            persist_bluetooth.mkdir(parents=True)
+            (persist_bluetooth / "settings").write_text("paired\n", encoding="utf-8")
+            root_bluetooth = root / "var/lib/bluetooth"
+            root_bluetooth.mkdir(parents=True)
+            config = ReadonlyConfig(
+                persist_mount=root / "persist",
+                persist_bluetooth_dir=persist_bluetooth,
+                persist_spec="/dev/disk/by-uuid/abc",
+                persist_device="/dev/sda1",
+            )
+            commands = []
+
+            def fake_run(command, *, check=True, capture=False):
+                commands.append(command)
+
+                class Completed:
+                    returncode = 0
+                    stdout = ""
+
+                if command[:2] == ["mountpoint", "-q"] or command[:2] == ["findmnt", "-rn"]:
+                    Completed.returncode = 1
+                return Completed()
+
+            def local_path(value: str) -> Path:
+                if value == "/var/lib/bluetooth":
+                    return root_bluetooth
+                return Path(value)
+
+            with ExitStack() as stack:
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.require_commands"))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.load_readonly_config", return_value=config))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.current_root_filesystem_type", return_value="ext4"))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.bluetooth_state_persistent", return_value=True))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}._systemctl_active", return_value=False))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.stop_b2u_if_installed", return_value=False))
+                restart_b2u = stack.enter_context(patch(f"{READONLY_WORKFLOWS}.restart_b2u_if_installed"))
+                remove_persist = stack.enter_context(patch(f"{READONLY_WORKFLOWS}.remove_persist_mount_unit"))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.remove_bluetooth_persist_dropin"))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.remove_bluetooth_bind_mount_unit"))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.output", return_value="persist.mount"))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.run", side_effect=fake_run))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.Path", side_effect=local_path))
+
+                migrate_bluetooth_state_to_rootfs()
+
+            self.assertIn(["systemctl", "disable", "--now", "persist.mount"], commands)
+            self.assertNotIn(["umount", config.persist_mount], commands)
+            remove_persist.assert_called_once_with(config.persist_mount)
+            restart_b2u.assert_called_once_with(False, "after migrating Bluetooth state back to rootfs")
+
+    def test_migrate_bluetooth_state_restores_services_when_persist_unmount_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            persist_bluetooth = root / "persist/bluetooth"
+            persist_bluetooth.mkdir(parents=True)
+            (persist_bluetooth / "settings").write_text("paired\n", encoding="utf-8")
+            root_bluetooth = root / "var/lib/bluetooth"
+            root_bluetooth.mkdir(parents=True)
+            config = ReadonlyConfig(
+                persist_mount=root / "persist",
+                persist_bluetooth_dir=persist_bluetooth,
+                persist_spec="/dev/disk/by-uuid/abc",
+                persist_device="/dev/sda1",
+            )
+            commands = []
+
+            def fake_run(command, *, check=True, capture=False):
+                commands.append(command)
+                if command == ["umount", config.persist_mount]:
+                    raise OpsError("umount failed")
+
+                class Completed:
+                    returncode = 0
+                    stdout = ""
+
+                if command[:2] == ["mountpoint", "-q"]:
+                    Completed.returncode = 1
+                return Completed()
+
+            def local_path(value: str) -> Path:
+                if value == "/var/lib/bluetooth":
+                    return root_bluetooth
+                return Path(value)
+
+            with ExitStack() as stack:
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.require_commands"))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.load_readonly_config", return_value=config))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.current_root_filesystem_type", return_value="ext4"))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.bluetooth_state_persistent", return_value=True))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}._systemctl_active", side_effect=[True, False]))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.stop_b2u_if_installed", return_value=True))
+                restart_b2u = stack.enter_context(patch(f"{READONLY_WORKFLOWS}.restart_b2u_if_installed"))
+                remove_persist = stack.enter_context(patch(f"{READONLY_WORKFLOWS}.remove_persist_mount_unit"))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.remove_bluetooth_persist_dropin"))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.remove_bluetooth_bind_mount_unit"))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.output", return_value="persist.mount"))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.run", side_effect=fake_run))
+                stack.enter_context(patch(f"{READONLY_WORKFLOWS}.Path", side_effect=local_path))
+
+                with self.assertRaisesRegex(OpsError, "could not be unmounted"):
+                    migrate_bluetooth_state_to_rootfs()
+
+            self.assertIn(["systemctl", "start", "bluetooth.service"], commands)
+            remove_persist.assert_not_called()
+            restart_b2u.assert_called_once_with(True, "after migrating Bluetooth state back to rootfs")

--- a/tests/test_ops_cli.py
+++ b/tests/test_ops_cli.py
@@ -81,6 +81,7 @@ class OpsCliTest(unittest.TestCase):
             (["readonly", "status"], "print_readonly_status"),
             (["readonly", "enable"], "enable_readonly"),
             (["readonly", "disable"], "disable_readonly"),
+            (["readonly", "migrate"], "migrate_bluetooth_state_to_rootfs"),
             (["udev", "install"], "install_hid_udev_rule"),
         )
 

--- a/tests/test_ops_deployment.py
+++ b/tests/test_ops_deployment.py
@@ -380,7 +380,6 @@ class OpsDeploymentTest(unittest.TestCase):
                 bluetooth_service_dropin_dir=root,
             )
             config = ReadonlyConfig(
-                mode="disabled",
                 persist_mount=root / "persist",
                 persist_bluetooth_dir=root / "persist" / "bluetooth",
                 persist_spec="",

--- a/tests/test_ops_diagnostics.py
+++ b/tests/test_ops_diagnostics.py
@@ -40,6 +40,7 @@ class OpsDiagnosticsTest(unittest.TestCase):
         with ExitStack() as stack:
             stack.enter_context(patch(f"{DIAGNOSTICS_SMOKETEST}.readonly_mode", return_value="disabled"))
             stack.enter_context(patch(f"{DIAGNOSTICS_SMOKETEST}.overlay_status", return_value="disabled"))
+            stack.enter_context(patch(f"{DIAGNOSTICS_SMOKETEST}.bluetooth_state_storage", return_value="rootfs"))
             stack.enter_context(patch(f"{DIAGNOSTICS_SMOKETEST}._first_modules_load", return_value=modules_load))
             stack.enter_context(patch(f"{DIAGNOSTICS_SMOKETEST}.boot_config.dwc2_mode", return_value=dwc2_mode))
             stack.enter_context(
@@ -80,6 +81,9 @@ class OpsDiagnosticsTest(unittest.TestCase):
                 patch(f"{DIAGNOSTICS_SMOKETEST}.bluetooth_rfkill_entries", return_value=rfkill_entries or [])
             )
             stack.enter_context(patch(f"{DIAGNOSTICS_SMOKETEST}.bluetooth_rfkill_blocked", return_value=rfkill_blocked))
+            stack.enter_context(
+                patch(f"{DIAGNOSTICS_SMOKETEST}.bluetooth_controller_powered_from_text", return_value=True)
+            )
             stack.enter_context(patch.object(smoke, "_check_boot_overlay"))
             stack.enter_context(
                 patch.object(
@@ -215,7 +219,115 @@ class OpsDiagnosticsTest(unittest.TestCase):
         self.assertEqual(len(rfkill_results), 1)
         self.assertEqual(rfkill_results[0].status, ProbeStatus.PASS)
         self.assertEqual(rfkill_results[0].detail, "rfkill0 type=bluetooth soft=0 hard=0 state=1")
-        self.assertEqual(stdout.getvalue().count("[+] Bluetooth rfkill state is not blocked"), 1)
+        self.assertNotIn("[+] Bluetooth rfkill state is not blocked", stdout.getvalue())
+
+    def test_smoketest_non_verbose_prints_section_success_messages(self) -> None:
+        smoke = SmokeTest(verbose=False, allow_non_pi=True)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stdout = StringIO()
+            with redirect_stdout(stdout):
+                self.run_smoketest_harness(smoke, root=Path(tmpdir), rfkill_entries=[_RfkillEntry()])
+
+        output = stdout.getvalue()
+        self.assertIn("Boot and USB\n[+] All checks passed", output)
+        self.assertIn("Service and Runtime\n[+] All checks passed", output)
+        self.assertIn("Bluetooth\n[+] All checks passed", output)
+
+    def test_smoketest_non_verbose_suppresses_routine_pass_lines_but_records_probes(self) -> None:
+        smoke = SmokeTest(verbose=False, allow_non_pi=True)
+
+        stdout = StringIO()
+        with redirect_stdout(stdout):
+            smoke._heading("Bluetooth")
+            smoke.pass_probe("btmgmt info succeeded")
+            smoke.pass_probe("Bluetooth rfkill state is not blocked", "rfkill0 type=bluetooth soft=0 hard=0 state=1")
+            smoke._heading("Summary")
+
+        output = stdout.getvalue()
+        self.assertIn("Bluetooth\n[+] All checks passed", output)
+        self.assertNotIn("btmgmt info succeeded", output)
+        self.assertNotIn("Bluetooth rfkill state is not blocked", output)
+        self.assertEqual(
+            [result.message for result in smoke.results],
+            ["btmgmt info succeeded", "Bluetooth rfkill state is not blocked"],
+        )
+
+    def test_smoketest_non_verbose_skips_section_success_when_section_warns(self) -> None:
+        smoke = SmokeTest(verbose=False, allow_non_pi=True)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stdout = StringIO()
+            with redirect_stdout(stdout):
+                self.run_smoketest_harness(
+                    smoke, root=Path(tmpdir), modules_load="modules-load=dwc2", udc_states={"dummy.udc": "not attached"}
+                )
+
+        output = stdout.getvalue()
+        boot_section = output[output.index("Boot and USB") : output.index("Service and Runtime")]
+        self.assertIn("UDC is not configured", boot_section)
+        self.assertNotIn("[+] All checks passed", boot_section)
+
+    def test_smoketest_non_verbose_keeps_device_counts_visible(self) -> None:
+        smoke = SmokeTest(verbose=False, allow_non_pi=True)
+        inventory = (0, '[{"relay_candidate": true}, {"relay_candidate": false}, {"relay_candidate": true}]')
+
+        stdout = StringIO()
+        with redirect_stdout(stdout), patch(f"{DIAGNOSTICS_SMOKETEST}.bluetooth_paired_count", return_value=1):
+            smoke._heading("Devices")
+            self.assertEqual(smoke._relayable_count(inventory), 2)
+            self.assertEqual(smoke._paired_count(), 1)
+
+        output = stdout.getvalue()
+        self.assertIn("[+] Relayable input devices detected (2)", output)
+        self.assertIn("[+] Paired Bluetooth devices detected (1)", output)
+
+    def test_smoketest_non_verbose_prints_compact_readonly_summary(self) -> None:
+        smoke = SmokeTest(verbose=False, allow_non_pi=True)
+
+        stdout = StringIO()
+        with redirect_stdout(stdout):
+            smoke._heading("Read-Only Mode")
+            smoke._check_overlay_runtime("disabled", "no", False)
+            smoke._check_readonly("disabled", "disabled", "no", False, "rootfs", False)
+            smoke._print_readonly_summary("disabled", "disabled", "no", "rootfs")
+
+        output = stdout.getvalue()
+        self.assertIn("[+] disabled: rootfs writable, Bluetooth state on rootfs", output)
+        self.assertNotIn("[+] Root filesystem is writable", output)
+        self.assertNotIn("[+] Bluetooth state is stored on rootfs", output)
+
+    def test_smoketest_verbose_keeps_detailed_pass_lines_without_section_success_messages(self) -> None:
+        smoke = SmokeTest(verbose=True, allow_non_pi=True)
+
+        stdout = StringIO()
+        with redirect_stdout(stdout):
+            smoke._heading("Bluetooth")
+            smoke.pass_probe("btmgmt info succeeded")
+            smoke._heading("Summary")
+
+        output = stdout.getvalue()
+        self.assertIn("[+] btmgmt info succeeded", output)
+        self.assertNotIn("[+] All checks passed", output)
+
+    def test_smoketest_capture_uses_20_second_timeout(self) -> None:
+        smoke = SmokeTest(verbose=False, allow_non_pi=True)
+
+        def fake_run(command, *, check=True, capture=False, timeout=None):
+            self.assertEqual(command, ["slow-probe"])
+            self.assertFalse(check)
+            self.assertTrue(capture)
+            self.assertEqual(timeout, 20)
+
+            class Completed:
+                returncode = 0
+                stdout = "ok\n"
+                stderr = ""
+
+            return Completed()
+
+        with patch(f"{DIAGNOSTICS_SMOKETEST}.run", side_effect=fake_run):
+            self.assertEqual(smoke._capture(["slow-probe"]), (0, "ok\n"))
 
     def test_smoketest_verbose_summary_groups_related_items_in_logical_order(self) -> None:
         smoke = SmokeTest(verbose=True, allow_non_pi=True)
@@ -231,20 +343,20 @@ class OpsDiagnosticsTest(unittest.TestCase):
         self.assertLess(output.index("### Read-Only Mode"), output.index("### Result"))
 
         readonly_group = output[output.index("### Read-Only Mode") : output.index("### Result")]
-        self.assertLess(readonly_group.index("Read-only mode:"), readonly_group.index("OverlayFS configured:"))
-        self.assertLess(readonly_group.index("OverlayFS configured:"), readonly_group.index("Root filesystem type:"))
-        self.assertLess(readonly_group.index("Root filesystem type:"), readonly_group.index("Root overlay active:"))
+        self.assertLess(readonly_group.index("Read-only state:"), readonly_group.index("OverlayFS boot setting:"))
+        self.assertLess(readonly_group.index("OverlayFS boot setting:"), readonly_group.index("Root filesystem type:"))
+        self.assertLess(readonly_group.index("Root filesystem type:"), readonly_group.index("Root source:"))
+        self.assertLess(readonly_group.index("Root source:"), readonly_group.index("Bluetooth state storage:"))
         self.assertLess(
-            readonly_group.index("Root overlay active:"), readonly_group.index("Bluetooth persistent mount:")
+            readonly_group.index("Bluetooth state storage:"), readonly_group.index("Bluetooth state source:")
         )
-        self.assertEqual(smoke.result_dict()["summary"]["Bluetooth persistent mount"], "not mounted")
+        self.assertEqual(smoke.result_dict()["summary"]["Bluetooth state storage"], "rootfs")
 
     def test_debug_report_keeps_writing_when_initial_systemctl_probe_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             paths = ManagedPaths(install_dir=root / "missing-install", log_dir=root / "logs")
             config = ReadonlyConfig(
-                mode="disabled",
                 persist_mount=root / "persist",
                 persist_bluetooth_dir=root / "persist" / "bluetooth",
                 persist_spec="",
@@ -287,6 +399,96 @@ class OpsDiagnosticsTest(unittest.TestCase):
             report = next(paths.log_dir.glob("debug_*.md"))
             self.assertIn("initial_service_state=unknown", report.read_text(encoding="utf-8"))
 
+    def test_debug_report_command_blocks_use_20_second_timeout(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            paths = ManagedPaths(install_dir=root / "missing-install", log_dir=root / "logs")
+            config = ReadonlyConfig(
+                persist_mount=root / "persist",
+                persist_bluetooth_dir=root / "persist" / "bluetooth",
+                persist_spec="",
+                persist_device="",
+            )
+            timeouts = []
+
+            def fake_run(command, *, check=True, capture=False, timeout=None, **kwargs):
+                del command, check, capture, kwargs
+                timeouts.append(timeout)
+
+                class Completed:
+                    returncode = 0
+                    stdout = ""
+                    stderr = ""
+
+                return Completed()
+
+            with ExitStack() as stack:
+                stack.enter_context(patch.dict(os.environ, {"HOSTNAME": "test-host"}))
+                stack.enter_context(patch(f"{DIAGNOSTICS_REPORT}.PATHS", paths))
+                stack.enter_context(patch(f"{DIAGNOSTICS_REPORT}.run", side_effect=fake_run))
+                stack.enter_context(patch(f"{DIAGNOSTICS_REPORT}.load_readonly_config", return_value=config))
+                stack.enter_context(patch(f"{DIAGNOSTICS_REPORT}.overlay_status", return_value="disabled"))
+                stack.enter_context(patch(f"{DIAGNOSTICS_REPORT}.readonly_mode", return_value="disabled"))
+                stack.enter_context(patch(f"{DIAGNOSTICS_REPORT}.bluetooth_state_persistent", return_value=False))
+                stack.enter_context(patch(f"{DIAGNOSTICS_REPORT}.rfkill_list_bluetooth", return_value=""))
+                stack.enter_context(
+                    patch(f"{DIAGNOSTICS_REPORT}.boot_config.detect_boot_dir", return_value=root / "boot")
+                )
+                stack.enter_context(
+                    patch(f"{DIAGNOSTICS_REPORT}.boot_config.boot_config_path", return_value=root / "config.txt")
+                )
+                stack.enter_context(
+                    patch(f"{DIAGNOSTICS_REPORT}.boot_config.boot_cmdline_path", return_value=root / "cmdline.txt")
+                )
+
+                self.assertEqual(debug_report(None), 0)
+
+        self.assertTrue(timeouts)
+        self.assertTrue(all(timeout == 20 for timeout in timeouts))
+
+    def test_debug_report_marks_timed_out_commands(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            paths = ManagedPaths(install_dir=root / "missing-install", log_dir=root / "logs")
+
+            def fake_run(command, *, check=True, capture=False, timeout=None, **kwargs):
+                del check, capture, timeout, kwargs
+                if command == ["uname", "-a"]:
+                    raise OpsError("Command timed out after 20s: uname -a")
+
+                class Completed:
+                    returncode = 0
+                    stdout = ""
+                    stderr = ""
+
+                return Completed()
+
+            with ExitStack() as stack:
+                stack.enter_context(patch.dict(os.environ, {"HOSTNAME": "test-host"}))
+                stack.enter_context(patch(f"{DIAGNOSTICS_REPORT}.PATHS", paths))
+                stack.enter_context(patch(f"{DIAGNOSTICS_REPORT}.run", side_effect=fake_run))
+                stack.enter_context(
+                    patch(f"{DIAGNOSTICS_REPORT}.load_readonly_config", side_effect=OpsError("invalid readonly env"))
+                )
+                stack.enter_context(patch(f"{DIAGNOSTICS_REPORT}.overlay_status", return_value="disabled"))
+                stack.enter_context(patch(f"{DIAGNOSTICS_REPORT}.readonly_mode", return_value="disabled"))
+                stack.enter_context(patch(f"{DIAGNOSTICS_REPORT}.rfkill_list_bluetooth", return_value=""))
+                stack.enter_context(
+                    patch(f"{DIAGNOSTICS_REPORT}.boot_config.detect_boot_dir", return_value=root / "boot")
+                )
+                stack.enter_context(
+                    patch(f"{DIAGNOSTICS_REPORT}.boot_config.boot_config_path", return_value=root / "config.txt")
+                )
+                stack.enter_context(
+                    patch(f"{DIAGNOSTICS_REPORT}.boot_config.boot_cmdline_path", return_value=root / "cmdline.txt")
+                )
+
+                self.assertEqual(debug_report(None), 0)
+
+            report = next(paths.log_dir.glob("debug_*.md")).read_text(encoding="utf-8")
+            self.assertIn("Command timed out after 20s: uname -a", report)
+            self.assertIn("[timed out after 20s]", report)
+
     def test_debug_report_keeps_writing_when_readonly_config_is_invalid(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -326,7 +528,7 @@ class OpsDiagnosticsTest(unittest.TestCase):
 
             report = next(paths.log_dir.glob("debug_*.md")).read_text(encoding="utf-8")
             self.assertIn("bluetooth_state_persistent_mount=unknown", report)
-            self.assertIn("Read-only config parse error: invalid readonly env", report)
+            self.assertIn("Persistent Bluetooth state config parse error: invalid readonly env", report)
 
     def test_debug_report_records_os_errors_as_command_failures(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -335,7 +537,6 @@ class OpsDiagnosticsTest(unittest.TestCase):
             paths.venv_python.parent.mkdir(parents=True)
             paths.venv_python.write_text("#!/bin/sh\n", encoding="utf-8")
             config = ReadonlyConfig(
-                mode="disabled",
                 persist_mount=root / "persist",
                 persist_bluetooth_dir=root / "persist" / "bluetooth",
                 persist_spec="",
@@ -385,7 +586,6 @@ class OpsDiagnosticsTest(unittest.TestCase):
             (root / "venv/bin/python").touch()
             paths = ManagedPaths(install_dir=root, log_dir=root / "logs", readonly_env_file=root / "readonly-env")
             config = ReadonlyConfig(
-                mode="disabled",
                 persist_mount=root / "persist",
                 persist_bluetooth_dir=root / "persist" / "bluetooth",
                 persist_spec="",


### PR DESCRIPTION
## Summary

Refines the read-only workflow and diagnostics surface:

- removes the read-only mode env setting while keeping the four persistent-state settings
- adds `readonly migrate` to move Bluetooth state back to rootfs and detach managed persistent mounts
- makes read-only status and Smoketest report active storage state more clearly
- streamlines non-verbose Smoketest output with concise section summaries and keeps full details in `--verbose`
- adds simple Rich status spinners and 20s subprocess timeouts for Smoketest/debug probes
- moves detailed diagnostics guidance out of README and into Troubleshooting

## Validation

- `venv/bin/black --check src tests`
- `venv/bin/ruff check src tests`
- `venv/bin/python -m compileall src tests`
- `venv/bin/python -m unittest discover -s tests -v` (`418 passed`)
- live `pi4b` migrate/setup/enable/disable cycle during development
- live `pi4b` `smoketest`
- live `pi4b` `smoketest --output json`
- live `pi4b` `debug --duration 1`
