### PR TITLE
feat: enrich diagnostics and device capture output

### DIFF
--- a/docs/device-capture.md
+++ b/docs/device-capture.md
@@ -2,8 +2,8 @@
 
 Use device capture when requesting or adding support for a new keyboard, mouse,
 gamepad, touchpad, remote, or other Linux input/HID-like device. It collects
-source-device metadata, evdev capabilities, compact live input snapshots, and
-best-effort hidraw report summaries from the real device.
+source-device metadata, evdev capabilities and input properties, compact live
+input snapshots, and best-effort hidraw report summaries from the real device.
 
 Capture output is redacted with the same pipeline used by diagnostics reports,
 but captures are still local artifacts that can include typed keys, button
@@ -25,6 +25,12 @@ devices, all matches are captured into the same JSONL artifact.
 Use it when collecting support data so the Pi desktop/session does not also
 consume the same input. While grabbed, those inputs may not control the Pi
 locally.
+
+During the countdown, exercise the controls that should be supported. Press the
+keys, buttons, axes, wheels, pads, or remote controls that matter for the
+support request. If no controls are used, the artifact can still include useful
+static metadata, but the live section will only prove that no input evidence was
+observed.
 
 ## Arguments
 
@@ -72,8 +78,11 @@ sudo bluetooth_2_usb device capture --devices /dev/input/event4 --duration 30 --
 ## Summarized And Raw Modes
 
 The default `--live-mode summarized` is preferred for support requests. It
-keeps compact per-key, per-axis, sync, and hidraw report summaries so repeated
-events do not create unnecessary data volume.
+keeps compact per-key, per-axis, per-`EV_MSC`, sync, event-type coverage, and
+hidraw report summaries so repeated events do not create unnecessary data
+volume. Summarized captures also include a short ordered sample of the first
+live evdev events, which helps maintainers see relationships such as
+`MSC_SCAN -> KEY_* -> SYN_REPORT` without needing raw mode.
 
 Use raw mode only when a maintainer asks for every event and report:
 

--- a/src/bluetooth_2_usb/ops/devices/cli.py
+++ b/src/bluetooth_2_usb/ops/devices/cli.py
@@ -8,8 +8,9 @@ from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
 
-from rich.console import Console
+from rich.console import Console, ConsoleOptions, RenderResult
 from rich.live import Live
+from rich.text import Text
 
 from ...evdev import ecodes
 from ..commands import info, ok, warn
@@ -21,6 +22,8 @@ EXIT_OK = 0
 EXIT_USAGE = 2
 EXIT_ENVIRONMENT = 3
 EXIT_INTERRUPTED = 130
+_SPINNER_FRAMES = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
+_PROGRESS_WIDTH = 8
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -106,9 +109,11 @@ def run(argv: list[str] | None = None) -> int:
     except KeyboardInterrupt:
         progress.finish_line()
         if progress.output_path is not None:
-            print(f"Device capture interrupted; wrote partial capture: {progress.output_path}", file=sys.stderr)
+            warn("Received keyboard interrupt; finalizing partial capture.")
+            ok(f"Wrote: {progress.output_path}")
+            _print_capture_summary(progress.output_path, generated_output=args.output is None)
         else:
-            print("Device capture interrupted", file=sys.stderr)
+            warn("Received keyboard interrupt before a capture path was created.")
         return EXIT_INTERRUPTED
     except DeviceCaptureError as exc:
         progress.finish_line()
@@ -174,16 +179,19 @@ class _CliProgress:
     abs_codes: set[str] = field(default_factory=set)
     hidraw_paths: set[str] = field(default_factory=set)
     _last_render_monotonic: float = 0.0
+    _started_monotonic: float = 0.0
+    _duration_sec: int = 0
     _live: Live | None = None
     _console: Console | None = None
 
-    def capture_started(self, devices, output_path: Path) -> None:
+    def capture_started(self, devices, output_path: Path, *, duration_sec: int) -> None:
         self.output_path = output_path
+        self._duration_sec = duration_sec
+        self._started_monotonic = time.monotonic()
         summaries = ", ".join(f"{getattr(device, 'path', '')} ({getattr(device, 'name', '')})" for device in devices)
         info(f"Capturing these matching devices: {summaries}")
-        info("Waiting for input; stop capturing with Ctrl-C.")
-        self._console = Console(stderr=True)
-        self._live = Live(self._render_text(), console=self._console, refresh_per_second=4, transient=False)
+        self._console = Console(stderr=True, highlight=False)
+        self._live = Live(self, console=self._console, refresh_per_second=4, transient=False)
         self._live.start()
 
     def evdev_event(self, device, event: object) -> None:
@@ -218,17 +226,53 @@ class _CliProgress:
             return
         self._last_render_monotonic = now
         if self._live is not None:
-            self._live.update(self._render_text())
+            self._live.update(self)
 
     def _render_text(self) -> str:
+        return self._render_status().plain
+
+    def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
+        del console, options
+        yield self._render_status()
+
+    def _render_status(self, *, now: float | None = None) -> Text:
+        now = time.monotonic() if now is None else now
+        elapsed_sec = max(0, int(now - self._started_monotonic)) if self._started_monotonic else 0
+        duration_sec = max(0, self._duration_sec)
+        remaining_sec = max(0, duration_sec - elapsed_sec) if duration_sec else 0
+        frame = _SPINNER_FRAMES[int(now * 4) % len(_SPINNER_FRAMES)]
         axes = len(self.rel_codes) + len(self.abs_codes)
-        size = ""
-        if self.output_path is not None and self.output_path.exists():
-            size = f" size={_format_bytes(self.output_path.stat().st_size)}"
-        return (
-            f"events={self.evdev_events} keys={len(self.key_codes)} axes={axes} "
-            f"hidraw={self.hidraw_reports} groups={len(self.hidraw_paths)}{size}"
+        status = Text()
+        status.append(frame, style="cyan")
+        status.append(" Waiting for input...", style="cyan")
+        status.append("   ")
+        status.append(
+            _progress_indicator(elapsed_sec=elapsed_sec, duration_sec=duration_sec, remaining_sec=remaining_sec)
         )
+        status.append("   |   ", style="white")
+        _append_metric(status, "events", self.evdev_events)
+        _append_metric(status, "keys", len(self.key_codes))
+        _append_metric(status, "axes", axes)
+        _append_metric(status, "hidraw", self.hidraw_reports)
+        _append_metric(status, "groups", len(self.hidraw_paths))
+        if self.output_path is not None and self.output_path.exists():
+            _append_metric(status, "size", _format_bytes(self.output_path.stat().st_size), trailing=False)
+        return status
+
+
+def _progress_indicator(*, elapsed_sec: int, duration_sec: int, remaining_sec: int) -> Text:
+    if duration_sec <= 0:
+        return Text(f"[{'-' * _PROGRESS_WIDTH}] {elapsed_sec}s", style="cyan")
+    filled = min(_PROGRESS_WIDTH, int((_PROGRESS_WIDTH * min(elapsed_sec, duration_sec)) / duration_sec))
+    bar = "#" * filled + "-" * (_PROGRESS_WIDTH - filled)
+    return Text(f"[{bar}] {remaining_sec}s", style="cyan")
+
+
+def _append_metric(status: Text, label: str, value: object, *, trailing: bool = True) -> None:
+    status.append(f"{label}=", style="yellow")
+    status.append(str(value), style="cyan")
+    if trailing:
+        status.append("   ")
 
 
 def _event_code_label(event: object) -> str:

--- a/src/bluetooth_2_usb/ops/devices/collector.py
+++ b/src/bluetooth_2_usb/ops/devices/collector.py
@@ -47,6 +47,12 @@ _LOCAL_EVENT_CODE_NAMES = {
 LiveMode = Literal["summarized", "raw"]
 _AXIS_SAMPLE_LIMIT = 8
 _HIDRAW_SAMPLE_LIMIT = 16
+_EVDEV_SAMPLE_SEQUENCE_LIMIT = 20
+
+
+class _TimedSummary(Protocol):
+    first_monotonic: float | None
+    last_monotonic: float | None
 
 
 class JsonlWriter:
@@ -271,7 +277,12 @@ def _close_capture_handles(handles: list[_CaptureHandle]) -> None:
 
 
 def _write_static_records(writer: JsonlWriter, device: InputDevice, max_sysfs_file_bytes: int) -> None:
-    for record_factory in (linux.input_device_record, linux.evdev_capabilities_record, linux.udev_properties_record):
+    for record_factory in (
+        linux.input_device_record,
+        linux.evdev_capabilities_record,
+        linux.evdev_input_properties_record,
+        linux.udev_properties_record,
+    ):
         try:
             writer.write(record_factory(device), flush=True)
         except Exception as exc:
@@ -327,7 +338,7 @@ async def _capture_live_records(
                     async with writer_lock:
                         writer.write(evdev_event_record(device, event), flush=True)
                 else:
-                    summaries.add_event(event)
+                    summaries.add_event(event, observed_monotonic=round(time.monotonic(), 6))
                 if progress is not None:
                     progress.evdev_event(device, event)
                 pending_event = _pending_event(reader)
@@ -363,7 +374,11 @@ async def _capture_live_records(
                             writer.write(hidraw_report_record(path, report, truncated=truncated), flush=True)
                     else:
                         summaries.add_hidraw_report(
-                            path, report, truncated=truncated, has_report_id=path in hidraw_report_id_paths
+                            path,
+                            report,
+                            truncated=truncated,
+                            has_report_id=path in hidraw_report_id_paths,
+                            observed_monotonic=round(time.monotonic(), 6),
                         )
                     if progress is not None:
                         progress.hidraw_report(path, report)
@@ -391,10 +406,13 @@ class _AxisSnapshot:
     same_value_repeat_count: int = 0
     sample_values: list[int] | None = None
     sample_values_truncated: bool = False
+    first_monotonic: float | None = None
+    last_monotonic: float | None = None
 
-    def add(self, value: int) -> None:
+    def add(self, value: int, *, observed_monotonic: float) -> None:
         if self.sample_values is None:
             self.sample_values = []
+        _update_timing(self, observed_monotonic)
         previous = self.last_value
         self.count += 1
         if self.first_value is None:
@@ -433,6 +451,8 @@ class _AxisSnapshot:
             "max_value": self.max_value,
             "sample_values": self.sample_values or [],
             "sample_values_truncated": self.sample_values_truncated,
+            "first_monotonic": self.first_monotonic,
+            "last_monotonic": self.last_monotonic,
         }
         if self.event_type == ecodes.EV_REL:
             record["sum_value"] = self.sum_value
@@ -452,8 +472,11 @@ class _KeySnapshot:
     repeat_count: int = 0
     first_value: int | None = None
     last_value: int | None = None
+    first_monotonic: float | None = None
+    last_monotonic: float | None = None
 
-    def add(self, value: int) -> None:
+    def add(self, value: int, *, observed_monotonic: float) -> None:
+        _update_timing(self, observed_monotonic)
         if self.first_value is None:
             self.first_value = value
         self.last_value = value
@@ -477,6 +500,8 @@ class _KeySnapshot:
             "repeat_count": self.repeat_count,
             "first_value": self.first_value,
             "last_value": self.last_value,
+            "first_monotonic": self.first_monotonic,
+            "last_monotonic": self.last_monotonic,
         }
 
 
@@ -486,8 +511,11 @@ class _SyncSnapshot:
     syn_report_count: int = 0
     syn_dropped_count: int = 0
     other_sync_counts: dict[str, int] | None = None
+    first_monotonic: float | None = None
+    last_monotonic: float | None = None
 
-    def add(self, code: int) -> None:
+    def add(self, code: int, *, observed_monotonic: float) -> None:
+        _update_timing(self, observed_monotonic)
         if code == ecodes.SYN_REPORT:
             self.syn_report_count += 1
         elif code == ecodes.SYN_DROPPED:
@@ -505,6 +533,59 @@ class _SyncSnapshot:
             "syn_report_count": self.syn_report_count,
             "syn_dropped_count": self.syn_dropped_count,
             "other_sync_counts": self.other_sync_counts or {},
+            "first_monotonic": self.first_monotonic,
+            "last_monotonic": self.last_monotonic,
+        }
+
+
+@dataclass(slots=True)
+class _MiscSnapshot:
+    path: str
+    code: int
+    count: int = 0
+    first_value: int | None = None
+    last_value: int | None = None
+    min_value: int | None = None
+    max_value: int | None = None
+    sample_values: list[int] | None = None
+    sample_values_truncated: bool = False
+    first_monotonic: float | None = None
+    last_monotonic: float | None = None
+
+    def add(self, value: int, *, observed_monotonic: float) -> None:
+        if self.sample_values is None:
+            self.sample_values = []
+        _update_timing(self, observed_monotonic)
+        previous = self.last_value
+        self.count += 1
+        if self.first_value is None:
+            self.first_value = value
+        self.last_value = value
+        self.min_value = value if self.min_value is None else min(self.min_value, value)
+        self.max_value = value if self.max_value is None else max(self.max_value, value)
+        if previous != value:
+            if len(self.sample_values) < _AXIS_SAMPLE_LIMIT:
+                self.sample_values.append(value)
+            else:
+                self.sample_values_truncated = True
+
+    def record(self) -> dict[str, object]:
+        return {
+            "record_type": "evdev_misc_snapshot",
+            "path": self.path,
+            "type": ecodes.EV_MSC,
+            "type_name": _event_type_name(ecodes.EV_MSC),
+            "code": self.code,
+            "code_name": _event_code_name(ecodes.EV_MSC, self.code),
+            "count": self.count,
+            "first_value": self.first_value,
+            "last_value": self.last_value,
+            "min_value": self.min_value,
+            "max_value": self.max_value,
+            "sample_values": self.sample_values or [],
+            "sample_values_truncated": self.sample_values_truncated,
+            "first_monotonic": self.first_monotonic,
+            "last_monotonic": self.last_monotonic,
         }
 
 
@@ -521,8 +602,10 @@ class _HidrawGroupSnapshot:
     sample_reports_truncated: bool = False
     changed_byte_indexes: set[int] | None = None
     byte_values: list[int | None] | None = None
+    first_monotonic: float | None = None
+    last_monotonic: float | None = None
 
-    def add(self, report: bytes, *, truncated: bool) -> None:
+    def add(self, report: bytes, *, truncated: bool, observed_monotonic: float) -> None:
         if self.sample_reports is None:
             self.sample_reports = []
         if self.seen_reports is None:
@@ -532,6 +615,7 @@ class _HidrawGroupSnapshot:
         if self.byte_values is None:
             self.byte_values = [None] * len(report)
 
+        _update_timing(self, observed_monotonic)
         self.count += 1
         if truncated:
             self.truncated_report_count += 1
@@ -563,6 +647,70 @@ class _HidrawGroupSnapshot:
             "sample_reports_truncated": self.sample_reports_truncated,
             "changed_byte_indexes": sorted(self.changed_byte_indexes or ()),
             "truncated_report_count": self.truncated_report_count,
+            "first_monotonic": self.first_monotonic,
+            "last_monotonic": self.last_monotonic,
+        }
+
+
+@dataclass(slots=True)
+class _EventTypeSummary:
+    path: str
+    counts: dict[int, int] | None = None
+    first_monotonic: float | None = None
+    last_monotonic: float | None = None
+
+    def add(self, event_type: int, *, observed_monotonic: float) -> None:
+        if self.counts is None:
+            self.counts = {}
+        _update_timing(self, observed_monotonic)
+        self.counts[event_type] = self.counts.get(event_type, 0) + 1
+
+    def record(self) -> dict[str, object]:
+        counts = self.counts or {}
+        return {
+            "record_type": "evdev_event_type_summary",
+            "path": self.path,
+            "counts": {
+                _event_type_name(event_type) or str(event_type): counts[event_type] for event_type in sorted(counts)
+            },
+            "type_codes": {str(event_type): _event_type_name(event_type) for event_type in sorted(counts)},
+            "first_monotonic": self.first_monotonic,
+            "last_monotonic": self.last_monotonic,
+        }
+
+
+@dataclass(slots=True)
+class _SampleSequence:
+    path: str
+    events: list[dict[str, object]] | None = None
+    sample_events_truncated: bool = False
+
+    def add(self, event: object, *, observed_monotonic: float) -> None:
+        if self.events is None:
+            self.events = []
+        if len(self.events) >= _EVDEV_SAMPLE_SEQUENCE_LIMIT:
+            self.sample_events_truncated = True
+            return
+        event_type = getattr(event, "type", None)
+        code = getattr(event, "code", None)
+        self.events.append(
+            {
+                "monotonic": observed_monotonic,
+                "type": event_type,
+                "type_name": _event_type_name(event_type),
+                "code": code,
+                "code_name": _event_code_name(event_type, code),
+                "value": getattr(event, "value", None),
+            }
+        )
+
+    def record(self) -> dict[str, object]:
+        return {
+            "record_type": "evdev_sample_sequence",
+            "path": self.path,
+            "sample_limit": _EVDEV_SAMPLE_SEQUENCE_LIMIT,
+            "sample_events_truncated": self.sample_events_truncated,
+            "events": self.events or [],
         }
 
 
@@ -571,46 +719,64 @@ class _LiveSummaries:
         self._path = getattr(device, "path", "")
         self._axes: dict[tuple[int, int], _AxisSnapshot] = {}
         self._keys: dict[int, _KeySnapshot] = {}
+        self._misc: dict[int, _MiscSnapshot] = {}
         self._sync: _SyncSnapshot | None = None
         self._hidraw: dict[tuple[Path, int | None, int], _HidrawGroupSnapshot] = {}
+        self._event_types = _EventTypeSummary(path=self._path)
+        self._sample_sequence = _SampleSequence(path=self._path)
 
-    def add_event(self, event: object) -> None:
+    def add_event(self, event: object, *, observed_monotonic: float) -> None:
         event_type = getattr(event, "type", None)
         code = getattr(event, "code", None)
         value = getattr(event, "value", None)
         if not isinstance(event_type, int) or not isinstance(code, int) or not isinstance(value, int):
             return
+        self._event_types.add(event_type, observed_monotonic=observed_monotonic)
+        self._sample_sequence.add(event, observed_monotonic=observed_monotonic)
         if event_type in (ecodes.EV_REL, ecodes.EV_ABS):
             key = (event_type, code)
             snapshot = self._axes.get(key)
             if snapshot is None:
                 snapshot = _AxisSnapshot(path=self._path, event_type=event_type, code=code)
                 self._axes[key] = snapshot
-            snapshot.add(value)
+            snapshot.add(value, observed_monotonic=observed_monotonic)
         elif event_type == ecodes.EV_KEY:
             snapshot = self._keys.get(code)
             if snapshot is None:
                 snapshot = _KeySnapshot(path=self._path, code=code)
                 self._keys[code] = snapshot
-            snapshot.add(value)
+            snapshot.add(value, observed_monotonic=observed_monotonic)
+        elif event_type == ecodes.EV_MSC:
+            snapshot = self._misc.get(code)
+            if snapshot is None:
+                snapshot = _MiscSnapshot(path=self._path, code=code)
+                self._misc[code] = snapshot
+            snapshot.add(value, observed_monotonic=observed_monotonic)
         elif event_type == ecodes.EV_SYN:
             if self._sync is None:
                 self._sync = _SyncSnapshot(path=self._path)
-            self._sync.add(code)
+            self._sync.add(code, observed_monotonic=observed_monotonic)
 
-    def add_hidraw_report(self, path: Path, report: bytes, *, truncated: bool, has_report_id: bool) -> None:
+    def add_hidraw_report(
+        self, path: Path, report: bytes, *, truncated: bool, has_report_id: bool, observed_monotonic: float
+    ) -> None:
         report_id = report[0] if has_report_id and report else None
         key = (path, report_id, len(report))
         snapshot = self._hidraw.get(key)
         if snapshot is None:
             snapshot = _HidrawGroupSnapshot(path=path, report_id=report_id, length=len(report))
             self._hidraw[key] = snapshot
-        snapshot.add(report, truncated=truncated)
+        snapshot.add(report, truncated=truncated, observed_monotonic=observed_monotonic)
 
     def records(self) -> list[dict[str, object]]:
         records: list[dict[str, object]] = []
+        if self._event_types.counts:
+            records.append(self._event_types.record())
+        if self._sample_sequence.events:
+            records.append(self._sample_sequence.record())
         records.extend(self._axes[key].record() for key in sorted(self._axes))
         records.extend(self._keys[key].record() for key in sorted(self._keys))
+        records.extend(self._misc[key].record() for key in sorted(self._misc))
         if self._sync is not None:
             records.append(self._sync.record())
         records.extend(
@@ -618,6 +784,12 @@ class _LiveSummaries:
             for key in sorted(self._hidraw, key=lambda item: (str(item[0]), item[1] or -1, item[2]))
         )
         return records
+
+
+def _update_timing(summary: _TimedSummary, observed_monotonic: float) -> None:
+    if summary.first_monotonic is None:
+        summary.first_monotonic = observed_monotonic
+    summary.last_monotonic = observed_monotonic
 
 
 def _hidraw_node_uses_report_ids(record: dict[str, object]) -> bool:

--- a/src/bluetooth_2_usb/ops/devices/collector.py
+++ b/src/bluetooth_2_usb/ops/devices/collector.py
@@ -64,7 +64,7 @@ class JsonlWriter:
 
 
 class CaptureProgress(Protocol):
-    def capture_started(self, devices: list[InputDevice], output_path: Path) -> None: ...
+    def capture_started(self, devices: list[InputDevice], output_path: Path, *, duration_sec: int) -> None: ...
 
     def evdev_event(self, device: InputDevice, event: object) -> None: ...
 
@@ -105,7 +105,7 @@ async def capture_device(
             writer = JsonlWriter(output_file, hostname=hostname)
             writer_lock = asyncio.Lock()
             if progress is not None:
-                progress.capture_started(input_devices, output_path)
+                progress.capture_started(input_devices, output_path, duration_sec=duration_sec)
             _write_capture_start(
                 writer, duration_sec=duration_sec, live_mode=live_mode, devices_filter=devices, handles=handles
             )

--- a/src/bluetooth_2_usb/ops/devices/collector.py
+++ b/src/bluetooth_2_usb/ops/devices/collector.py
@@ -48,6 +48,7 @@ LiveMode = Literal["summarized", "raw"]
 _AXIS_SAMPLE_LIMIT = 8
 _HIDRAW_SAMPLE_LIMIT = 16
 _EVDEV_SAMPLE_SEQUENCE_LIMIT = 20
+_PER_CODE_SAMPLE_EVENT_LIMIT = 8
 
 
 class _TimedSummary(Protocol):
@@ -406,12 +407,15 @@ class _AxisSnapshot:
     same_value_repeat_count: int = 0
     sample_values: list[int] | None = None
     sample_values_truncated: bool = False
+    sample_events: list[dict[str, object]] | None = None
+    sample_events_truncated: bool = False
     first_monotonic: float | None = None
     last_monotonic: float | None = None
 
     def add(self, value: int, *, observed_monotonic: float) -> None:
         if self.sample_values is None:
             self.sample_values = []
+        self._add_sample_event(value=value, observed_monotonic=observed_monotonic)
         _update_timing(self, observed_monotonic)
         previous = self.last_value
         self.count += 1
@@ -451,6 +455,8 @@ class _AxisSnapshot:
             "max_value": self.max_value,
             "sample_values": self.sample_values or [],
             "sample_values_truncated": self.sample_values_truncated,
+            "sample_events": self.sample_events or [],
+            "sample_events_truncated": self.sample_events_truncated,
             "first_monotonic": self.first_monotonic,
             "last_monotonic": self.last_monotonic,
         }
@@ -462,6 +468,14 @@ class _AxisSnapshot:
             record["same_value_repeat_count"] = self.same_value_repeat_count
         return record
 
+    def _add_sample_event(self, *, value: int, observed_monotonic: float) -> None:
+        if self.sample_events is None:
+            self.sample_events = []
+        if len(self.sample_events) >= _PER_CODE_SAMPLE_EVENT_LIMIT:
+            self.sample_events_truncated = True
+            return
+        self.sample_events.append({"monotonic": observed_monotonic, "value": value})
+
 
 @dataclass(slots=True)
 class _KeySnapshot:
@@ -472,10 +486,13 @@ class _KeySnapshot:
     repeat_count: int = 0
     first_value: int | None = None
     last_value: int | None = None
+    sample_events: list[dict[str, object]] | None = None
+    sample_events_truncated: bool = False
     first_monotonic: float | None = None
     last_monotonic: float | None = None
 
     def add(self, value: int, *, observed_monotonic: float) -> None:
+        self._add_sample_event(value=value, observed_monotonic=observed_monotonic)
         _update_timing(self, observed_monotonic)
         if self.first_value is None:
             self.first_value = value
@@ -500,9 +517,19 @@ class _KeySnapshot:
             "repeat_count": self.repeat_count,
             "first_value": self.first_value,
             "last_value": self.last_value,
+            "sample_events": self.sample_events or [],
+            "sample_events_truncated": self.sample_events_truncated,
             "first_monotonic": self.first_monotonic,
             "last_monotonic": self.last_monotonic,
         }
+
+    def _add_sample_event(self, *, value: int, observed_monotonic: float) -> None:
+        if self.sample_events is None:
+            self.sample_events = []
+        if len(self.sample_events) >= _PER_CODE_SAMPLE_EVENT_LIMIT:
+            self.sample_events_truncated = True
+            return
+        self.sample_events.append({"monotonic": observed_monotonic, "value": value})
 
 
 @dataclass(slots=True)
@@ -549,12 +576,15 @@ class _MiscSnapshot:
     max_value: int | None = None
     sample_values: list[int] | None = None
     sample_values_truncated: bool = False
+    sample_events: list[dict[str, object]] | None = None
+    sample_events_truncated: bool = False
     first_monotonic: float | None = None
     last_monotonic: float | None = None
 
     def add(self, value: int, *, observed_monotonic: float) -> None:
         if self.sample_values is None:
             self.sample_values = []
+        self._add_sample_event(value=value, observed_monotonic=observed_monotonic)
         _update_timing(self, observed_monotonic)
         previous = self.last_value
         self.count += 1
@@ -584,9 +614,19 @@ class _MiscSnapshot:
             "max_value": self.max_value,
             "sample_values": self.sample_values or [],
             "sample_values_truncated": self.sample_values_truncated,
+            "sample_events": self.sample_events or [],
+            "sample_events_truncated": self.sample_events_truncated,
             "first_monotonic": self.first_monotonic,
             "last_monotonic": self.last_monotonic,
         }
+
+    def _add_sample_event(self, *, value: int, observed_monotonic: float) -> None:
+        if self.sample_events is None:
+            self.sample_events = []
+        if len(self.sample_events) >= _PER_CODE_SAMPLE_EVENT_LIMIT:
+            self.sample_events_truncated = True
+            return
+        self.sample_events.append({"monotonic": observed_monotonic, "value": value})
 
 
 @dataclass(slots=True)
@@ -597,7 +637,7 @@ class _HidrawGroupSnapshot:
     count: int = 0
     exact_duplicate_count: int = 0
     truncated_report_count: int = 0
-    sample_reports: list[bytes] | None = None
+    sample_reports: list[dict[str, object]] | None = None
     seen_reports: set[bytes] | None = None
     sample_reports_truncated: bool = False
     changed_byte_indexes: set[int] | None = None
@@ -624,7 +664,7 @@ class _HidrawGroupSnapshot:
         else:
             self.seen_reports.add(report)
             if len(self.sample_reports) < _HIDRAW_SAMPLE_LIMIT:
-                self.sample_reports.append(report)
+                self.sample_reports.append({"monotonic": observed_monotonic, "report": report.hex(" ")})
             else:
                 self.sample_reports_truncated = True
         for index, byte in enumerate(report):
@@ -643,7 +683,7 @@ class _HidrawGroupSnapshot:
             "count": self.count,
             "exact_duplicate_count": self.exact_duplicate_count,
             "unique_report_count": len(self.seen_reports or ()),
-            "sample_reports": [report.hex(" ") for report in self.sample_reports or []],
+            "sample_reports": self.sample_reports or [],
             "sample_reports_truncated": self.sample_reports_truncated,
             "changed_byte_indexes": sorted(self.changed_byte_indexes or ()),
             "truncated_report_count": self.truncated_report_count,

--- a/src/bluetooth_2_usb/ops/devices/linux.py
+++ b/src/bluetooth_2_usb/ops/devices/linux.py
@@ -104,6 +104,26 @@ def evdev_capabilities_record(device: InputDevice) -> dict[str, object]:
     return {"record_type": "evdev_capabilities", "path": getattr(device, "path", ""), "capabilities": verbose}
 
 
+def evdev_input_properties_record(device: InputDevice) -> dict[str, object]:
+    path = getattr(device, "path", "")
+    input_props = getattr(device, "input_props", None)
+    if input_props is None:
+        return {
+            "record_type": "evdev_input_properties",
+            "path": path,
+            "properties": [],
+            "error": "input properties unavailable",
+        }
+    try:
+        try:
+            properties = input_props(verbose=True)
+        except TypeError:
+            properties = input_props()
+    except Exception as exc:
+        return {"record_type": "evdev_input_properties", "path": path, "properties": [], "error": str(exc)}
+    return {"record_type": "evdev_input_properties", "path": path, "properties": properties}
+
+
 def udev_properties_record(device: InputDevice) -> dict[str, object]:
     path = getattr(device, "path", "")
     properties: dict[str, object] = {}

--- a/src/bluetooth_2_usb/ops/devices/result.py
+++ b/src/bluetooth_2_usb/ops/devices/result.py
@@ -5,7 +5,7 @@ from dataclasses import asdict, is_dataclass
 from pathlib import Path
 from typing import Any
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 
 def normalize(value: object) -> Any:

--- a/src/bluetooth_2_usb/ops/devices/validate.py
+++ b/src/bluetooth_2_usb/ops/devices/validate.py
@@ -17,6 +17,7 @@ KNOWN_RECORD_TYPES = {
     "capture_warning",
     "input_device",
     "evdev_capabilities",
+    "evdev_input_properties",
     "udev_properties",
     "sysfs_snapshot",
     "hidraw_node",
@@ -24,6 +25,9 @@ KNOWN_RECORD_TYPES = {
     "hidraw_report",
     "evdev_axis_snapshot",
     "evdev_key_snapshot",
+    "evdev_misc_snapshot",
+    "evdev_event_type_summary",
+    "evdev_sample_sequence",
     "evdev_sync_summary",
     "hidraw_report_group_summary",
 }
@@ -132,7 +136,13 @@ def validate_capture(path: Path, *, generated_output: bool = False) -> CaptureVa
         warnings.append("elapsed_sec is missing")
     if not matched_devices:
         warnings.append("no matched devices recorded")
-    for required_type in ("input_device", "evdev_capabilities", "udev_properties", "sysfs_snapshot"):
+    for required_type in (
+        "input_device",
+        "evdev_capabilities",
+        "evdev_input_properties",
+        "udev_properties",
+        "sysfs_snapshot",
+    ):
         if record_counts.get(required_type, 0) == 0:
             warnings.append(f"missing {required_type} records")
 
@@ -143,6 +153,7 @@ def validate_capture(path: Path, *, generated_output: bool = False) -> CaptureVa
     unique_key_codes = _unique_codes(records, ecodes.EV_KEY)
     unique_rel_codes = _unique_codes(records, ecodes.EV_REL)
     unique_abs_codes = _unique_codes(records, ecodes.EV_ABS)
+    unique_msc_codes = _unique_codes(records, ecodes.EV_MSC)
     if warning_records:
         for record in warning_records:
             message = str(record.get("message") or "capture warning")
@@ -177,6 +188,7 @@ def validate_capture(path: Path, *, generated_output: bool = False) -> CaptureVa
         "capture_end": record_counts.get("capture_end", 0) > 0,
         "input_device": record_counts.get("input_device", 0) > 0,
         "evdev_capabilities": record_counts.get("evdev_capabilities", 0) > 0,
+        "evdev_input_properties": record_counts.get("evdev_input_properties", 0) > 0,
         "udev_properties": record_counts.get("udev_properties", 0) > 0,
         "sysfs_snapshot": record_counts.get("sysfs_snapshot", 0) > 0,
         "grabbed": any(
@@ -189,6 +201,9 @@ def validate_capture(path: Path, *, generated_output: bool = False) -> CaptureVa
         "evdev_event_raw": record_counts.get("evdev_event", 0) > 0,
         "evdev_key_snapshot": record_counts.get("evdev_key_snapshot", 0) > 0,
         "evdev_axis_snapshot": record_counts.get("evdev_axis_snapshot", 0) > 0,
+        "evdev_misc_snapshot": record_counts.get("evdev_misc_snapshot", 0) > 0,
+        "evdev_event_type_summary": record_counts.get("evdev_event_type_summary", 0) > 0,
+        "evdev_sample_sequence": record_counts.get("evdev_sample_sequence", 0) > 0,
         "evdev_sync_summary": record_counts.get("evdev_sync_summary", 0) > 0,
     }
     unique_paths = sorted(
@@ -203,8 +218,13 @@ def validate_capture(path: Path, *, generated_output: bool = False) -> CaptureVa
         "unique_key_codes": sorted(unique_key_codes),
         "unique_rel_codes": sorted(unique_rel_codes),
         "unique_abs_codes": sorted(unique_abs_codes),
+        "unique_msc_codes": sorted(unique_msc_codes),
+        "input_properties_count": record_counts.get("evdev_input_properties", 0),
         "axis_snapshot_count": record_counts.get("evdev_axis_snapshot", 0),
         "key_snapshot_count": record_counts.get("evdev_key_snapshot", 0),
+        "misc_snapshot_count": record_counts.get("evdev_misc_snapshot", 0),
+        "event_type_summary_count": record_counts.get("evdev_event_type_summary", 0),
+        "sample_sequence_count": record_counts.get("evdev_sample_sequence", 0),
         "raw_evdev_event_count": record_counts.get("evdev_event", 0),
         "raw_hidraw_report_count": record_counts.get("hidraw_report", 0),
         "hidraw_summary_count": record_counts.get("hidraw_report_group_summary", 0),
@@ -276,6 +296,9 @@ def _live_record_types() -> tuple[str, ...]:
         "hidraw_report",
         "evdev_axis_snapshot",
         "evdev_key_snapshot",
+        "evdev_misc_snapshot",
+        "evdev_event_type_summary",
+        "evdev_sample_sequence",
         "evdev_sync_summary",
         "hidraw_report_group_summary",
     )
@@ -291,7 +314,9 @@ def _unique_codes(records: list[dict[str, object]], event_type: int) -> set[str]
             continue
         if record_type == "evdev_key_snapshot" and event_type != ecodes.EV_KEY:
             continue
-        if record_type not in {"evdev_event", "evdev_axis_snapshot", "evdev_key_snapshot"}:
+        if record_type == "evdev_misc_snapshot" and event_type != ecodes.EV_MSC:
+            continue
+        if record_type not in {"evdev_event", "evdev_axis_snapshot", "evdev_key_snapshot", "evdev_misc_snapshot"}:
             continue
         code = record.get("code_name") or record.get("code")
         if code is not None:

--- a/src/bluetooth_2_usb/ops/diagnostics/smoketest.py
+++ b/src/bluetooth_2_usb/ops/diagnostics/smoketest.py
@@ -486,10 +486,13 @@ class SmokeTest:
     def _print_readonly_summary(
         self, readonly: str, overlay: str, root_overlay_active: str, bluetooth_storage: str
     ) -> None:
-        if self.verbose or self.section_statuses.get("Read-Only Mode") is ProbeStatus.FAIL:
+        if self.section_statuses.get("Read-Only Mode") is ProbeStatus.FAIL:
             return
         message = _readonly_summary_message(readonly, overlay, root_overlay_active, bluetooth_storage)
-        ok_final(message)
+        if self.verbose:
+            print(bold(f"Read-only summary: {message}"))
+        else:
+            ok(message)
         self.results.append(ProbeResult(ProbeStatus.PASS, message, ""))
 
     def _print_verbose(self, rfkill_entries, *logs: tuple[int, str]) -> None:

--- a/tests/test_device_capture.py
+++ b/tests/test_device_capture.py
@@ -47,6 +47,9 @@ class _FakeInputDevice:
     def capabilities(self, verbose=True):
         return {1: [(30, "KEY_A")]}
 
+    def input_props(self, verbose=True):
+        return [(0, "INPUT_PROP_POINTER")]
+
     def async_read_loop(self):
         events = list(self._events)
 
@@ -151,7 +154,7 @@ def _minimal_capture_records(*, live_mode: str = "summarized", warning: str | No
     records: list[dict[str, object]] = [
         {
             "record_type": "capture_start",
-            "schema_version": 1,
+            "schema_version": 2,
             "tool": "bluetooth_2_usb device capture",
             "started_at": "2026-05-06T01:02:03Z",
             "duration_sec": 30,
@@ -161,6 +164,7 @@ def _minimal_capture_records(*, live_mode: str = "summarized", warning: str | No
         },
         {"record_type": "input_device", "path": "/dev/input/event1", "name": "Keyboard"},
         {"record_type": "evdev_capabilities", "path": "/dev/input/event1", "capabilities": {}},
+        {"record_type": "evdev_input_properties", "path": "/dev/input/event1", "properties": []},
         {"record_type": "udev_properties", "path": "/dev/input/event1", "properties": {}},
         {"record_type": "sysfs_snapshot", "path": "/dev/input/event1", "files": []},
         {"record_type": "capture_note", "path": "/dev/input/event1", "message": "grabbed input device"},
@@ -312,6 +316,62 @@ class DeviceCaptureTest(unittest.TestCase):
                 for span in status.spans
             )
         )
+
+    def test_capture_records_input_properties(self) -> None:
+        device = _FakeInputDevice("/dev/input/event1", "Touchpad")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = Path(tmpdir) / "capture.jsonl"
+            with (
+                patch(f"{DEVICE_LINUX}.select_input_devices", return_value=[device]),
+                patch(f"{DEVICE_LINUX}.discover_hidraw_nodes", return_value=[]),
+            ):
+                asyncio.run(
+                    collector.capture_device(
+                        devices="/dev/input/event1",
+                        duration_sec=0,
+                        output_path=output,
+                        grab=False,
+                        include_hidraw=False,
+                        max_report_bytes=8,
+                        max_sysfs_file_bytes=8,
+                    )
+                )
+
+            records = [json.loads(line) for line in output.read_text(encoding="utf-8").splitlines()]
+
+        properties = next(record for record in records if record["record_type"] == "evdev_input_properties")
+        self.assertEqual(properties["path"], "/dev/input/event1")
+        self.assertEqual(properties["properties"], [[0, "INPUT_PROP_POINTER"]])
+
+    def test_capture_input_properties_records_error_when_unavailable(self) -> None:
+        class FailingInputPropsDevice(_FakeInputDevice):
+            def input_props(self, verbose=True):
+                raise OSError("props unavailable")
+
+        device = FailingInputPropsDevice("/dev/input/event1", "Touchpad")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = Path(tmpdir) / "capture.jsonl"
+            with (
+                patch(f"{DEVICE_LINUX}.select_input_devices", return_value=[device]),
+                patch(f"{DEVICE_LINUX}.discover_hidraw_nodes", return_value=[]),
+            ):
+                asyncio.run(
+                    collector.capture_device(
+                        devices="/dev/input/event1",
+                        duration_sec=0,
+                        output_path=output,
+                        grab=False,
+                        include_hidraw=False,
+                        max_report_bytes=8,
+                        max_sysfs_file_bytes=8,
+                    )
+                )
+
+            records = [json.loads(line) for line in output.read_text(encoding="utf-8").splitlines()]
+
+        properties = next(record for record in records if record["record_type"] == "evdev_input_properties")
+        self.assertEqual(properties["properties"], [])
+        self.assertEqual(properties["error"], "props unavailable")
 
     def test_select_input_device_accepts_exact_path_and_closes_nonmatches(self) -> None:
         selected = _FakeInputDevice("/dev/input/event1", "Keyboard")
@@ -990,6 +1050,15 @@ class DeviceCaptureTest(unittest.TestCase):
             records = [json.loads(line) for line in output.read_text(encoding="utf-8").splitlines()]
 
         self.assertEqual([record["record_type"] for record in records].count("evdev_event"), 1)
+        summarized_record_types = {
+            "evdev_misc_snapshot",
+            "evdev_event_type_summary",
+            "evdev_sample_sequence",
+            "evdev_axis_snapshot",
+            "evdev_key_snapshot",
+            "evdev_sync_summary",
+        }
+        self.assertFalse(any(record["record_type"] in summarized_record_types for record in records))
 
     def test_summarized_capture_records_short_rel_and_abs_axis_snapshots(self) -> None:
         device = _FakeInputDevice(
@@ -1032,6 +1101,8 @@ class DeviceCaptureTest(unittest.TestCase):
         self.assertEqual(rel["count"], 2)
         self.assertEqual(rel["sum_value"], 2)
         self.assertEqual(rel["sum_abs_value"], 4)
+        self.assertIn("first_monotonic", rel)
+        self.assertIn("last_monotonic", rel)
         self.assertEqual(abs_axis["count"], 3)
         self.assertEqual(abs_axis["min_value"], 10)
         self.assertEqual(abs_axis["max_value"], 20)
@@ -1071,6 +1142,148 @@ class DeviceCaptureTest(unittest.TestCase):
         sync = next(record for record in records if record["record_type"] == "evdev_sync_summary")
         self.assertEqual(sync["syn_report_count"], 1)
         self.assertEqual(sync["syn_dropped_count"], 1)
+        self.assertIn("first_monotonic", sync)
+        self.assertIn("last_monotonic", sync)
+
+    def test_summarized_capture_records_misc_scan_summary(self) -> None:
+        device = _FakeInputDevice(
+            "/dev/input/event1",
+            "Remote",
+            events=[
+                SimpleNamespace(sec=1, usec=1, type=4, code=4, value=458792),
+                SimpleNamespace(sec=1, usec=2, type=4, code=4, value=458793),
+                SimpleNamespace(sec=1, usec=3, type=4, code=4, value=458793),
+            ],
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = Path(tmpdir) / "capture.jsonl"
+            with (
+                patch(f"{DEVICE_LINUX}.select_input_devices", return_value=[device]),
+                patch(f"{DEVICE_LINUX}.discover_hidraw_nodes", return_value=[]),
+            ):
+                asyncio.run(
+                    collector.capture_device(
+                        devices="/dev/input/event1",
+                        duration_sec=1,
+                        output_path=output,
+                        grab=False,
+                        include_hidraw=False,
+                        max_report_bytes=8,
+                        max_sysfs_file_bytes=8,
+                    )
+                )
+
+            records = [json.loads(line) for line in output.read_text(encoding="utf-8").splitlines()]
+
+        misc = next(record for record in records if record["record_type"] == "evdev_misc_snapshot")
+        self.assertEqual(misc["type_name"], "EV_MSC")
+        self.assertEqual(misc["code_name"], "MSC_SCAN")
+        self.assertEqual(misc["count"], 3)
+        self.assertEqual(misc["first_value"], 458792)
+        self.assertEqual(misc["last_value"], 458793)
+        self.assertEqual(misc["min_value"], 458792)
+        self.assertEqual(misc["max_value"], 458793)
+        self.assertEqual(misc["sample_values"], [458792, 458793])
+        self.assertIn("first_monotonic", misc)
+        self.assertIn("last_monotonic", misc)
+
+    def test_summarized_capture_records_event_type_summary_and_sample_sequence(self) -> None:
+        device = _FakeInputDevice(
+            "/dev/input/event1",
+            "Remote",
+            events=[
+                SimpleNamespace(sec=1, usec=1, type=4, code=4, value=458792),
+                SimpleNamespace(sec=1, usec=2, type=1, code=115, value=1),
+                SimpleNamespace(sec=1, usec=3, type=0, code=0, value=0),
+            ],
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = Path(tmpdir) / "capture.jsonl"
+            with (
+                patch(f"{DEVICE_LINUX}.select_input_devices", return_value=[device]),
+                patch(f"{DEVICE_LINUX}.discover_hidraw_nodes", return_value=[]),
+            ):
+                asyncio.run(
+                    collector.capture_device(
+                        devices="/dev/input/event1",
+                        duration_sec=1,
+                        output_path=output,
+                        grab=False,
+                        include_hidraw=False,
+                        max_report_bytes=8,
+                        max_sysfs_file_bytes=8,
+                    )
+                )
+
+            records = [json.loads(line) for line in output.read_text(encoding="utf-8").splitlines()]
+
+        event_types = next(record for record in records if record["record_type"] == "evdev_event_type_summary")
+        self.assertEqual(event_types["counts"], {"EV_SYN": 1, "EV_KEY": 1, "EV_MSC": 1})
+        self.assertEqual(event_types["type_codes"], {"0": "EV_SYN", "1": "EV_KEY", "4": "EV_MSC"})
+        self.assertIn("first_monotonic", event_types)
+        self.assertIn("last_monotonic", event_types)
+        sample = next(record for record in records if record["record_type"] == "evdev_sample_sequence")
+        self.assertFalse(sample["sample_events_truncated"])
+        self.assertEqual([event["type_name"] for event in sample["events"]], ["EV_MSC", "EV_KEY", "EV_SYN"])
+        self.assertEqual(sample["events"][0]["code_name"], "MSC_SCAN")
+
+    def test_event_type_summary_counts_ignored_event_types(self) -> None:
+        device = _FakeInputDevice(
+            "/dev/input/event1", "Switch", events=[SimpleNamespace(sec=1, usec=1, type=5, code=0, value=1)]
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = Path(tmpdir) / "capture.jsonl"
+            with (
+                patch(f"{DEVICE_LINUX}.select_input_devices", return_value=[device]),
+                patch(f"{DEVICE_LINUX}.discover_hidraw_nodes", return_value=[]),
+            ):
+                asyncio.run(
+                    collector.capture_device(
+                        devices="/dev/input/event1",
+                        duration_sec=1,
+                        output_path=output,
+                        grab=False,
+                        include_hidraw=False,
+                        max_report_bytes=8,
+                        max_sysfs_file_bytes=8,
+                    )
+                )
+
+            records = [json.loads(line) for line in output.read_text(encoding="utf-8").splitlines()]
+
+        event_types = next(record for record in records if record["record_type"] == "evdev_event_type_summary")
+        self.assertEqual(event_types["counts"], {"EV_SW": 1})
+
+    def test_summarized_capture_truncates_evdev_sample_sequence(self) -> None:
+        device = _FakeInputDevice(
+            "/dev/input/event1",
+            "Keyboard",
+            events=[SimpleNamespace(sec=1, usec=index, type=1, code=30, value=1) for index in range(25)],
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = Path(tmpdir) / "capture.jsonl"
+            with (
+                patch(f"{DEVICE_LINUX}.select_input_devices", return_value=[device]),
+                patch(f"{DEVICE_LINUX}.discover_hidraw_nodes", return_value=[]),
+            ):
+                asyncio.run(
+                    collector.capture_device(
+                        devices="/dev/input/event1",
+                        duration_sec=1,
+                        output_path=output,
+                        grab=False,
+                        include_hidraw=False,
+                        max_report_bytes=8,
+                        max_sysfs_file_bytes=8,
+                    )
+                )
+
+            records = [json.loads(line) for line in output.read_text(encoding="utf-8").splitlines()]
+
+        sample = next(record for record in records if record["record_type"] == "evdev_sample_sequence")
+        self.assertEqual(sample["sample_limit"], 20)
+        self.assertEqual(len(sample["events"]), 20)
+        self.assertTrue(sample["sample_events_truncated"])
 
     def test_summarized_capture_records_hidraw_group_summary(self) -> None:
         device = _FakeInputDevice("/dev/input/event1", "Controller")
@@ -1113,6 +1326,8 @@ class DeviceCaptureTest(unittest.TestCase):
         self.assertEqual(summary["exact_duplicate_count"], 1)
         self.assertEqual(summary["unique_report_count"], 2)
         self.assertEqual(summary["changed_byte_indexes"], [1])
+        self.assertIn("first_monotonic", summary)
+        self.assertIn("last_monotonic", summary)
 
     def test_summarized_capture_uses_hidraw_report_id_only_when_descriptor_declares_one(self) -> None:
         device = _FakeInputDevice("/dev/input/event1", "Controller")
@@ -1224,6 +1439,7 @@ class DeviceCaptureTest(unittest.TestCase):
         self.assertTrue(report.valid)
         self.assertEqual(report.live_mode, "summarized")
         self.assertTrue(report.captured["evdev_key_snapshot"])
+        self.assertTrue(report.captured["evdev_input_properties"])
         self.assertFalse(report.errors)
 
     def test_validate_capture_accepts_raw_capture_with_raw_filename(self) -> None:
@@ -1356,6 +1572,35 @@ class DeviceCaptureTest(unittest.TestCase):
 
         self.assertTrue(report.valid)
         self.assertIn("no live input evidence captured", report.warnings)
+
+    def test_validate_capture_counts_misc_evidence_as_live(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "remote_20260506_010203.jsonl"
+            records = [
+                record
+                for record in _minimal_capture_records()
+                if record["record_type"] not in {"evdev_key_snapshot", "evdev_axis_snapshot", "evdev_sync_summary"}
+            ]
+            records.insert(
+                -1,
+                {
+                    "record_type": "evdev_misc_snapshot",
+                    "path": "/dev/input/event1",
+                    "type": 4,
+                    "type_name": "EV_MSC",
+                    "code": 4,
+                    "code_name": "MSC_SCAN",
+                    "count": 1,
+                },
+            )
+            _write_jsonl(path, records)
+
+            report = validate_capture(path)
+
+        self.assertTrue(report.valid)
+        self.assertNotIn("no live input evidence captured", report.warnings)
+        self.assertEqual(report.metrics["unique_msc_codes"], ["MSC_SCAN"])
+        self.assertTrue(report.captured["evdev_misc_snapshot"])
 
 
 if __name__ == "__main__":

--- a/tests/test_device_capture.py
+++ b/tests/test_device_capture.py
@@ -278,8 +278,10 @@ class DeviceCaptureTest(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertIn("Capture summary: mode=summarized matched=1 live=yes warnings=0", stdout.getvalue())
 
-    def test_capture_progress_status_line_stays_compact(self) -> None:
+    def test_capture_progress_status_line_includes_spinner_countdown_and_spaced_metrics(self) -> None:
         progress = _CliProgress()
+        progress._started_monotonic = 100.0
+        progress._duration_sec = 30
         progress.evdev_events = 12
         progress.hidraw_reports = 3
         progress.key_codes.update({"KEY_A", "BTN_LEFT"})
@@ -287,9 +289,29 @@ class DeviceCaptureTest(unittest.TestCase):
         progress.abs_codes.add("ABS_X")
         progress.hidraw_paths.add("hidraw0:8B")
 
-        line = progress._render_text()
+        line = progress._render_status(now=112.0).plain
 
-        self.assertEqual(line, "events=12 keys=2 axes=2 hidraw=3 groups=1")
+        self.assertIn("Waiting for input...", line)
+        self.assertIn("[###-----] 18s", line)
+        self.assertIn("events=12   keys=2   axes=2   hidraw=3   groups=1", line)
+
+    def test_capture_progress_status_colors_decimal_size_as_one_value(self) -> None:
+        progress = _CliProgress()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = Path(tmpdir) / "capture.jsonl"
+            output.write_bytes(b"x" * 14848)
+            progress.output_path = output
+
+            status = progress._render_status(now=0.0)
+
+        value_start = status.plain.index("14.5K")
+        value_end = value_start + len("14.5K")
+        self.assertTrue(
+            any(
+                span.start <= value_start and span.end >= value_end and str(span.style) == "cyan"
+                for span in status.spans
+            )
+        )
 
     def test_select_input_device_accepts_exact_path_and_closes_nonmatches(self) -> None:
         selected = _FakeInputDevice("/dev/input/event1", "Keyboard")
@@ -314,14 +336,31 @@ class DeviceCaptureTest(unittest.TestCase):
         self.assertEqual(exit_code, 3)
         self.assertIn("Device capture failed: denied", stderr.getvalue())
 
-    def test_capture_reports_interrupted_partial_output_path(self) -> None:
+    def test_capture_reports_interrupted_then_regular_write_success(self) -> None:
+        stdout = io.StringIO()
         stderr = io.StringIO()
 
-        with patch(f"{DEVICE_CLI}.capture_device", side_effect=KeyboardInterrupt), patch(f"{SYS}.stderr", stderr):
+        def interrupting_capture(*args, **kwargs):
+            progress = kwargs["progress"]
+            progress.output_path = Path("/tmp/capture.jsonl")
+            raise KeyboardInterrupt
+
+        with (
+            patch(f"{DEVICE_CLI}.capture_device", side_effect=interrupting_capture),
+            patch(f"{DEVICE_CLI}._print_capture_summary") as summary,
+            patch(f"{SYS}.stdout", stdout),
+            patch(f"{SYS}.stderr", stderr),
+        ):
             exit_code = run_device(["capture", "--devices", "/dev/input/event1"])
 
         self.assertEqual(exit_code, 130)
-        self.assertIn("Device capture interrupted", stderr.getvalue())
+        output_lines = stdout.getvalue().splitlines()
+        self.assertEqual(
+            output_lines[:2],
+            ["[!] Received keyboard interrupt; finalizing partial capture.", "[+] Wrote: /tmp/capture.jsonl"],
+        )
+        summary.assert_called_once_with(Path("/tmp/capture.jsonl"), generated_output=True)
+        self.assertEqual(stderr.getvalue(), "")
 
     def test_select_input_devices_returns_all_name_matches(self) -> None:
         devices = [_FakeInputDevice("/dev/input/event1", "Keyboard"), _FakeInputDevice("/dev/input/event2", "Keyboard")]
@@ -478,7 +517,7 @@ class DeviceCaptureTest(unittest.TestCase):
         started_devices = []
 
         class Progress:
-            def capture_started(self, devices, output_path: Path) -> None:
+            def capture_started(self, devices, output_path: Path, *, duration_sec: int) -> None:
                 started_devices.extend(devices)
 
             def evdev_event(self, device, event) -> None:

--- a/tests/test_device_capture.py
+++ b/tests/test_device_capture.py
@@ -1103,10 +1103,13 @@ class DeviceCaptureTest(unittest.TestCase):
         self.assertEqual(rel["sum_abs_value"], 4)
         self.assertIn("first_monotonic", rel)
         self.assertIn("last_monotonic", rel)
+        self.assertEqual([event["value"] for event in rel["sample_events"]], [3, -1])
+        self.assertFalse(rel["sample_events_truncated"])
         self.assertEqual(abs_axis["count"], 3)
         self.assertEqual(abs_axis["min_value"], 10)
         self.assertEqual(abs_axis["max_value"], 20)
         self.assertEqual(abs_axis["sample_values"], [10, 20])
+        self.assertEqual([event["value"] for event in abs_axis["sample_events"]], [10, 10, 20])
         self.assertEqual(abs_axis["changed_value_count"], 2)
         self.assertEqual(abs_axis["same_value_repeat_count"], 1)
 
@@ -1184,6 +1187,8 @@ class DeviceCaptureTest(unittest.TestCase):
         self.assertEqual(misc["min_value"], 458792)
         self.assertEqual(misc["max_value"], 458793)
         self.assertEqual(misc["sample_values"], [458792, 458793])
+        self.assertEqual([event["value"] for event in misc["sample_events"]], [458792, 458793, 458793])
+        self.assertFalse(misc["sample_events_truncated"])
         self.assertIn("first_monotonic", misc)
         self.assertIn("last_monotonic", misc)
 
@@ -1285,6 +1290,43 @@ class DeviceCaptureTest(unittest.TestCase):
         self.assertEqual(len(sample["events"]), 20)
         self.assertTrue(sample["sample_events_truncated"])
 
+    def test_summarized_capture_truncates_per_key_axis_and_misc_sample_events(self) -> None:
+        device = _FakeInputDevice(
+            "/dev/input/event1",
+            "Controller",
+            events=[
+                *(SimpleNamespace(sec=1, usec=index, type=1, code=30, value=index % 3) for index in range(10)),
+                *(SimpleNamespace(sec=2, usec=index, type=2, code=0, value=index) for index in range(10)),
+                *(SimpleNamespace(sec=3, usec=index, type=4, code=4, value=1000 + index) for index in range(10)),
+            ],
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = Path(tmpdir) / "capture.jsonl"
+            with (
+                patch(f"{DEVICE_LINUX}.select_input_devices", return_value=[device]),
+                patch(f"{DEVICE_LINUX}.discover_hidraw_nodes", return_value=[]),
+            ):
+                asyncio.run(
+                    collector.capture_device(
+                        devices="/dev/input/event1",
+                        duration_sec=1,
+                        output_path=output,
+                        grab=False,
+                        include_hidraw=False,
+                        max_report_bytes=8,
+                        max_sysfs_file_bytes=8,
+                    )
+                )
+
+            records = [json.loads(line) for line in output.read_text(encoding="utf-8").splitlines()]
+
+        key = next(record for record in records if record["record_type"] == "evdev_key_snapshot")
+        axis = next(record for record in records if record["record_type"] == "evdev_axis_snapshot")
+        misc = next(record for record in records if record["record_type"] == "evdev_misc_snapshot")
+        for record in (key, axis, misc):
+            self.assertEqual(len(record["sample_events"]), 8)
+            self.assertTrue(record["sample_events_truncated"])
+
     def test_summarized_capture_records_hidraw_group_summary(self) -> None:
         device = _FakeInputDevice("/dev/input/event1", "Controller")
         hidraw = Path("/dev/hidraw1")
@@ -1326,6 +1368,8 @@ class DeviceCaptureTest(unittest.TestCase):
         self.assertEqual(summary["exact_duplicate_count"], 1)
         self.assertEqual(summary["unique_report_count"], 2)
         self.assertEqual(summary["changed_byte_indexes"], [1])
+        self.assertEqual([sample["report"] for sample in summary["sample_reports"]], ["01 00 00", "01 02 00"])
+        self.assertTrue(all("monotonic" in sample for sample in summary["sample_reports"]))
         self.assertIn("first_monotonic", summary)
         self.assertIn("last_monotonic", summary)
 

--- a/tests/test_ops_diagnostics.py
+++ b/tests/test_ops_diagnostics.py
@@ -24,6 +24,11 @@ class _RfkillEntry:
         return "rfkill0 type=bluetooth soft=0 hard=0 state=1"
 
 
+class _TtyStringIO(StringIO):
+    def isatty(self) -> bool:
+        return True
+
+
 class OpsDiagnosticsTest(unittest.TestCase):
     def assert_ordered_substrings(self, text: str, substrings: list[str]) -> None:
         previous = -1
@@ -298,8 +303,8 @@ class OpsDiagnosticsTest(unittest.TestCase):
     def test_smoketest_non_verbose_prints_compact_readonly_summary(self) -> None:
         smoke = SmokeTest(verbose=False, allow_non_pi=True)
 
-        stdout = StringIO()
-        with redirect_stdout(stdout):
+        stdout = _TtyStringIO()
+        with redirect_stdout(stdout), patch.dict(os.environ, {"NO_COLOR": ""}):
             smoke._heading("Read-Only Mode")
             smoke._check_overlay_runtime("disabled", "no", False)
             smoke._check_readonly("disabled", "disabled", "no", False, "rootfs", False)
@@ -307,8 +312,24 @@ class OpsDiagnosticsTest(unittest.TestCase):
 
         output = stdout.getvalue()
         self.assertIn("[+] disabled: rootfs writable, Bluetooth state on rootfs", output)
+        self.assertNotIn("\033[1m[+] disabled: rootfs writable, Bluetooth state on rootfs", output)
         self.assertNotIn("[+] Root filesystem is writable", output)
         self.assertNotIn("[+] Bluetooth state is stored on rootfs", output)
+
+    def test_smoketest_verbose_bolds_compact_readonly_summary(self) -> None:
+        smoke = SmokeTest(verbose=True, allow_non_pi=True)
+
+        stdout = _TtyStringIO()
+        with redirect_stdout(stdout), patch.dict(os.environ, {"NO_COLOR": ""}):
+            smoke._heading("Read-Only Mode")
+            smoke._check_overlay_runtime("disabled", "no", False)
+            smoke._check_readonly("disabled", "disabled", "no", False, "rootfs", False)
+            smoke._print_readonly_summary("disabled", "disabled", "no", "rootfs")
+
+        output = stdout.getvalue()
+        self.assertIn("\033[1mRead-only summary: disabled: rootfs writable, Bluetooth state on rootfs\033[0m", output)
+        self.assertIn("[+] Root filesystem is writable", output)
+        self.assertIn("[+] Bluetooth state is stored on rootfs", output)
 
     def test_smoketest_rejects_rootfs_bluetooth_state_when_readonly_is_active(self) -> None:
         smoke = SmokeTest(verbose=False, allow_non_pi=True)


### PR DESCRIPTION
## Summary

- Print the compact read-only smoketest summary as a normal pass line in non-verbose output and as a bold `Read-only summary:` line in verbose output.
- Improve `device capture` live output with a spinner, countdown, spaced metrics, and stable value coloring.
- Handle Ctrl-C captures with a warning followed by the regular `[+] Wrote:` success flow and capture validation summary.
- Enrich device capture schema v2 with input properties, summarized `EV_MSC`, event-type coverage, first/last monotonic timing, per-code samples, timestamped hidraw samples, and a compact live evdev sample sequence.
- Document that users should exercise representative controls during the capture countdown.

## Validation

- `venv/bin/python -m unittest tests.test_device_capture -v`
- `venv/bin/python -m unittest discover -s tests -v`
- `venv/bin/python -m black --check src tests`
- `venv/bin/python -m ruff check src tests`
- `venv/bin/python -m compileall src tests`
- `git diff --check`

## Hardware note

Also deployed the already-built Pi 4B wake kernel to `pi4b` outside this PR and validated that the host booted `6.12.81-b2u-wake`, exposed `wakeup_on_write`, and passed smoketest/debug with the expected no-relayable-device warning.
