### PR TITLE
[codex] Adjust read-only smoketest summary styling

### DIFF
--- a/src/bluetooth_2_usb/ops/diagnostics/smoketest.py
+++ b/src/bluetooth_2_usb/ops/diagnostics/smoketest.py
@@ -486,10 +486,13 @@ class SmokeTest:
     def _print_readonly_summary(
         self, readonly: str, overlay: str, root_overlay_active: str, bluetooth_storage: str
     ) -> None:
-        if self.verbose or self.section_statuses.get("Read-Only Mode") is ProbeStatus.FAIL:
+        if self.section_statuses.get("Read-Only Mode") is ProbeStatus.FAIL:
             return
         message = _readonly_summary_message(readonly, overlay, root_overlay_active, bluetooth_storage)
-        ok_final(message)
+        if self.verbose:
+            print(bold(f"Read-only summary: {message}"))
+        else:
+            ok(message)
         self.results.append(ProbeResult(ProbeStatus.PASS, message, ""))
 
     def _print_verbose(self, rfkill_entries, *logs: tuple[int, str]) -> None:

--- a/tests/test_ops_diagnostics.py
+++ b/tests/test_ops_diagnostics.py
@@ -24,6 +24,11 @@ class _RfkillEntry:
         return "rfkill0 type=bluetooth soft=0 hard=0 state=1"
 
 
+class _TtyStringIO(StringIO):
+    def isatty(self) -> bool:
+        return True
+
+
 class OpsDiagnosticsTest(unittest.TestCase):
     def assert_ordered_substrings(self, text: str, substrings: list[str]) -> None:
         previous = -1
@@ -298,8 +303,8 @@ class OpsDiagnosticsTest(unittest.TestCase):
     def test_smoketest_non_verbose_prints_compact_readonly_summary(self) -> None:
         smoke = SmokeTest(verbose=False, allow_non_pi=True)
 
-        stdout = StringIO()
-        with redirect_stdout(stdout):
+        stdout = _TtyStringIO()
+        with redirect_stdout(stdout), patch.dict(os.environ, {"NO_COLOR": ""}):
             smoke._heading("Read-Only Mode")
             smoke._check_overlay_runtime("disabled", "no", False)
             smoke._check_readonly("disabled", "disabled", "no", False, "rootfs", False)
@@ -307,8 +312,24 @@ class OpsDiagnosticsTest(unittest.TestCase):
 
         output = stdout.getvalue()
         self.assertIn("[+] disabled: rootfs writable, Bluetooth state on rootfs", output)
+        self.assertNotIn("\033[1m[+] disabled: rootfs writable, Bluetooth state on rootfs", output)
         self.assertNotIn("[+] Root filesystem is writable", output)
         self.assertNotIn("[+] Bluetooth state is stored on rootfs", output)
+
+    def test_smoketest_verbose_bolds_compact_readonly_summary(self) -> None:
+        smoke = SmokeTest(verbose=True, allow_non_pi=True)
+
+        stdout = _TtyStringIO()
+        with redirect_stdout(stdout), patch.dict(os.environ, {"NO_COLOR": ""}):
+            smoke._heading("Read-Only Mode")
+            smoke._check_overlay_runtime("disabled", "no", False)
+            smoke._check_readonly("disabled", "disabled", "no", False, "rootfs", False)
+            smoke._print_readonly_summary("disabled", "disabled", "no", "rootfs")
+
+        output = stdout.getvalue()
+        self.assertIn("\033[1mRead-only summary: disabled: rootfs writable, Bluetooth state on rootfs\033[0m", output)
+        self.assertIn("[+] Root filesystem is writable", output)
+        self.assertIn("[+] Bluetooth state is stored on rootfs", output)
 
     def test_smoketest_rejects_rootfs_bluetooth_state_when_readonly_is_active(self) -> None:
         smoke = SmokeTest(verbose=False, allow_non_pi=True)


### PR DESCRIPTION
## Summary

- Print the compact read-only smoketest summary as a normal pass line in non-verbose output.
- Show that same compact read-only summary as a bold `Read-only summary:` line in verbose output.
- Add TTY-style unit coverage for the non-verbose and verbose styling boundary.

## Validation

- `venv/bin/python -m unittest discover -s tests -v`
- `venv/bin/python -m black --check src tests`
- `venv/bin/python -m ruff check src tests`
- `venv/bin/python -m compileall src tests`

## Hardware note

Also deployed the already-built Pi 4B wake kernel to `pi4b` outside this PR and validated that the host booted `6.12.81-b2u-wake`, exposed `wakeup_on_write`, and passed smoketest/debug with the expected no-relayable-device warning.